### PR TITLE
Do not depend on iptables if fw3 installed

### DIFF
--- a/packages/lime-proto-bmx6/Makefile
+++ b/packages/lime-proto-bmx6/Makefile
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
-  DEPENDS:=+bmx6 +bmx6-json +bmx6-sms +bmx6-table +bmx6-uci-config +iptables \
+	DEPENDS:=+bmx6 +bmx6-json +bmx6-sms +bmx6-table +bmx6-uci-config +!PACKAGE_firewall:iptables \
   +lime-system +lua +libuci-lua +kmod-ebtables-ipv6
 endef
 

--- a/packages/lime-proto-bmx6/Makefile
+++ b/packages/lime-proto-bmx6/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LIME_BUILDDATE:=$(shell date +%Y%m%d_%H%M)
-LIME_CODENAME:=bigbang
+LIME_CODENAME:=DaybootRelay
 
 GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
 GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
-	DEPENDS:=+bmx6 +bmx6-json +bmx6-sms +bmx6-table +bmx6-uci-config +!PACKAGE_firewall:iptables \
+  DEPENDS:=+bmx6 +bmx6-json +bmx6-sms +bmx6-table +bmx6-uci-config +!PACKAGE_firewall:iptables \
   +lime-system +lua +libuci-lua +kmod-ebtables-ipv6
 endef
 

--- a/packages/lime-proto-bmx7/Makefile
+++ b/packages/lime-proto-bmx7/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LIME_BUILDDATE:=$(shell date +%Y%m%d_%H%M)
-LIME_CODENAME:=bigbang
+LIME_CODENAME:=DaybootRelay
 
 GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
 GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
@@ -22,7 +22,8 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
-	DEPENDS:=+bmx7 +bmx7-json +bmx7-sms +bmx7-table +bmx7-uci-config +bmx7-tun +!PACKAGE_firewall:iptables +lime-system +lua +libuci-lua
+  DEPENDS:=+bmx7 +bmx7-json +bmx7-sms +bmx7-table +bmx7-uci-config +bmx7-tun \
+  +!PACKAGE_firewall:iptables +lime-system +lua +libuci-lua
 endef
 
 define Build/Compile

--- a/packages/lime-proto-bmx7/Makefile
+++ b/packages/lime-proto-bmx7/Makefile
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
-  DEPENDS:=+bmx7 +bmx7-json +bmx7-sms +bmx7-table +bmx7-uci-config +bmx7-tun +iptables +lime-system +lua +libuci-lua
+	DEPENDS:=+bmx7 +bmx7-json +bmx7-sms +bmx7-table +bmx7-uci-config +bmx7-tun +!PACKAGE_firewall:iptables +lime-system +lua +libuci-lua
 endef
 
 define Build/Compile

--- a/packages/lime-proto-wan/Makefile
+++ b/packages/lime-proto-wan/Makefile
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
-  DEPENDS:=+lime-system +lua +libuci-lua +kmod-ipt-nat +iptables
+	DEPENDS:=+lime-system +lua +libuci-lua +kmod-ipt-nat +!PACKAGE_firewall:iptables
 endef
 
 define Build/Compile

--- a/packages/lime-proto-wan/Makefile
+++ b/packages/lime-proto-wan/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LIME_BUILDDATE:=$(shell date +%Y%m%d_%H%M)
-LIME_CODENAME:=bigbang
+LIME_CODENAME:=DaybootRelay
 
 GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
 GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
-	DEPENDS:=+lime-system +lua +libuci-lua +kmod-ipt-nat +!PACKAGE_firewall:iptables
+  DEPENDS:=+lime-system +lua +libuci-lua +kmod-ipt-nat +!PACKAGE_firewall:iptables
 endef
 
 define Build/Compile


### PR DESCRIPTION
lime-proto-wan and lime-proto-bmx[6/7] only depend on iptables if
lede/openwrt firewall is not selected.

Signed-off-by: Pau Escrich <p4u@dabax.net>