### PR TITLE
Stop suggesting to deselect firewall in menuconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Select the router architecture, model and the needed packages in menuconfig.
 
     make menuconfig
 
-We suggest you to deselect the package _dnsmasq_ from _Base system_ section and to select _dnsmasq-dhcpv6_ in the same section. Then to deselect _firewall_ from _Base system_ section. Finally to deselect _odhcpd_ from _Network_ section. 
+We suggest you to deselect the package _dnsmasq_ from _Base system_ section and to select _dnsmasq-dhcpv6_ in the same section. Then to deselect _odhcpd_ from _Network_ section.
 
 Finally enter the _LiMe_ section and select the wanted LibreMesh features, a good option is to select lime-full. 
 


### PR DESCRIPTION
`firewall` package is not deprecated anymore from default LibreMesh setup. Refer to libremesh/lime-sdk@f4f5e6f