### PR TITLE
Adds link to LibreMap.net in location page. Fixes #120

### DIFF
--- a/packages/luci-app-lime-location/files/usr/lib/lua/luci/view/location/location.htm
+++ b/packages/luci-app-lime-location/files/usr/lib/lua/luci/view/location/location.htm
@@ -35,6 +35,9 @@ local hostname = sys.hostname()
 <script src="<%=resource%>/location/Google.js"></script>
 
 <h2><a id="content" name="content"><%:Location%></a></h2>
+
+<h3> View the full map on <a href="<%=libremap_url%>" target="_blank">LibreMap.net</a>
+
 <h3> <%=hostname%> <%:at%> <%=community%></h3>
 
 <div id="map" style="height: 280px"></div>


### PR DESCRIPTION
As per title, this commit adds a link in the `/cgi-bin/luci/lime/location` page pointing to http://libremap.net it opens the link in new tab