### PR TITLE
Avoid lime-basic to select lime-docs-minimal when lime-docs is selected by lime-full

### DIFF
--- a/packages/lime-basic-uing/Makefile
+++ b/packages/lime-basic-uing/Makefile
@@ -28,7 +28,7 @@ define Package/$(PKG_NAME)
 	         +lime-proto-anygw +lime-proto-wan +dnsmasq-lease-share \
 	         +dnsmasq-distributed-hosts +lime-webui-ng \
 	         +lime-hwd-openwrt-wan +bmx6-auto-gw-mode +lime-hwd-ground-routing \
-		 +lime-docs-minimal
+		 +!PACKAGE_lime-docs:lime-docs-minimal
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-basic/Makefile
+++ b/packages/lime-basic/Makefile
@@ -27,7 +27,7 @@ define Package/$(PKG_NAME)
 	DEPENDS:=+lime-system +lime-proto-bmx6 +lime-proto-batadv \
 	         +lime-proto-anygw +lime-proto-wan +dnsmasq-lease-share \
 	         +dnsmasq-distributed-hosts +lime-webui \
-	         +lime-hwd-openwrt-wan +lime-docs-minimal \
+		 +lime-hwd-openwrt-wan +!PACKAGE_lime-docs:lime-docs-minimal \
 	         +bmx6-auto-gw-mode +lime-hwd-ground-routing +smonit
 endef
 
@@ -41,7 +41,7 @@ define Package/$(PKG_NAME)-no-ui
 	DEPENDS:=+lime-system +lime-proto-bmx6 +lime-proto-batadv \
 	         +lime-proto-anygw +lime-proto-wan +dnsmasq-lease-share \
 	         +dnsmasq-distributed-hosts \
-	         +lime-hwd-openwrt-wan +lime-docs-minimal \
+		 +lime-hwd-openwrt-wan +!PACKAGE_lime-docs:lime-docs-minimal \
 	         +bmx6-auto-gw-mode +lime-hwd-ground-routing +smonit
 endef
 


### PR DESCRIPTION
As explained in #184, its merge introduced a dependency problem which seemed innocuous (?) but appears to break continuous integration (#186).