### PR TITLE
Pkg description reflecting that Alfred doesn't need batman-adv

### DIFF
--- a/packages/dnsmasq-distributed-hosts/Makefile
+++ b/packages/dnsmasq-distributed-hosts/Makefile
@@ -16,14 +16,14 @@ include $(INCLUDE_DIR)/package.mk
 define Package/$(PKG_NAME)
  SECTION:=net
  CATEGORY:=LiMe
- TITLE:=/etc/hosts sharing accross mesh
+ TITLE:=/etc/hosts sharing across mesh
  MAINTAINER:=Gui Iribarren <gui@altermundi.net>
  URL:=http://libremesh.org
  DEPENDS:=+alfred +lua +libuci-lua
 endef
 
 define Package/$(PKG_NAME)/description
- Share /etc/hosts file accross all nodes of a mesh with enabled alfred
+ Share hostnames in /etc/hosts file across nodes of the same mesh cloud
 endef
 
 define Build/Prepare

--- a/packages/dnsmasq-distributed-hosts/Makefile
+++ b/packages/dnsmasq-distributed-hosts/Makefile
@@ -16,14 +16,14 @@ include $(INCLUDE_DIR)/package.mk
 define Package/$(PKG_NAME)
  SECTION:=net
  CATEGORY:=LiMe
- TITLE:=/etc/hosts sharing accross batman-adv mesh
+ TITLE:=/etc/hosts sharing accross mesh
  MAINTAINER:=Gui Iribarren <gui@altermundi.net>
  URL:=http://libremesh.org
  DEPENDS:=+alfred +lua +libuci-lua
 endef
 
 define Package/$(PKG_NAME)/description
- Share /etc/hosts file accross all batman-adv nodes of a mesh with enabled alfred
+ Share /etc/hosts file accross all nodes of a mesh with enabled alfred
 endef
 
 define Build/Prepare

--- a/packages/dnsmasq-lease-share/Makefile
+++ b/packages/dnsmasq-lease-share/Makefile
@@ -16,14 +16,14 @@ include $(INCLUDE_DIR)/package.mk
 define Package/$(PKG_NAME)
  SECTION:=net
  CATEGORY:=LiMe
- TITLE:=dnsmasq lease sharing accross mesh
+ TITLE:=dnsmasq lease sharing across mesh
  MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
  URL:=http://libremesh.org
  DEPENDS:=+alfred +lua +libuci-lua
 endef
 
 define Package/$(PKG_NAME)/description
- Share dnsmasq lease file accross all nodes of a mesh with enabled alfred
+ Share dnsmasq DHCP lease file across nodes of the same mesh cloud
 endef
 
 define Build/Prepare

--- a/packages/dnsmasq-lease-share/Makefile
+++ b/packages/dnsmasq-lease-share/Makefile
@@ -16,14 +16,14 @@ include $(INCLUDE_DIR)/package.mk
 define Package/$(PKG_NAME)
  SECTION:=net
  CATEGORY:=LiMe
- TITLE:=dnsmasq lease sharing accross batman-adv mesh
+ TITLE:=dnsmasq lease sharing accross mesh
  MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
  URL:=http://libremesh.org
  DEPENDS:=+alfred +lua +libuci-lua
 endef
 
 define Package/$(PKG_NAME)/description
- Share dnsmasq lease file accross all batman-adv nodes of a mesh with enabled alfred
+ Share dnsmasq lease file accross all nodes of a mesh with enabled alfred
 endef
 
 define Build/Prepare


### PR DESCRIPTION
Thanks to bcfae39, alfred works also when batman-adv is missing.
Adapt *dnsmasq-distributed-hosts* and *dnsmasq-lease-share* packages descriptions to this change.