### PR TITLE
replace luci{-mod-admin-full,} to fix #260

### DIFF
--- a/packages/lime-full/Makefile
+++ b/packages/lime-full/Makefile
@@ -23,7 +23,7 @@ define Package/$(PKG_NAME)
   SUBMENU:=Collections
   MAINTAINER:=Pau Escrich <p4u@dabax.net>
   URL:=http://libremesh.org
-  DEPENDS:=+lime-basic +lime-debug +luci-mod-admin-full +lime-map-agent +lime-docs +lime-app
+  DEPENDS:=+lime-basic +lime-debug +luci +lime-map-agent +lime-docs +lime-app
 endef
 
 define Package/$(PKG_NAME)/description


### PR DESCRIPTION
Install full luci instead of *only* the luci-mod-admin-full. The package luci-proto-ppp is additionally installed which result's in a squashed file size increase of < 1KB.