### PR TITLE
Removing overlap between lime-docs and lime-docs-minimal

### DIFF
--- a/packages/lime-docs/Makefile
+++ b/packages/lime-docs/Makefile
@@ -23,6 +23,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   TITLE:=LibreMesh documentation
+  DEPENDS:=+lime-docs-minimal
   MAINTAINER:=Ilario Gelmetti <ilario@tgnu.ml>
   URL:=http://libremesh.org/docs/
 endef
@@ -49,7 +50,7 @@ endef
 
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/www/docs/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/*txt $(1)/www/docs/
+	$(INSTALL_BIN) $(filter-out $(PKG_BUILD_DIR)/config.txt,$(wildcard $(PKG_BUILD_DIR)/*.txt)) $(1)/www/docs/
 	@ln -s /www/docs $(1)/docs
 endef
 


### PR DESCRIPTION
Merging of pull request #140 introduced the following error when compiling using LEDE buildroot (using lime-sdk such errors are ignored maybe?):

```
 * check_data_file_clashes: Package lime-docs wants to install file /home/ilario/software/lede3/build_dir/target-powerpc_8540_musl/root-mpc85xx/www/docs/config.txt
	But that file is already provided by package  * lime-docs-minimal
 * opkg_install_cmd: Cannot install package lime-docs.
```

So this fixes removing `config.txt` from lime-docs and introducing it via lime-docs-minimal as a dependency of lime-docs.