### PR TITLE
Add lime_zero and lime_mini to continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,5 @@ script:
 - export J=$(($(nproc)+1))
 - ./cooker -b x86/generic
 - ./cooker --flavor=lime_default -c x86/generic --profile=Generic
+- ./cooker --flavor=lime_mini -c x86/generic --profile=Generic
+- ./cooker --flavor=lime_zero -c x86/generic --profile=Generic


### PR DESCRIPTION
This could be useful for verifying dependency problems which can be different for lime_default and other LibreMesh flavors.