### PR TITLE
Changes the way bmx6 hosts are used, adding them to the /etc/hosts file.

### DIFF
--- a/packages/lime-proto-bmx6/src/bmx6hosts_dnsmasq_update
+++ b/packages/lime-proto-bmx6/src/bmx6hosts_dnsmasq_update
@@ -1,11 +1,5 @@
 #!/bin/sh
 bmx6hosts > /var/hosts/bmx6
-new=/tmp/bmx6hosts.new.md5
-last=/tmp/bmx6hosts.last.md5
-touch $last
-md5sum /var/hosts/bmx6| awk '{print $1}' > $new 
-[ "$(cat $new)" != "$(cat $last)" ] && {
-	logger -t bmx6hosts "New bmx6 hosts found, updating dnsmasq"
-	killall -HUP dnsmasq
-}
-cp -f $new $last
+
+grep -q -F '# BEGIN' /etc/hosts || echo -e "# BEGIN\n# END" >> /etc/hosts
+sed -i -ne '/# BEGIN/ {p; r /var/hosts/bmx6' -e ':a; n; /# END/ {p; b}; ba}; p' /etc/hosts


### PR DESCRIPTION
This pull request changes the way the bmx6hosts is used so it is more reliable.
Before this change, the bmx6hosts were unreliable, it woked most of the time, but sometimes it did not (random).
Using this strategy we guarantee that we always resolve locally, without depending on dnsmasq.