### PR TITLE
lime-docs-minimal just installs lime-example

### DIFF
--- a/packages/lime-basic-uing/Makefile
+++ b/packages/lime-basic-uing/Makefile
@@ -28,7 +28,7 @@ define Package/$(PKG_NAME)
 	         +lime-proto-anygw +lime-proto-wan +dnsmasq-lease-share \
 	         +dnsmasq-distributed-hosts +lime-webui-ng \
 	         +lime-hwd-openwrt-wan +bmx6-auto-gw-mode +lime-hwd-ground-routing \
-		 +!PACKAGE_lime-docs:lime-docs-minimal
+		 +lime-docs-minimal
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-basic/Makefile
+++ b/packages/lime-basic/Makefile
@@ -27,7 +27,7 @@ define Package/$(PKG_NAME)
 	DEPENDS:=+lime-system +lime-proto-bmx6 +lime-proto-batadv \
 	         +lime-proto-anygw +lime-proto-wan +dnsmasq-lease-share \
 	         +dnsmasq-distributed-hosts +lime-webui \
-		 +lime-hwd-openwrt-wan +!PACKAGE_lime-docs:lime-docs-minimal \
+		 +lime-hwd-openwrt-wan +lime-docs-minimal \
 	         +bmx6-auto-gw-mode +lime-hwd-ground-routing +smonit
 endef
 
@@ -41,7 +41,7 @@ define Package/$(PKG_NAME)-no-ui
 	DEPENDS:=+lime-system +lime-proto-bmx6 +lime-proto-batadv \
 	         +lime-proto-anygw +lime-proto-wan +dnsmasq-lease-share \
 	         +dnsmasq-distributed-hosts \
-		 +lime-hwd-openwrt-wan +!PACKAGE_lime-docs:lime-docs-minimal \
+		 +lime-hwd-openwrt-wan +lime-docs-minimal \
 	         +bmx6-auto-gw-mode +lime-hwd-ground-routing +smonit
 endef
 

--- a/packages/lime-docs/Makefile
+++ b/packages/lime-docs/Makefile
@@ -23,7 +23,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   TITLE:=LibreMesh English documentation
-  DEPENDS:=@(!PACKAGE_$(PKG_NAME)-minimal)
+  DEPENDS:=+$(PKG_NAME)-minimal
   MAINTAINER:=Ilario Gelmetti <ilario@tgnu.ml>
   URL:=http://libremesh.org/docs/
   SUBMENU:=Offline Documentation
@@ -32,7 +32,7 @@ endef
 define Package/$(PKG_NAME)-it
   CATEGORY:=LiMe
   TITLE:=LibreMesh Italian documentation
-  DEPENDS:=@(!PACKAGE_$(PKG_NAME)-minimal)
+  DEPENDS:=+$(PKG_NAME)-minimal
   MAINTAINER:=Ilario Gelmetti <ilario@tgnu.ml>
   URL:=http://libremesh.org/docs/
   SUBMENU:=Offline Documentation
@@ -42,7 +42,7 @@ define Package/$(PKG_NAME)-minimal
   CATEGORY:=LiMe
   TITLE:=LibreMesh minimal documentation
   MAINTAINER:=Ilario Gelmetti <ilario@tgnu.ml>
-  URL:=http://libremesh.org/docs/en_config.html
+  URL:=http://libremesh.org/docs/
   SUBMENU:=Offline Documentation
 endef
 
@@ -56,7 +56,7 @@ endef
 
 define Package/$(PKG_NAME)-minimal/description
 Minimal offline English documentation for LibreMesh firmware containing
-just an expaination of the main config file.
+just a commented example of the main config file.
 endef
 
 define Build/Compile
@@ -65,20 +65,18 @@ endef
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/www/docs/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/en_*.txt $(1)/www/docs/
-	$(INSTALL_DATA) ./files/lime-example $(1)/www/docs/
 	@ln -s /www/docs $(1)/docs
 endef
 
 define Package/$(PKG_NAME)-it/install
 	$(INSTALL_DIR) $(1)/www/docs/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/it_*.txt $(1)/www/docs/
-	$(INSTALL_DATA) ./files/lime-example $(1)/www/docs/
 	@ln -s /www/docs $(1)/docs
 endef
 
 define Package/$(PKG_NAME)-minimal/install
 	$(INSTALL_DIR) $(1)/www/docs/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/en_config.txt $(1)/www/docs/
+	$(INSTALL_DATA) ./files/lime-example $(1)/www/docs/
 	@ln -s /www/docs $(1)/docs
 endef
 


### PR DESCRIPTION
Following the discussion on #183, lime-docs-minimal was installing `en_config.txt` from lime-web. This file is installed also by lime-docs, for avoiding the errors caused by this overlap, a complex dependency was required, but appears to be broken (it compiles on my laptop but @nicopace is having problems with this).
Needless to say, the easiest solution is the one proposed in #183 (removing the overlap).