### PR TITLE
tip4commit-removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![tip for next commit](http://tip4commit.com/projects/804.svg)](http://tip4commit.com/projects/804)
-
 # [LibreMesh][5] packages "Dayboot Relay" release (17.06)
 
 [![LibreMesh logo](https://raw.githubusercontent.com/libremesh/lime-web/master/logo/logo.png)](http://libremesh.org)


### PR DESCRIPTION
Removes tip4commit badge, as we are thinking about deprecating it for now