### PR TITLE
lime-proto-bmx6,7: fix maxRate for wifi

### DIFF
--- a/packages/lime-proto-bmx6/src/bmx6.lua
+++ b/packages/lime-proto-bmx6/src/bmx6.lua
@@ -198,7 +198,7 @@ function bmx6.setup_interface(ifname, args)
 
 	-- BEGIN [Workaround issue 40]
 	if ifname:match("^wlan%d+") then
-		uci:set(bmx6.f, owrtInterfaceName, "rateMax", "54000")
+		uci:set(bmx6.f, owrtInterfaceName, "rateMax", "54000000")
 	end
 	--- END [Workaround issue 40]
 

--- a/packages/lime-proto-bmx7/src/bmx7.lua
+++ b/packages/lime-proto-bmx7/src/bmx7.lua
@@ -196,7 +196,7 @@ function bmx7.setup_interface(ifname, args)
 
 	-- BEGIN [Workaround issue 40]
 	if ifname:match("^wlan%d+") then
-		uci:set(bmx7.f, owrtInterfaceName, "rateMax", "54000")
+		uci:set(bmx7.f, owrtInterfaceName, "rateMax", "54000000")
 	end
 	--- END [Workaround issue 40]
 


### PR DESCRIPTION
max rate is configured in Bits not KBits. 54000 would result in
a estimated max connection of 54KBit while it's really 54Mbit.