### PR TITLE
firewall: add lm_* interfaces to 'lan' zone

### DIFF
--- a/packages/lime-system/files/etc/firewall.lime
+++ b/packages/lime-system/files/etc/firewall.lime
@@ -2,6 +2,9 @@
 # they will be executed during each firewall (re-)start
 # or, if firewall package is not installed, just during boot.
 # They are interpreted as shell script.
+
+[ $(ls -1 /etc/firewall.lime.d/* 2>/dev/null | wc -l) = 0 ] && return 0
+
 for hook in /etc/firewall.lime.d/* ; do
         [ -s "$hook" ] && /bin/sh "$hook"
 done

--- a/packages/lime-system/files/usr/lib/lua/lime/firewall.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/firewall.lua
@@ -12,6 +12,7 @@ end
 function firewall.configure()
     if utils.is_installed('firewall') then
         local uci = libuci:cursor()
+        local lanIfs = {}
         uci:foreach("firewall", "defaults",
             function(section)
                 uci:set("firewall", section[".name"], "input", "ACCEPT")
@@ -19,22 +20,32 @@ function firewall.configure()
                 uci:set("firewall", section[".name"], "forward", "ACCEPT")
             end
         )
-        uci:foreach("firewall", "zone",
+
+        uci:foreach("network", "interface",
             function(section)
-                if uci:get("firewall", section[".name"], "name") == "wan"
-                or uci:get("firewall", section[".name"], "name") == "lan" then
-                    uci:set("firewall", section[".name"], "input", "ACCEPT")
-                    uci:set("firewall", section[".name"], "output", "ACCEPT")
-                    uci:set("firewall", section[".name"], "forward", "ACCEPT")
+                if "lan" == section[".name"] or
+                   "lm_" == string.sub(section[".name"], 1, 3) and
+                   "_if" == string.sub(section[".name"], -3) then
+                    table.insert(lanIfs, section[".name"])
                 end
             end
         )
-	uci:set("firewall", "include_firewall_lime", "include")
-	uci:set("firewall", "include_firewall_lime", "path", "/etc/firewall.lime")
 
+        uci:foreach("firewall", "zone",
+             function(section)
+                if uci:get("firewall", section[".name"], "name") == "lan" then
+                    uci:set("firewall", section[".name"], "input", "ACCEPT")
+                    uci:set("firewall", section[".name"], "output", "ACCEPT")
+                    uci:set("firewall", section[".name"], "forward", "ACCEPT")
+                    uci:set("firewall", section[".name"], "network", lanIfs)
+                end
+            end
+        )
+
+        uci:set("firewall", "include_firewall_lime", "include")
+        uci:set("firewall", "include_firewall_lime", "path", "/etc/firewall.lime")
         uci:save("firewall")
     end
-    
 end
 
 return firewall


### PR DESCRIPTION
To get the stock firewall working nicely, add a all lm_* interfaces
to the 'lan' zone. And we really shouldn't change the defaults for
the wan zone (!), why ever this was done, it really shouldn't.
If the wan interface isn't used as a wan interface, it shouldn't be
called wan -- calling it wan and opening the firewall for all
incoming packages while keeping SSH with no-password-auth open is
real madness and will get people pwned.