### PR TITLE
lime-proto-bmx7: print BMX7 ID on login

### DIFF
--- a/packages/lime-proto-bmx7/Makefile
+++ b/packages/lime-proto-bmx7/Makefile
@@ -34,6 +34,14 @@ endef
 define Package/$(PKG_NAME)/install
 	@mkdir -p $(1)/usr/lib/lua/lime/proto || true
 	$(CP) ./build/bmx7.lua $(1)/usr/lib/lua/lime/proto/
+
+	@mkdir -p $(1)/etc/uci-defaults
+	$(CP) ./files/etc/uci-defaults/bmx7-id-banner.defaults /etc/uci-defaults/bmx7-id-banner
+endef
+
+define Package/$(PKG_NAME)/postrm
+	#!/bin/sh
+	sed -i '/^pgrep bmx7 > /dev/null && echo " BMX7 ID: .*$/d' /etc/profile
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/lime-proto-bmx7/files/etc/uci-defaults/bmx7-id-banner.defaults
+++ b/packages/lime-proto-bmx7/files/etc/uci-defaults/bmx7-id-banner.defaults
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cat << EOF > /etc/profile
+pgrep bmx7 > /dev/null && echo " BMX7 ID: $(bmx7 -c show=status /r=1 | tail -n 1 | awk '{ print $2 }')"
+EOF
+


### PR DESCRIPTION
looks like this
```  ___   __ __                _______             __
 |   |_|__|  |--.----.-----.|   |   |-----.-----|  |--.
 |     |  |  _  |   _|  -__||       |  -__|__ --|     |
 |_____|__|_____|__| |_____||__|_|__|_____|_____|__|__|

 ------------------------------------------------------
 LiMe 17.06 DaybootRely (17.06 rev. ac18095 20171216_0345)
 ------------------------------------------------------
 http://libremesh.org
 ------------------------------------------------------
 BMX7 ID: 5FA90DD26826D3DF98BF12271FB8B00C7DB7F25DB3FEF6C7D60B49CC
```
The ID can be used for various things and is so a handy information.