### PR TITLE
Introduce new option bmx6_publish_ownip

### DIFF
--- a/packages/lime-proto-bmx6/src/bmx6.lua
+++ b/packages/lime-proto-bmx6/src/bmx6.lua
@@ -32,8 +32,8 @@ function bmx6.configure(args)
 	uci:set(bmx6.f, "main", "tun6Address", ipv6:string())
 
 	-- If publish own IP enabled, configure tunIn
-	local pub_own_ip = config.get("network", "bmx6_publish_ownip")
-	if (pub_own_ip == '1' or pub_own_ip == 'true') then
+	local pub_own_ip = config.get_bool("network", "bmx6_publish_ownip", false)
+	if (pub_own_ip) then
 		uci:set(bmx6.f, "myIP4", "tunIn")
 		uci:set(bmx6.f, "myIP4", "tunIn", "myIP4")
 		uci:set(bmx6.f, "myIP4", "network", utils.split(ipv4:string(),'/')[1]..'/32')

--- a/packages/lime-proto-bmx6/src/bmx6.lua
+++ b/packages/lime-proto-bmx6/src/bmx6.lua
@@ -31,6 +31,17 @@ function bmx6.configure(args)
 	uci:set(bmx6.f, "main", "tun4Address", ipv4:string())
 	uci:set(bmx6.f, "main", "tun6Address", ipv6:string())
 
+	-- If publish own IP enabled, configure tunIn
+	local pub_own_ip = config.get("network", "bmx6_publish_ownip")
+	if (pub_own_ip == '1' or pub_own_ip == 'true') then
+		uci:set(bmx6.f, "myIP4", "tunIn")
+		uci:set(bmx6.f, "myIP4", "tunIn", "myIP4")
+		uci:set(bmx6.f, "myIP4", "network", utils.split(ipv4:string(),'/')[1]..'/32')
+		uci:set(bmx6.f, "myIP6", "tunIn")
+		uci:set(bmx6.f, "myIP6", "tunIn", "myIP6")
+		uci:set(bmx6.f, "myIP6", "network", utils.split(ipv6:string(),'/')[1]..'/128')
+	end
+
 	-- Enable bmx6 uci config plugin
 	uci:set(bmx6.f, "config", "plugin")
 	uci:set(bmx6.f, "config", "plugin", "bmx6_config.so")

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -17,6 +17,7 @@ config lime network
 	option anygw_dhcp_limit '0'
 	option main_ipv6_address '2a00:1508:0a%N1:%N200::/64'
 	option bmx6_mtu '1500'
+	option bmx6_publish_ownip '0'
 	list protocols ieee80211s
 	list protocols lan
 	list protocols anygw

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -16,8 +16,6 @@ config lime network
 	option anygw_dhcp_start '2'
 	option anygw_dhcp_limit '0'
 	option main_ipv6_address '2a00:1508:0a%N1:%N200::/64'
-	option bmx6_mtu '1500'
-	option bmx6_publish_ownip '0'
 	list protocols ieee80211s
 	list protocols lan
 	list protocols anygw
@@ -29,6 +27,8 @@ config lime network
 	list resolvers 4.2.2.2   # b.resolvers.Level3.net
 	list resolvers 141.1.1.1 # cns1.cw.net
 	list resolvers 2001:470:20::2 # ordns.he.net
+	option bmx6_mtu '1500'
+	option bmx6_publish_ownip false
 	option bmx6_over_batman false
 	option bmx6_pref_gw none
 	option bmx7_over_batman false

--- a/packages/lime-system/files/usr/lib/lua/lime/config.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/config.lua
@@ -20,6 +20,8 @@ function config.get(sectionname, option, default)
 		config.set(sectionname, option, defcnf)
 	elseif ( default ~= nil ) then
 		defcnf = default
+		local cfn = sectionname.."."..option
+		print("WARNING: Option "..cfn.." is not defined. Using value "..(default or 'False'))
 	else
 		local cfn = sectionname.."."..option
 		print("WARNING: Attempt to access undeclared default for: "..cfn)


### PR DESCRIPTION
If enabled bmx6 will publish the own node IPv4/IPv6 addresses via tunIn. By default it is disabled.

This option on some scenarios such as:

1. The users want to have an easy way to identify node IPs (bmx6 tunnels will show it)
2. A cloud (sharing the same network domain) is broken. If this option is enabled the nodes of one side will be able to reach the nodes of the other side throgh the standard ipv4 and ipv6
3. The users want to let bmx6 decide which path to take from one node to another (instead of just dropping the packet to br-lan and let bat-adv decide).

Signed-off-by: p4u <p4u@dabax.net>