### PR TITLE
Add line for psk in example of private ap mode configuration

### DIFF
--- a/packages/lime-system/files/etc/config/lime-example
+++ b/packages/lime-system/files/etc/config/lime-example
@@ -87,6 +87,7 @@ config lime wifi
 #  option channel_5ghz '36'
 #  option ap_ssid 'MyPrivateSSID'
 #  option ap_key 'WPA2PskKey'
+#  option ap_encryption 'psk2'
 
 
 ### Network interface specific options ( override general option )


### PR DESCRIPTION
I didn't test this but the encryption type configuration should be needed in the example of a private ap configuration. 