### PR TITLE
lime-apply check if hostname changes and restart watchping

### DIFF
--- a/packages/lime-system/files/usr/bin/lime-apply
+++ b/packages/lime-system/files/usr/bin/lime-apply
@@ -6,4 +6,12 @@ echo "Reload network config"
 /sbin/reload_config
 echo "Reload routing protocols"
 # Workaround until "bmx6 configReload" updates hostname
-[ -x /etc/init.d/bmx6 ] && /etc/init.d/bmx6 restart
+[ -x /etc/init.d/bmx6 ] && {
+	bmx6_hostname=$(bmx6 -c jshow status | jsonfilter -e '@.status.name')
+	sys_hostname=$(uci get system.@system[0].hostname)
+	[ "$bmx6_hostname" == "$sys_hostname" ] && bmx6 -c configReload || {
+		/etc/init.d/watchping stop
+		/etc/init.d/bmx6 restart
+		sleep 1 && /etc/init.d/watchping start
+	}
+}


### PR DESCRIPTION
If hostname does not changes, bmx6 can be just reloaded.
If nostname changes, bmx6 must be restarted to update hostname
information. Also watchping must be restarted for checking if Internet
must be announced or not (and execute actions over bmx6).

Signed-off-by: Pau Escrich <p4u@dabax.net>