### PR TITLE
lime-hwd-openwrt-wan: fix script if missing wan

### DIFF
--- a/packages/lime-hwd-openwrt-wan/src/openwrt_wan.lua
+++ b/packages/lime-hwd-openwrt-wan/src/openwrt_wan.lua
@@ -19,7 +19,7 @@ function openwrt_wan.detect_hardware()
 		local handle = io.popen("sh /usr/lib/lua/lime/hwd/openwrt_wan.sh")
 		local ifname = handle:read("*a")
 		handle:close()
-		if ifname then
+		if ifname and ifname ~= "" then
 			local protos = {}
 			local net = require("lime.network")
 			local utils = require("lime.utils")
@@ -41,6 +41,8 @@ function openwrt_wan.detect_hardware()
 			config.set(openwrt_wan.sectionName, "protocols", protos)
 			config.set(openwrt_wan.sectionName, "linux_name", ifname)
 			config.end_batch()
+		else
+			print("No wan interface detected")
 		end
 	end
 end

--- a/packages/lime-hwd-openwrt-wan/src/openwrt_wan.sh
+++ b/packages/lime-hwd-openwrt-wan/src/openwrt_wan.sh
@@ -5,7 +5,11 @@
 json_load "$(cat /etc/board.json)"
 
 json_select network
-json_select wan
-json_get_var ifname ifname
+if json_get_type Type wan && [ "$Type" == object ]; then
+    json_select wan
+    json_get_var ifname ifname
+else
+    ifname=""
+fi
 
 echo -n "$ifname"


### PR DESCRIPTION
currently a missing wan interfaces screws the config, the following
string will be inserted:

    WARNING: Variable 'wan' does not exist or is not an array/object

this happens for instance on a raspberry pi with only one eth port.

If no wan is detected, just leave it unconfigured.

Signed-off-by: Paul Spooren <spooren@informatik.uni-leipzig.de>