### PR TITLE
lime/wireless: activate wifi modes based on suffix

### DIFF
--- a/packages/lime-docs/files/lime-example
+++ b/packages/lime-docs/files/lime-example
@@ -60,8 +60,11 @@ config lime wifi
 	list modes 'ap'
 	list modes 'apname'
 	list modes 'ieee80211s'
-#	list modes 'adhoc'				# See below for adhoc configuration
-#	list modes 'client'				# See below for client configuration
+#	list modes 'adhoc'            # See below for adhoc configuration
+#	list modes 'client'           # See below for client configuration
+#	list modes 'ap_2ghz'          # Enable Access Point only on 2.4GHz Radio
+#	list modes 'apname_2ghz' 
+#	list modes 'ieee80211s_5ghz'  # Enable Mesh network only on 5Ghz Radio
 	option ap_ssid 'LibreMesh.org'
 #	option ap_key 'SomeWPA2PskKey'
 #	option ap_encryption 'psk2'
@@ -72,6 +75,7 @@ config lime wifi
 	option ieee80211s_mesh_id 'LiMe'
 #	option ieee80211s_encryption 'psk2/aes'
 #	option ieee80211s_key 'SomePsk2AESKey'
+
 
 
 # The following interface specific options have to be included in /etc/config/lime, not in /etc/config/lime-defaults

--- a/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
@@ -113,31 +113,35 @@ function wireless.configure()
 			uci:save("wireless")
 
 			for _,modeName in pairs(modes) do
-				local args = {}
-				local mode = require("lime.mode."..modeName)
+				if not modeName:match(ignoredSuffix) then
+					modeName = modeName:gsub(freqSuffix, "")
 
-				for key,value in pairs(options) do
-					local keyPrefix = utils.split(key, "_")[1]
-					local isGoodOption = ( (key ~= "modes")
-					                and (not key:match("^%."))
-					                and (not key:match("channel"))
-					                and (not key:match("country"))
-					                and (not key:match("htmode"))
-					                and (not (wireless.isMode(keyPrefix) and keyPrefix ~= modeName))
-					                and (not key:match(ignoredSuffix)) )
-					if isGoodOption then
-						local nk = key:gsub("^"..modeName.."_", ""):gsub(freqSuffix.."$", "")
-						if nk == "ssid" then
-							value = utils.applyHostnameTemplate(value)
-							value = utils.applyMacTemplate16(value, network.primary_mac())
-							value = string.sub(value, 1, 32)
+					local args = {}
+					local mode = require("lime.mode."..modeName)
+
+					for key,value in pairs(options) do
+						local keyPrefix = utils.split(key, "_")[1]
+						local isGoodOption = ( (key ~= "modes")
+							and (not key:match("^%."))
+							and (not key:match("channel"))
+							and (not key:match("country"))
+							and (not key:match("htmode"))
+							and (not (wireless.isMode(keyPrefix) and keyPrefix ~= modeName))
+							and (not key:match(ignoredSuffix)) )
+						if isGoodOption then
+							local nk = key:gsub("^"..modeName.."_", ""):gsub(freqSuffix.."$", "")
+							if nk == "ssid" then
+								value = utils.applyHostnameTemplate(value)
+								value = utils.applyMacTemplate16(value, network.primary_mac())
+								value = string.sub(value, 1, 32)
+							end
+
+							args[nk] = value
 						end
-
-						args[nk] = value
 					end
-				end
 
-				mode.setup_radio(radio, args)
+					mode.setup_radio(radio, args)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Add the option to add `_2ghz` and `_5ghz` as a suffix to the
activated wifi modes (ap, apname, ieee80211s).

This is usefull as the specific radio configuration (radio0, radio1,
etc) only works with /etc/config/lime but not with lime-defaults.

When using encrypted mesh and encrypted AP it comes to an error
mentioned [here](https://github.com/libremesh/lime-packages/issues/208).

Fixes https://github.com/libremesh/lime-packages/issues/306