### PR TITLE
Update feeds in readme/buildroot to the ones present in lime-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ Clone LEDE stable repository, nowadays is version 17.01 (Reboot).
     git clone -b lede-17.01 https://git.lede-project.org/source.git lede
     cd lede
 
-Add lime-packages feed to the default ones.
+Add lime-packages, libremap and lime-ui-ng feeds to the default ones.
 
     cp feeds.conf.default feeds.conf
-    echo "src-git lime https://github.com/libremesh/lime-packages.git" >> feeds.conf
+    echo "src-git libremesh https://github.com/libremesh/lime-packages.git" >> feeds.conf
+    echo "src-git libremap https://github.com/libremap/libremap-agent-openwrt.git" >> feeds.conf
+    echo "src-git limeui https://github.com/libremesh/lime-ui-ng.git" >> feeds.conf
 
 If you want to use a specific branch of lime-packages specify it adding ;nameofthebranch at the end of the last line. For example:
 


### PR DESCRIPTION
LEDE buildroot does not compile following instructions in readme because of dependencies on libremap from lime-full. The addition of libremap feeds is inserted in readme.
In [lime-sdk feeds](/libremesh/lime-sdk/blob/master/feeds.conf.default) also lime-ui-ng is present, so I add also this which will be likely needed soon.