### PR TITLE
support IPv6 gateway detection

### DIFF
--- a/packages/bmx6-auto-gw-mode/files/etc/watchping/wan6-fail.d/bmx6-gw
+++ b/packages/bmx6-auto-gw-mode/files/etc/watchping/wan6-fail.d/bmx6-gw
@@ -1,0 +1,4 @@
+#!/bin/sh
+logger -t bmx6-auto-gw "Searching IPv6 Internet access into the mesh"
+bmx6 -c tunIn -inet6
+bmx6 -c tunOut inet6 /network 2000::/3 /maxPrefixLen 64

--- a/packages/bmx6-auto-gw-mode/files/etc/watchping/wan6-ok.d/bmx6-gw
+++ b/packages/bmx6-auto-gw-mode/files/etc/watchping/wan6-ok.d/bmx6-gw
@@ -1,0 +1,13 @@
+#!/bin/sh
+logger -t bmx6-auto-gw "We got IPv6 Internet access"
+netstatus="$(ubus call network.interface dump)"
+prefix="$( jsonfilter -s "$netstatus" -e "@.interface[*]['ipv6-prefix'][*]['address']" )"
+mask="$( jsonfilter -s "$netstatus" -e "@.interface[*]['ipv6-prefix'][*]['mask']" )"
+[ "$prefix" -a "$mask" ] || exit 0
+logger -t bmx6-auto-gw "Announcing prefix $prefix/$mask to the mesh"
+
+bmx6 -c tunDev main /tun6Address ${prefix}1/$mask /ingress6Prefix ${prefix}/$mask
+bmx6 -c tunOut -inet6
+bmx6 -c tunOut=6 /n=${prefix}/${mask} /minPrefixLen=64
+bmx6 -c tunIn inet6 /n=2000::/3
+

--- a/packages/watchping/files/etc/init.d/watchping
+++ b/packages/watchping/files/etc/init.d/watchping
@@ -107,6 +107,7 @@ service_triggers() {
 		for iface in $trigger_interfaces; do
 			logger -p user.info -t "watchping" "adding ifup trigger for $iface"
 			procd_add_interface_trigger "interface.*.up" "$iface" /etc/init.d/watchping restart
+			procd_add_interface_trigger "interface.*.update" "$iface" /etc/init.d/watchping restart
 		done
 	fi
 }

--- a/packages/watchping/files/etc/uci-defaults/90_watchping
+++ b/packages/watchping/files/etc/uci-defaults/90_watchping
@@ -2,11 +2,16 @@
 
 uci -q get system.@watchping[0] || {
         uci batch <<EOF
-        add system watchping
-        set system.@watchping[0].interface=wan
-        set system.@watchping[0].timeout=2m
-        set system.@watchping[0].pinghosts=8.8.8.8
-        set system.@watchping[0].pinginterval=20s
+        set system.watchping=watchping
+        set system.watchping.interface=wan
+        set system.watchping.timeout=2m
+        set system.watchping.pinghosts=8.8.8.8
+        set system.watchping.pinginterval=20s
+        set system.watchping6=watchping
+        set system.watchping6.interface=wan6
+        set system.watchping6.timeout=2m
+        set system.watchping6.pinghosts=2001:470:20::2
+        set system.watchping6.pinginterval=20s
         commit system
 EOF
 }

--- a/packages/watchping/files/etc/watchping/wan6-fail.d/README
+++ b/packages/watchping/files/etc/watchping/wan6-fail.d/README
@@ -1,0 +1,4 @@
+# All executable files in this directory are processed
+# when watchping gets no reply through wan6 ('interface')
+# from all of the hosts listed in 'pinghosts'
+# after the time set in 'timeout'

--- a/packages/watchping/files/etc/watchping/wan6-ok.d/README
+++ b/packages/watchping/files/etc/watchping/wan6-ok.d/README
@@ -1,0 +1,3 @@
+# All executable files in this directory are processed
+# when watchping can get a reply through wan6 ('interface')
+# from any of the hosts listed in 'pinghosts'

--- a/packages/watchping/files/usr/bin/watchping
+++ b/packages/watchping/files/usr/bin/watchping
@@ -18,7 +18,8 @@ run_hooks () {
 watchping_ping() {
 	local ifname="$1"; local timeout="$2"; local pinghosts="$3"; local pinginterval="$4"; local hookname="$5"
 	local last_hooks_run="fail"
-	
+	local pingexec="ping"
+
 	if [ ! -r "/sys/class/net/$ifname/ifindex" ] ; then
 		echo "Interface $ifname unsupported or not found!"
 		exit 1
@@ -45,8 +46,13 @@ watchping_ping() {
 		time_now="${time_now%%.*}"
 		time_lastcheck="$time_now"
 
+		case "$host" in
+			*":"*)
+				[ "$(which ping6 2>/dev/null)" ] && pingexec="ping6"
+				;;
+		esac
 		for host in "$pinghosts" ; do
-			if ping -I "$ifname" -c 1 "$host" &> /dev/null ; then 
+			if $pingexec -I "$ifname" -c 1 "$host" &> /dev/null ; then
 				time_lastcheck_withinternet="$time_now"
 			else
 				time_diff="$((time_now-time_lastcheck_withinternet))"


### PR DESCRIPTION
For the beginning, make watchping aware of IPv6 hosts (probably this won't even be needed on newer busybox versions, on ChaosCalmer it still is).
Also create tested scripts which announce the IPv6 gateway to the mesh.