### PR TITLE
Enable batadv protocol on ethernet by default

### DIFF
--- a/packages/lime-proto-batadv/src/batadv.lua
+++ b/packages/lime-proto-batadv/src/batadv.lua
@@ -58,7 +58,6 @@ end
 function batadv.setup_interface(ifname, args)
 	if not args["specific"] then
 		if ifname:match("^wlan%d+.ap") then return end
-		if ifname:match("^eth") then return end
 	end
 
 	local vlanId = args[2] or "%N1"


### PR DESCRIPTION
Due to lack of reproducibility and eventual alternative solution (tc+netem)
proposed for bla+ogm batadv deadloop on bridged ethernet interfaces.
Batman advanced is now re-enabled by default on plain ethernet interfaces.