### PR TITLE
lime-proto-bmx7: various fixups

### DIFF
--- a/packages/lime-proto-bmx7/src/bmx7.lua
+++ b/packages/lime-proto-bmx7/src/bmx7.lua
@@ -48,9 +48,15 @@ function bmx7.configure(args)
 	uci:set(bmx7.f, "config", "plugin", "bmx7_config.so")
 
 	-- Enable JSON plugin to get bmx7 information in json format
-	if utils.is_installed("bmx7-sms") then
+	if utils.is_installed("bmx7-json") then
 		uci:set(bmx7.f, "json", "plugin")
 		uci:set(bmx7.f, "json", "plugin", "bmx7_json.so")
+	end
+
+	-- Enable topology plugin to get netjson file
+	if utils.is_installed("bmx7-topology") then
+		uci:set(bmx7.f, "topology", "plugin")
+		uci:set(bmx7.f, "topology", "plugin", "bmx7_topology.so")
 	end
 
 	-- Enable iwinfo plugin to get better link bandwidth estimation
@@ -60,8 +66,10 @@ function bmx7.configure(args)
 	end
 
 	-- Enable SMS plugin to enable sharing of small files
-	uci:set(bmx7.f, "sms", "plugin")
-	uci:set(bmx7.f, "sms", "plugin", "bmx7_sms.so")
+	if utils.is_installed("bmx7-sms") then
+		uci:set(bmx7.f, "sms", "plugin")
+		uci:set(bmx7.f, "sms", "plugin", "bmx7_sms.so")
+	end
 
 	-- Enable tun plugin, DISCLAIMER: this must be positioned before table plugin if used.
 	uci:set(bmx7.f, "ptun", "plugin")


### PR DESCRIPTION
replace copy & paste error (s/sms/json/)
active topology plugin if installed
only activate sms plugin if installed

Signed-off-by: Paul Spooren <spooren@informatik.uni-leipzig.de>