### PR TITLE
network.lua: set again the prefix in case of invalid IPv4 address, fix #287

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -68,7 +68,10 @@ function network.primary_address(offset)
 	invalid = invalid or ipv4_template:equal(mc:minhost())
 	--! Generated address is the broadcast address like 192.0.2.255/24 ?
 	invalid = invalid or ipv4_template:equal(mc:broadcast())
-	if invalid then ipv4_template = mc:maxhost() end
+	if invalid then
+		ipv4_template = mc:maxhost()
+		ipv4_template:prefix(tonumber(ipv4_maskbits))
+	end
 
 	ipv6_template:prefix(tonumber(ipv6_maskbits))
 


### PR DESCRIPTION
As described in #287, network.lua was correctly identifying invalid IPv4 (in the specific case IPs which were overlapping with anygw IP, so the first of the domain) but was not setting correctly the netmask in this case.
Let me know if there is a more elegant way to do this, I expected it was possible to change just the IPv4 address with just one command without changing the prefix (something like `ipv4_template:host(mc:maxhost())`) but I couldn't find it.