### PR TITLE
enable watchping to check for ipv6 connectivity

### DIFF
--- a/packages/watchping/files/etc/init.d/watchping
+++ b/packages/watchping/files/etc/init.d/watchping
@@ -107,6 +107,7 @@ service_triggers() {
 		for iface in $trigger_interfaces; do
 			logger -p user.info -t "watchping" "adding ifup trigger for $iface"
 			procd_add_interface_trigger "interface.*.up" "$iface" /etc/init.d/watchping restart
+			procd_add_interface_trigger "interface.*.update" "$iface" /etc/init.d/watchping restart
 		done
 	fi
 }

--- a/packages/watchping/files/etc/uci-defaults/90_watchping
+++ b/packages/watchping/files/etc/uci-defaults/90_watchping
@@ -2,11 +2,16 @@
 
 uci -q get system.@watchping[0] || {
         uci batch <<EOF
-        add system watchping
-        set system.@watchping[0].interface=wan
-        set system.@watchping[0].timeout=2m
-        set system.@watchping[0].pinghosts=8.8.8.8
-        set system.@watchping[0].pinginterval=20s
+        set system.watchping=watchping
+        set system.watchping.interface=wan
+        set system.watchping.timeout=2m
+        set system.watchping.pinghosts=8.8.8.8
+        set system.watchping.pinginterval=20s
+        set system.watchping6=watchping
+        set system.watchping6.interface=wan6
+        set system.watchping6.timeout=2m
+        set system.watchping6.pinghosts=2001:470:20::2
+        set system.watchping6.pinginterval=20s
         commit system
 EOF
 }

--- a/packages/watchping/files/etc/watchping/wan6-fail.d/README
+++ b/packages/watchping/files/etc/watchping/wan6-fail.d/README
@@ -1,0 +1,4 @@
+# All executable files in this directory are processed
+# when watchping gets no reply through wan6 ('interface')
+# from all of the hosts listed in 'pinghosts'
+# after the time set in 'timeout'

--- a/packages/watchping/files/etc/watchping/wan6-ok.d/README
+++ b/packages/watchping/files/etc/watchping/wan6-ok.d/README
@@ -1,0 +1,3 @@
+# All executable files in this directory are processed
+# when watchping can get a reply through wan6 ('interface')
+# from any of the hosts listed in 'pinghosts'

--- a/packages/watchping/files/usr/bin/watchping
+++ b/packages/watchping/files/usr/bin/watchping
@@ -18,7 +18,8 @@ run_hooks () {
 watchping_ping() {
 	local ifname="$1"; local timeout="$2"; local pinghosts="$3"; local pinginterval="$4"; local hookname="$5"
 	local last_hooks_run="fail"
-	
+	local pingexec="ping"
+
 	if [ ! -r "/sys/class/net/$ifname/ifindex" ] ; then
 		echo "Interface $ifname unsupported or not found!"
 		exit 1
@@ -45,8 +46,13 @@ watchping_ping() {
 		time_now="${time_now%%.*}"
 		time_lastcheck="$time_now"
 
+		case "$host" in
+			*":"*)
+				[ "$(which ping6 2>/dev/null)" ] && pingexec="ping6"
+				;;
+		esac
 		for host in "$pinghosts" ; do
-			if ping -I "$ifname" -c 1 "$host" &> /dev/null ; then 
+			if $pingexec -I "$ifname" -c 1 "$host" &> /dev/null ; then
 				time_lastcheck_withinternet="$time_now"
 			else
 				time_diff="$((time_now-time_lastcheck_withinternet))"


### PR DESCRIPTION
all work done by @dangowrt and based on https://github.com/libremesh/lime-packages/pull/71
This PR does not include the bmx6 script as the discussion is still
ongoing. As IPv6 watchping functionality is not directly related this
can be merged independently.