### PR TITLE
Add bmx6 hosts file to dnsmasq

### DIFF
--- a/packages/lime-proto-bmx6/src/85-add-bmx6-addresses-to-hosts
+++ b/packages/lime-proto-bmx6/src/85-add-bmx6-addresses-to-hosts
@@ -1,5 +1,10 @@
 #!/bin/sh
-echo "adding bmx6 IPv6 addresses to dnsmasq hosts file directory"
-echo "*/4 * * * * /usr/bin/bmx6hosts_dnsmasq_update" >> /etc/crontabs/root
-uci add_list dhcp.@dnsmasq[0].addnhosts='/var/hosts/bmx6'
-uci commit dhcp
+cat /etc/crontabs/root | grep /usr/bin/bmx6hosts_dnsmasq_update || {
+  echo "adding bmx6 IPv6 addresses to dnsmasq hosts file directory"
+  echo "*/4 * * * * /usr/bin/bmx6hosts_dnsmasq_update" >> /etc/crontabs/root
+}
+
+uci show dhcp.@dnsmasq[0].addnhosts | grep '/var/hosts/bmx6' || {
+  uci add_list dhcp.@dnsmasq[0].addnhosts='/var/hosts/bmx6'
+  uci commit dhcp
+}

--- a/packages/lime-proto-bmx6/src/85-add-bmx6-addresses-to-hosts
+++ b/packages/lime-proto-bmx6/src/85-add-bmx6-addresses-to-hosts
@@ -1,3 +1,5 @@
 #!/bin/sh
 echo "adding bmx6 IPv6 addresses to dnsmasq hosts file directory"
 echo "*/4 * * * * /usr/bin/bmx6hosts_dnsmasq_update" >> /etc/crontabs/root
+uci add_list dhcp.@dnsmasq[0].addnhosts='/var/hosts/bmx6'
+uci commit dhcp


### PR DESCRIPTION
Adds a new entry to /etc/config/dhcp to tell dnsmasq look into
/var/hosts/bmx6 (for .mesh domains provided by lime-proto-bmx6 package).

It ensures that .mesh domains are resolved without depending in any other package.

Signed-off-by: p4u <p4u@dabax.net>