### PR TITLE
Changes on kmod-ebtables package dependency

### DIFF
--- a/packages/lime-basic/Makefile
+++ b/packages/lime-basic/Makefile
@@ -23,7 +23,7 @@ define Package/$(PKG_NAME)
 	SUBMENU:=Collections
 	MAINTAINER:=Pau Escrich <p4u@dabax.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lime-system +lime-proto-bmx6 +lime-proto-batadv \
+	DEPENDS:=+lime-system +lime-proto-bmx6 +lime-proto-batadv +kmod-ebtables \
 	         +lime-proto-anygw +lime-proto-wan +dnsmasq-lease-share \
 	         +dnsmasq-distributed-hosts +lime-webui \
 		 +lime-hwd-openwrt-wan +lime-docs-minimal \
@@ -37,7 +37,7 @@ define Package/$(PKG_NAME)-no-ui
 	SUBMENU:=Collections
 	MAINTAINER:=Pau Escrich <p4u@dabax.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lime-system +lime-proto-bmx6 +lime-proto-batadv \
+	DEPENDS:=+lime-system +lime-proto-bmx6 +lime-proto-batadv +kmod-ebtables \
 	         +lime-proto-anygw +lime-proto-wan +dnsmasq-lease-share \
 	         +dnsmasq-distributed-hosts \
 		 +lime-hwd-openwrt-wan +lime-docs-minimal \

--- a/packages/lime-proto-anygw/Makefile
+++ b/packages/lime-proto-anygw/Makefile
@@ -21,7 +21,8 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
-  DEPENDS:=+ebtables +lime-system +lua +libuci-lua +kmod-macvlan +dnsmasq-lease-share +dnsmasq-dhcpv6 @(!PACKAGE_dnsmasq)
+  DEPENDS:=+kmod-ebtables +ebtables +lime-system +lua +libuci-lua +kmod-macvlan \
+	+dnsmasq-lease-share +dnsmasq-dhcpv6 @(!PACKAGE_dnsmasq)
 endef
 
 define Build/Compile

--- a/packages/lime-proto-bmx6/Makefile
+++ b/packages/lime-proto-bmx6/Makefile
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
   DEPENDS:=+bmx6 +bmx6-json +bmx6-sms +bmx6-table +bmx6-uci-config +!PACKAGE_firewall:iptables \
-  +lime-system +lua +libuci-lua +kmod-ebtables-ipv6
+  +lime-system +lua +libuci-lua +PACKAGE_lime-proto-batadv:kmod-ebtables-ipv6
 endef
 
 define Build/Compile


### PR DESCRIPTION
Kmod-ebtables needs to be explicity selected due a strict dependency on
ebtables package.
Add conditional dependency in package lime-proto-bmx6 on ebtables and
lime-proto-batadv. Iff batadv is not installed bmx6 does not need
ebtables.

Signed-off-by: p4u <p4u@dabax.net>