### PR TITLE
switched sprunge from curl to netcat and restored as lime-debug dependency

### DIFF
--- a/packages/lime-debug/Makefile
+++ b/packages/lime-debug/Makefile
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libre-mesh.org
-  DEPENDS:=+batctl +iwinfo +iw +mtr +ip +iputils-ping6
+  DEPENDS:=+batctl +iwinfo +iw +mtr +ip +iputils-ping6 +sprunge
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/sprunge/Makefile
+++ b/packages/sprunge/Makefile
@@ -20,7 +20,6 @@ define Package/$(PKG_NAME)
   CATEGORY:=Utilities
   MAINTAINER:=Ilario Gelmetti <ilario@eigenlab.org>
   URL:=http://sprunge.us
-  DEPENDS:=+curl
 endef
 
 define Package/$(PKG_NAME)/description


### PR DESCRIPTION
I switched the core of sprunge upload function from curl to netcat.
The use of curl was deprecated by P4u in https://github.com/libre-mesh/lime-packages/commit/612c4fbae87bb8fd0617f3acb5bd3ce17365c8ec
Now this package doesn't depend from curl, so I added again it as dependency of lime-debug.
