### PR TITLE
[RFC] proto/lan: handle bridged primary_interface fix #355

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/proto/lan.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/proto/lan.lua
@@ -55,6 +55,9 @@ function lan.setup_interface(ifname, args)
 			table.insert(bridgedIfs, iface)
 		end
 	end
+    if ifname == config.get("network", "primary_interface") then
+        config.set("network", "primary_interface", "br-lan")
+    end
 	table.insert(bridgedIfs, ifname)
 	uci:set("network", "lan", "ifname", bridgedIfs)
 	uci:save("network")


### PR DESCRIPTION
If eth0 is bridged on br-lan the bridge receive the devices MAC address
and the real eth0 (seems to) get a random generated MAC address.

To avoid random MAC addresses the primary interface of lime is setup to
br-lan in these cases.

Signed-off-by: Paul Spooren <spooren@informatik.uni-leipzig.de>