### PR TITLE
lime-proto-bmx7: enable SMS plugin

### DIFF
--- a/packages/lime-proto-bmx7/src/bmx7.lua
+++ b/packages/lime-proto-bmx7/src/bmx7.lua
@@ -37,6 +37,10 @@ function bmx7.configure(args)
 	-- Enable JSON plugin to get bmx7 information in json format
 	uci:set(bmx7.f, "json", "plugin")
 	uci:set(bmx7.f, "json", "plugin", "bmx7_json.so")
+	
+	-- Enable SMS plugin to enable sharing of small files
+	uci:set(bmx7.f, "sms", "plugin")
+	uci:set(bmx7.f, "sms", "plugin", "bmx7_sms.so")
 
 	-- Enable tun plugin, DISCLAIMER: this must be positioned before table plugin if used.
 	uci:set(bmx7.f, "ptun", "plugin")


### PR DESCRIPTION
The [SMS plugin](https://github.com/bmx-routing/bmx7#sms-plugin) can be very useful for various projects

See https://github.com/libremesh/lime-packages/issues/104