### PR TITLE
Fix travis fails on forks pull request

### DIFF
--- a/.ci/after_success.sh
+++ b/.ci/after_success.sh
@@ -1,14 +1,15 @@
 #!/bin/sh
-openssl aes-256-cbc -K $encrypted_4ddb7c1a1584_key -iv $encrypted_4ddb7c1a1584_iv -in $TRAVIS_BUILD_DIR/.ci/travisci_rsa.enc -out $TRAVIS_BUILD_DIR/.ci/travisci_rsa -d
-chmod 400 $TRAVIS_BUILD_DIR/.ci/travisci_rsa
-openssl aes-256-cbc -K $encrypted_055f76aafa25_key -iv $encrypted_055f76aafa25_iv -in $TRAVIS_BUILD_DIR/.ci/commentBotKey.enc -out $TRAVIS_BUILD_DIR/.ci/commentBotKey -d
-export COMMENT_BOT_KEY=`cat $TRAVIS_BUILD_DIR/.ci/commentBotKey`
-if [ $TRAVIS_BUILD_DIR ]; then
-    mv $TRAVIS_BUILD_DIR/sdk/output $TRAVIS_BUILD_DIR/sdk/$TRAVIS_PULL_REQUEST
-    rsync -r -v -e "ssh -i $TRAVIS_BUILD_DIR/.ci/travisci_rsa -o UserKnownHostsFile=$TRAVIS_BUILD_DIR/.ci/known_hosts" $TRAVIS_BUILD_DIR/sdk/$TRAVIS_PULL_REQUEST ci@repo.libremesh.org:/var/www/ci/
-    chmod +x $TRAVIS_BUILD_DIR/.ci/announce_link_in_PR
-    $TRAVIS_BUILD_DIR/.ci/announce_link_in_PR
-else
-    echo "not a pull request branch, skip copying binaries."
+if [ ! -z "$encrypted_4ddb7c1a1584_key" ]; then
+    openssl aes-256-cbc -K $encrypted_4ddb7c1a1584_key -iv $encrypted_4ddb7c1a1584_iv -in $TRAVIS_BUILD_DIR/.ci/travisci_rsa.enc -out $TRAVIS_BUILD_DIR/.ci/travisci_rsa -d
+    chmod 400 $TRAVIS_BUILD_DIR/.ci/travisci_rsa
+    openssl aes-256-cbc -K $encrypted_055f76aafa25_key -iv $encrypted_055f76aafa25_iv -in $TRAVIS_BUILD_DIR/.ci/commentBotKey.enc -out $TRAVIS_BUILD_DIR/.ci/commentBotKey -d
+    export COMMENT_BOT_KEY=`cat $TRAVIS_BUILD_DIR/.ci/commentBotKey`
+    if [ $TRAVIS_BUILD_DIR ]; then
+        mv $TRAVIS_BUILD_DIR/sdk/output $TRAVIS_BUILD_DIR/sdk/$TRAVIS_PULL_REQUEST
+        rsync -r -v -e "ssh -i $TRAVIS_BUILD_DIR/.ci/travisci_rsa -o UserKnownHostsFile=$TRAVIS_BUILD_DIR/.ci/known_hosts" $TRAVIS_BUILD_DIR/sdk/$TRAVIS_PULL_REQUEST ci@repo.libremesh.org:/var/www/ci/
+        chmod +x $TRAVIS_BUILD_DIR/.ci/announce_link_in_PR
+        $TRAVIS_BUILD_DIR/.ci/announce_link_in_PR
+    else
+        echo "not a pull request branch, skip copying binaries."
+    fi
 fi
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ script:
 - cd $TRAVIS_BUILD_DIR/sdk
 - export J=$(($(nproc)+1))
 - ./cooker -b x86/generic
-- ./cooker --flavor=lime_default -c x86/generic --profile=Generic
-- ./cooker --flavor=lime_mini -c x86/generic --profile=Generic
-- ./cooker --flavor=lime_zero -c x86/generic --profile=Generic
+- travis_wait ./cooker --flavor=lime_default -c x86/generic --profile=Generic
+- travis_wait ./cooker --flavor=lime_mini -c x86/generic --profile=Generic
+- travis_wait ./cooker --flavor=lime_zero -c x86/generic --profile=Generic
 after_success:
 - chmod +x $TRAVIS_BUILD_DIR/.ci/after_success.sh
 - $TRAVIS_BUILD_DIR/.ci/after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,7 @@ script:
 - ./cooker --flavor=lime_mini -c x86/generic --profile=Generic
 - ./cooker --flavor=lime_zero -c x86/generic --profile=Generic
 after_success:
-- chmod +x $TRAVIS_BUILD_DIR/.ci/after_success.sh
-- $TRAVIS_BUILD_DIR/.ci/after_success.sh
+- if [ $TRAVIS_REPO_SLUG = "libremesh/lime-packages" ]; then
+    chmod +x $TRAVIS_BUILD_DIR/.ci/after_success.sh
+    $TRAVIS_BUILD_DIR/.ci/after_success.sh
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,5 @@ script:
 - ./cooker --flavor=lime_mini -c x86/generic --profile=Generic
 - ./cooker --flavor=lime_zero -c x86/generic --profile=Generic
 after_success:
-- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-    if [ $TRAVIS_REPO_SLUG = "libremesh/lime-packages" ]; then
-      chmod +x $TRAVIS_BUILD_DIR/.ci/after_success.sh;
-      $TRAVIS_BUILD_DIR/.ci/after_success.sh;
-    fi
-  fi
+- chmod +x $TRAVIS_BUILD_DIR/.ci/after_success.sh
+- $TRAVIS_BUILD_DIR/.ci/after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,9 @@ script:
 - ./cooker --flavor=lime_mini -c x86/generic --profile=Generic
 - ./cooker --flavor=lime_zero -c x86/generic --profile=Generic
 after_success:
-- if [ $TRAVIS_REPO_SLUG = "libremesh/lime-packages" ]; then
-    chmod +x $TRAVIS_BUILD_DIR/.ci/after_success.sh
-    $TRAVIS_BUILD_DIR/.ci/after_success.sh
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    if [ $TRAVIS_REPO_SLUG = "libremesh/lime-packages" ]; then
+      chmod +x $TRAVIS_BUILD_DIR/.ci/after_success.sh;
+      $TRAVIS_BUILD_DIR/.ci/after_success.sh;
+    fi
   fi


### PR DESCRIPTION
Pull requests sent from forked repositories do not have access to encrypted variables or data.
As you can not access the variables you can not decrypt the key and perform the tasks in after_success.sh
This change verifies that the action comes from the libremesh/lime-packages repository and not from a fork.