### PR TITLE
lime-config: configure ALFRED batman interface

### DIFF
--- a/packages/lime-proto-batadv/src/batadv.lua
+++ b/packages/lime-proto-batadv/src/batadv.lua
@@ -47,6 +47,12 @@ function batadv.configure(args)
 	uci:set("network", owrtInterfaceName, "proto", "batadv")
 	uci:set("network", owrtInterfaceName, "mesh", "bat0")
 	uci:save("network")
+
+	-- enable alfred on bat0 if installed
+	if utils.is_installed("alfred") then
+		uci:set("alfred", "alfred", "batmanif", "bat0")
+		uci:save("alfred")
+	end
 end
 
 function batadv.setup_interface(ifname, args)

--- a/packages/lime-system/files/usr/bin/lime-apply
+++ b/packages/lime-system/files/usr/bin/lime-apply
@@ -4,6 +4,10 @@ hostname="$(/sbin/uci get system.@system[0].hostname)"
 echo "$hostname" > /proc/sys/kernel/hostname
 echo "Reload network config"
 /sbin/reload_config
+[ -x /etc/init.d/alfred ] && {
+	echo "Reload ALFRED"
+	/etc/init.d/alfred restart &
+}
 echo "Reload routing protocols"
 # Workaround until "bmx6 configReload" updates hostname
 [ -x /etc/init.d/bmx6 ] && {


### PR DESCRIPTION
If batman-adv is not enabled, ALFRED does not start cause it waits for bat0 interface (which does not exist). However if ALFRED is not running, dnsmasq distributed leases does not work. On a network with LAN enabled more than one libremesh nodes might be wired connected and lease share must work between them.

This commit solves this case.

1. If batadv enabled on configuration, set ALFRED batman interface to bat0.
2. If batadv not enabled but LAN is, set it to "none", so ALFRED still works on LAN.
