### PR TITLE
change .po file encoding to UTF-8

### DIFF
--- a/packages/lime-webui/po/es/lime-webui.po
+++ b/packages/lime-webui/po/es/lime-webui.po
@@ -35,7 +35,7 @@ msgid "Distance"
 msgstr "Distancia"
 
 msgid "Max distance for the links in meters (big impact on performance)"
-msgstr "Distancia m√xima de los enlaces WiFi en metros (impacto importante)"
+msgstr "Distancia m√°xima de los enlaces WiFi en metros (impacto importante)"
 
 msgid "Default channel used for 2.4 GHz radios"
 msgstr "Canal por defecto usado para las radios de 2.4GHz"


### PR DESCRIPTION
In order to work with TranslateWiki, @Nikerabbit asked to change the .po files from ISO-8859 to UTF-8. Two files (po/limeweb-ui.pot and po/qqq/limeweb-ui.po) were already in UTF-8. In this commit, I changed the remaining file po/es/limeweb-ui.po to UTF-8.

@nicoechaniz thinks it will be ok with the routers, but says to ask @G10h4ck .
@G10h4ck would be surprised if UTF-8 works on the routers.

Opinions? Solutions? Ways to test without bricking routers?