### PR TITLE
wireless.lua: reduce default distance to 1000

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
@@ -100,7 +100,7 @@ function wireless.configure()
 			end
 
 			--! up to 10km links by default
-			local distance = options["distance"..freqSuffix] or options["distance"] or 10000
+			local distance = options["distance"..freqSuffix] or options["distance"] or 1000
 			local htmode = options["htmode"..freqSuffix] or options["htmode"]
 			local channel = options["channel"..freqSuffix] or options["channel"]
 


### PR DESCRIPTION
following the [lime-defaults](https://github.com/libremesh/lime-packages/blob/develop/packages/lime-system/files/etc/config/lime-defaults) the hard coded default shouldn't be that big as most connections are under 10km.