### PR TITLE
Changes PR name for ID in artifacts copy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,5 @@ script:
 after_success:
 - openssl aes-256-cbc -K $encrypted_4ddb7c1a1584_key -iv $encrypted_4ddb7c1a1584_iv -in $TRAVIS_BUILD_DIR/.ci/travisci_rsa.enc -out $TRAVIS_BUILD_DIR/.ci/travisci_rsa -d
 - chmod 400 $TRAVIS_BUILD_DIR/.ci/travisci_rsa
-- mv $TRAVIS_BUILD_DIR/sdk/output $TRAVIS_BUILD_DIR/sdk/$TRAVIS_BRANCH
-- rsync -r -v -e "ssh -i $TRAVIS_BUILD_DIR/.ci/travisci_rsa -o UserKnownHostsFile=$TRAVIS_BUILD_DIR/.ci/known_hosts" $TRAVIS_BUILD_DIR/sdk/$TRAVIS_BRANCH ci@repo.libremesh.org:/var/www/ci/
+- mv $TRAVIS_BUILD_DIR/sdk/output $TRAVIS_BUILD_DIR/sdk/$TRAVIS_PULL_REQUEST
+- rsync -r -v -e "ssh -i $TRAVIS_BUILD_DIR/.ci/travisci_rsa -o UserKnownHostsFile=$TRAVIS_BUILD_DIR/.ci/known_hosts" $TRAVIS_BUILD_DIR/sdk/$TRAVIS_PULL_REQUEST ci@repo.libremesh.org:/var/www/ci/


### PR DESCRIPTION
If two branches have the same name, they will collide.
In order to prevent that, we will use the PR ID as the base for directories.