### PR TITLE
lime-proto-bmx{6,7}: sms only active if installed

### DIFF
--- a/packages/lime-proto-bmx6/src/bmx6.lua
+++ b/packages/lime-proto-bmx6/src/bmx6.lua
@@ -51,9 +51,10 @@ function bmx6.configure(args)
 	uci:set(bmx6.f, "json", "plugin", "bmx6_json.so")
 
 	-- Enable sms plugin
-	uci:set(bmx6.f, "sms", "plugin")
-	uci:set(bmx6.f, "sms", "plugin", "bmx6_sms.so")
-
+	if utils.is_installed("bmx6-sms") then
+		uci:set(bmx6.f, "sms", "plugin")
+		uci:set(bmx6.f, "sms", "plugin", "bmx6_sms.so")
+	end
 
 	-- Enable tun plugin, DISCLAIMER: this must be positioned before table plugin if used.
 	--uci:set(bmx6.f, "ptun", "plugin")

--- a/packages/lime-proto-bmx7/src/bmx7.lua
+++ b/packages/lime-proto-bmx7/src/bmx7.lua
@@ -48,8 +48,10 @@ function bmx7.configure(args)
 	uci:set(bmx7.f, "config", "plugin", "bmx7_config.so")
 
 	-- Enable JSON plugin to get bmx7 information in json format
-	uci:set(bmx7.f, "json", "plugin")
-	uci:set(bmx7.f, "json", "plugin", "bmx7_json.so")
+	if utils.is_installed("bmx7-sms") then
+		uci:set(bmx7.f, "json", "plugin")
+		uci:set(bmx7.f, "json", "plugin", "bmx7_json.so")
+	end
 
 	-- Enable SMS plugin to enable sharing of small files
 	uci:set(bmx7.f, "sms", "plugin")


### PR DESCRIPTION
if the plugin is activated but the plugin not installed bmx7 crashes on
startup.