### PR TITLE
Fix #141 - Logout error on Simple Config area

### DIFF
--- a/packages/lime-webui/luasrc/controller/lime.lua
+++ b/packages/lime-webui/luasrc/controller/lime.lua
@@ -120,14 +120,17 @@ end
 
 function action_logout()
 	local dsp = require "luci.dispatcher"
-	local sauth = require "luci.sauth"
-	if dsp.context.authsession then
-		sauth.kill(dsp.context.authsession)
-		dsp.context.urltoken.stok = nil
+	local utl = require "luci.util"
+	local sid = dsp.context.authsession
+
+	if sid then
+		utl.ubus("session", "destroy", { ubus_rpc_session = sid })
+		luci.http.header("Set-Cookie", "sysauth=%s; expires=%s; path=%s/" %{
+			sid, 'Thu, 01 Jan 1970 01:00:00 GMT', dsp.build_url()
+		})
 	end
 
-	luci.http.header("Set-Cookie", "sysauth=; path=" .. dsp.build_url())
-	luci.http.redirect(luci.dispatcher.build_url())
+	luci.http.redirect(dsp.build_url())
 end
 
 function action_flashops()


### PR DESCRIPTION
Replaced the logout function of the Simple Administration area with the same code as the one in the Advanced Administration area.