### PR TITLE
Add anygw_mac_enable option on lime config

### DIFF
--- a/packages/lime-proto-anygw/src/anygw.lua
+++ b/packages/lime-proto-anygw/src/anygw.lua
@@ -9,7 +9,11 @@ anygw = {}
 anygw.configured = false
 
 function anygw.anygw_mac()
-	local anygw_mac = config.get("network", "anygw_mac") or "aa:aa:aa:%N1:%N2:aa"
+	local anygw_mac = utils.applyMacTemplate16("aa:%N1:%N2:%M4:%M5:%M6",
+	                                          network.primary_mac())
+	if config.get_bool("network","anygw_mac_enable",false) then
+		anygw_mac = config.get("network", "anygw_mac","aa:%N1:%N2:aa:aa:aa")
+	end
 	return utils.applyNetTemplate16(anygw_mac)
 end
 

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -15,6 +15,7 @@ config lime network
 	option main_ipv4_address '10.%N1.0.0/16'
 	option main_ipv6_address '2a00:1508:0a%N1:%N200::/64'
 	option bmx6_mtu '1398'
+	option anygw_mac_enable false
 	list protocols adhoc
 	list protocols lan
 	list protocols anygw


### PR DESCRIPTION
Adds the possibility to disable anyMAC from anyGW, so the nodes are not
sharing the same MAC address anymore. This should fix unexpected
behaviors on some routers (those with internal switch). By default
anyMAC will be disabled, it might be enabled for a more agressive
roaming of the network, which might be useful on specific deployments.

Signed-off-by: Pau Escrich <p4u@dabax.net>