### PR TITLE
WIP: lime-proto-bmx{6,7}: fixup maxrate and add "false"

### DIFF
--- a/packages/lime-proto-bmx6/src/bmx6.lua
+++ b/packages/lime-proto-bmx6/src/bmx6.lua
@@ -199,8 +199,10 @@ function bmx6.setup_interface(ifname, args)
 
 	-- BEGIN [Workaround issue 40]
 	if ifname:match("^wlan%d+") then
-		local rateMax = config.get_bool("network", "bmx6_wifi_rate_max", 54000000)
-		uci:set(bmx6.f, owrtInterfaceName, "rateMax", rateMax)
+		local rateMax = config.get("network", "bmx6_wifi_rate_max", 54000000)
+		if rateMax then
+			uci:set(bmx6.f, owrtInterfaceName, "rateMax", rateMax)
+		end
 	end
 	--- END [Workaround issue 40]
 

--- a/packages/lime-proto-bmx7/src/bmx7.lua
+++ b/packages/lime-proto-bmx7/src/bmx7.lua
@@ -204,8 +204,10 @@ function bmx7.setup_interface(ifname, args)
 
 	-- BEGIN [Workaround issue 40]
 	if ifname:match("^wlan%d+") then
-		local rateMax = config.get_bool("network", "bmx7_wifi_rate_max", 54000000)
-		uci:set(bmx7.f, owrtInterfaceName, "rateMax", rateMax)
+		local rateMax = config.get("network", "bmx7_wifi_rate_max", 54000000)
+		if rateMax then
+			uci:set(bmx7.f, owrtInterfaceName, "rateMax", rateMax)
+		end
 	end
 	--- END [Workaround issue 40]
 


### PR DESCRIPTION
blind copy&paste is bad and I feel bad

also setting manually bmx{6,7}_wifi_rate_max to false disables
automatically the rateMax parameter. This is useful as bmx7 now does
good bandwidth estimations itself [1]

[1] https://github.com/bmx-routing/bmx7/pull/15