### PR TITLE
Add CRON as dependency for smonit

### DIFF
--- a/packages/smonit/Makefile
+++ b/packages/smonit/Makefile
@@ -20,6 +20,12 @@ define Package/$(PKG_NAME)
   DEPENDS:=
 endef
 
+define Package/$(PKG_NAME)/config
+  select CONFIG_BUSYBOX_CONFIG_CROND
+  select CONFIG_BUSYBOX_CONFIG_CRONTAB
+endef
+
+
 define Package/$(PKG_NAME)/description
   Small modular daemon for monitoring system processes using hooks
 endef


### PR DESCRIPTION
Required for some profiles which do not have CRON enabled by default
Fix #221

Signed-off-by: p4u <p4u@dabax.net>