### PR TITLE
network.lua: add use_odhcpd option

### DIFF
--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -37,6 +37,7 @@ config lime network
 	option bmx7_over_batman false
 	option bmx7_pref_gw none
 	option anygw_mac "aa:aa:aa:%N1:%N2:aa"
+	option use_odhcpd false
 
 config lime wifi
 	option channel_2ghz '11'

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -138,8 +138,15 @@ function network.clean()
 
 	uci:save("network")
 
-	print("Disabling odhcpd")
-	io.popen("/etc/init.d/odhcpd disable 2>/dev/null || true"):close()
+	if config.get_bool("network", "use_odhcpd", false) then
+		print("Use odhcpd as dhcp server")
+		uci:set("dhcp", "odchpd", "maindhcp", 1)
+		os.execute("/etc/init.d/odhcpd enable")
+	else
+		print("Disabling odhcpd")
+		uci:set("dhcp", "odchpd", "maindhcp", 0)
+		os.execute("/etc/init.d/odhcpd disable")
+	end
 
 	print("Cleaning dnsmasq")
 	uci:foreach("dhcp", "dnsmasq", function(s) uci:delete("dhcp", s[".name"], "server") end)


### PR DESCRIPTION
introduce new lime-defaults option use_odhcpd (default currently on
false) which dis- or enables odhcpd as primary dhcp server.

replace io.popen by os.execute for a simpler syntax

Signed-off-by: Paul Spooren <spooren@informatik.uni-leipzig.de>