### PR TITLE
batctl vd is gone. use batadv-vis.

### DIFF
--- a/packages/luci-app-batman-adv/files/usr/lib/lua/luci/controller/batman.lua
+++ b/packages/luci-app-batman-adv/files/usr/lib/lua/luci/controller/batman.lua
@@ -47,10 +47,6 @@ function index()
 	page = node("batman", "json")
 	page.target = call("act_json")
 
-	page = node("batman", "vis")
-	page.target = call("act_vis")
-	page.leaf   = true
-
 	page = node("batman", "topo")
 	page.target = call("act_topo")
 	page.leaf   = true
@@ -60,19 +56,9 @@ function index()
 	page.leaf   = true
 end
 
-function act_vis(mode)
-	if mode == "server" or mode == "client" or mode == "off" then
-		luci.sys.call("batctl vm %q >/dev/null" % mode)
-		luci.http.prepare_content("application/json")
-		luci.http.write_json(mode)
-	else
-		luci.http.status(500, "Bad mode")
-	end
-end
-
 function act_topo(mode)
 	if not mode or mode == "dot" or mode == "json" then
-		local fd = io.popen("batctl vd %s" %( mode or "dot" ))
+		local fd = io.popen("batadv-vis -f %s" %( mode or "dot" ))
 		if fd then
 			if mode == "json" then
 				luci.http.prepare_content("application/json")

--- a/packages/luci-app-batman-adv/files/usr/lib/lua/luci/view/batman.htm
+++ b/packages/luci-app-batman-adv/files/usr/lib/lua/luci/view/batman.htm
@@ -12,28 +12,10 @@ $Id$
 
 -%>
 
-<%
-	local cur_vm = luci.sys.exec("batctl vm"):trim()
-%>
-
 <%+header%>
 
 <script type="text/javascript" src="<%=resource%>/cbi.js"></script>
 <script type="text/javascript">//<![CDATA[
-	function vis_apply(field)
-	{
-		document.getElementById('vis_form').style.display = 'none';
-		document.getElementById('vis_apply').style.display = '';
-
-		XHR.get('<%=luci.dispatcher.build_url("batman/vis")%>/'+field.value, null,
-			function() {
-				document.getElementById('vis_form').style.display = '';
-				document.getElementById('vis_apply').style.display = 'none';
-				document.getElementById('vis_form_dl').style.display =
-					(field.value == 'server') ? '' : 'none';
-			});
-	}
-
 	function gw_apply(field)
 	{
 		var mode, val;
@@ -153,22 +135,12 @@ $Id$
 <h2><a id="content" name="content"><%:B.A.T.M.A.N. Status%></a></h2>
 
 <fieldset class="cbi-section">
-	<legend><%:Visualization Server%></legend>
+	<legend><%:Visualization%></legend>
 	<div id="vis_form">
-		<input type="radio" name="vis" value="client" id="vis_client" onchange="vis_apply(this)"<%=ifattr(cur_vm ~= "server", "checked", "checked")%> />
-		<label for="vis_client"><%:Act as client%></label>
-		&#160; &#160;
-
-		<input type="radio" name="vis" value="server" id="vis_server" onchange="vis_apply(this)"<%=ifattr(cur_vm == "server", "checked", "checked")%> />
-		<label for="vis_server"><%:Act as server%></label>
-
-		<span id="vis_form_dl"<%=ifattr(cur_vm ~= "server", "style", "display:none")%>>
+		<span id="vis_form_dl">
 			- <a href="<%=luci.dispatcher.build_url("batman/graph")%>"><%:View Topology%></a>
 			- <a href="<%=luci.dispatcher.build_url("batman/topo")%>"><%:Download Topology%></a>
 		</span>
-	</div>
-	<div id="vis_apply" style="display:none">
-		<em><%:Applying change...%></em>
 	</div>
 </fieldset>
 


### PR DESCRIPTION
This also implies dropping all the 'batctl vm' related code,
since now master or slave mode is an alfred status, that exceeds
the scope of the visualization tool, so shouldn't be touched by this luci-app

Signed-off-by: Gui Iribarren <gui@altermundi.net>