### PR TITLE
luci-webview: add attendedsysupgrade tab if exists

### DIFF
--- a/packages/lime-webui/luasrc/controller/lime.lua
+++ b/packages/lime-webui/luasrc/controller/lime.lua
@@ -109,6 +109,10 @@ function index()
 	entry({"lime","about"}, call("action_about"), _("About"), 80).dependent=false
 	entry({"lime","logout"}, call("action_logout"), _("Logout"), 90)
 
+	if nixio.fs.access("/usr/libexec/rpcd/attendedsysupgrade") then
+		entry({"lime", "attendedsysupgrade"}, template("attendedsysupgrade"), _("Attended Sysupgrade"), 75)
+	end
+
 	entry({"lime", "flashops"}, call("action_flashops"), _("Flash Firmware"), 70)
 	entry({"lime", "flashops", "sysupgrade"}, call("action_sysupgrade"))
 end


### PR DESCRIPTION
the attended sysupgrade shoudl simplify sysupgrades. If the app is
installed an entry should appear in the simple admin config.

@p4u

Signed-off-by: Paul Spooren <paul@spooren.de>