### PR TITLE
Document that specific options can't go in /etc/config/lime-defaults

### DIFF
--- a/packages/lime-docs/files/lime-example
+++ b/packages/lime-docs/files/lime-example
@@ -1,5 +1,6 @@
 # The /etc/config/lime-defaults file contains the default configuration.
 # To configure LibreMesh insert options in /etc/config/lime file, these will override the default ones.
+# Interface specific options have to be included in /etc/config/lime, if in /etc/config/lime-defaults they'll be ignored.
 #
 # The options marked with "Parametrizable with %Mn, %Nn, %H"
 # can include %Mn templates that will be substituted
@@ -70,6 +71,8 @@ config lime wifi
 #	option ieee80211s_encryption 'psk2/aes'
 #	option ieee80211s_key 'SomePsk2AESKey'
 
+
+# The following interface specific options have to be included in /etc/config/lime, not in /etc/config/lime-defaults
 
 ### WiFi interface specific options ( override general option )
 

--- a/packages/lime-docs/files/lime-example
+++ b/packages/lime-docs/files/lime-example
@@ -1,6 +1,6 @@
 # The /etc/config/lime-defaults file contains the default configuration.
 # To configure LibreMesh insert options in /etc/config/lime file, these will override the default ones.
-# Interface specific options have to be included in /etc/config/lime, if in /etc/config/lime-defaults they'll be ignored.
+# Interface specific options have to be included in /etc/config/lime, if in /etc/config/lime-defaults they'll cause unpredictable behaviour.
 #
 # The options marked with "Parametrizable with %Mn, %Nn, %H"
 # can include %Mn templates that will be substituted


### PR DESCRIPTION
Interface specific options does not work when included in /etc/config/lime-defaults, refer to @p4u's answer in lime-dev mailing list: https://lists.libremesh.org/pipermail/lime-dev/2017-August/000976.html