### PR TITLE
lime-defaults: remove unused olsr

### DIFF
--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -22,9 +22,6 @@ config lime network
 	list protocols anygw
 	list protocols batadv:%N1
 	list protocols bmx6:13
-	list protocols olsr:14
-	list protocols olsr6:15
-	list protocols olsr2:16
 	list resolvers 4.2.2.2   # b.resolvers.Level3.net
 	list resolvers 141.1.1.1 # cns1.cw.net
 	list resolvers 2001:470:20::2 # ordns.he.net


### PR DESCRIPTION
olsr is not installed by default and so shouldn't be configured per default. 
This should slightly clean up lime-defaults to be easier readable.