### PR TITLE
Use libiwinfo-lua do detect radio mode instead of uci

### DIFF
--- a/packages/lime-system/Makefile
+++ b/packages/lime-system/Makefile
@@ -27,7 +27,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
-  DEPENDS:=+lua +libuci-lua +luci-lib-ip +luci-lib-nixio
+  DEPENDS:=+libiwinfo-lua +lua +libuci-lua +luci-lib-ip +luci-lib-nixio
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
@@ -5,6 +5,7 @@ local network = require("lime.network")
 local utils = require("lime.utils")
 local libuci = require("uci")
 local fs = require("nixio.fs")
+local iwinfo = require("iwinfo")
 
 wireless = {}
 
@@ -32,12 +33,8 @@ function wireless.scandevices()
 end
 
 function wireless.is5Ghz(radio)
-	local uci = libuci:cursor()
-	local hwmode = uci:get("wireless", radio, "hwmode") or "11ng"
-	if hwmode:find("a") then
-		return true
-	end
-	return false
+	local devModes = iwinfo.nl80211.hwmodelist(radio)
+	return devModes.a or devModes.ac
 end
 
 wireless.availableModes = { adhoc=true, ap=true, apname=true, ieee80211s=true }


### PR DESCRIPTION
This is expected to correctly detect available radio modes (abgnc) on
meshpotato too, before being merged need testing on meshpotato too

I reopen the PR because github someway got stuck believing the other PR has been merged while it is not