### PR TITLE
treewide: set PKGARCH:=all

### DIFF
--- a/packages/altermap-agent/Makefile
+++ b/packages/altermap-agent/Makefile
@@ -19,6 +19,7 @@ define Package/$(PKG_NAME)
   TITLE:=Send system information to an AlterMap server
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
   DEPENDS:= +luci-lib-core +luci-lib-httpclient +luci-lib-json +luci-lib-nixio +libuci-lua
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/batman-adv-auto-gw-mode/Makefile
+++ b/packages/batman-adv-auto-gw-mode/Makefile
@@ -20,6 +20,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
   URL:=http://libremesh.org
   DEPENDS:= +kmod-batman-adv +watchping +dnsmasq-dhcpv6 +ip
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/bmx6-auto-gw-mode/Makefile
+++ b/packages/bmx6-auto-gw-mode/Makefile
@@ -20,6 +20,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Pau Escrich <p4u@dabax.et>
   URL:=http://libremesh.org
   DEPENDS:= bmx6 +watchping +ip
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/bmx7-auto-gw-mode/Makefile
+++ b/packages/bmx7-auto-gw-mode/Makefile
@@ -20,6 +20,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Pau Escrich <p4u@dabax.et>
   URL:=http://libremesh.org
   DEPENDS:= bmx7 +watchping +ip
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/cotonete/Makefile
+++ b/packages/cotonete/Makefile
@@ -14,6 +14,7 @@ define Package/$(PKG_NAME)
     MAINTAINER:=Nicolas Pace <nico@libre.ws>
     URL:=http://www.libremesh.org/
     DEPENDS:=
+    PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/dnsmasq-distributed-hosts/Makefile
+++ b/packages/dnsmasq-distributed-hosts/Makefile
@@ -20,6 +20,7 @@ define Package/$(PKG_NAME)
  MAINTAINER:=Gui Iribarren <gui@altermundi.net>
  URL:=http://libremesh.org
  DEPENDS:=+alfred +lua +libuci-lua
+ PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/dnsmasq-lease-share/Makefile
+++ b/packages/dnsmasq-lease-share/Makefile
@@ -20,6 +20,7 @@ define Package/$(PKG_NAME)
  MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
  URL:=http://libremesh.org
  DEPENDS:=+alfred +lua +libuci-lua
+ PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-altermesh/Makefile
+++ b/packages/lime-altermesh/Makefile
@@ -28,6 +28,7 @@ define Package/$(PKG_NAME)
            +luci-mod-status +luci-mod-lime-basic-ssl \
            +libremap-agent +luci-lib-libremap-wireless \
            +luci-lib-libremap-location +luci-lib-libremap-system
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-ap-watchping/Makefile
+++ b/packages/lime-ap-watchping/Makefile
@@ -21,6 +21,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Pau Escrich <p4u@dabax.et>
   URL:=http://libremesh.org
   DEPENDS:= +watchping
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-basic-uing/Makefile
+++ b/packages/lime-basic-uing/Makefile
@@ -28,6 +28,7 @@ define Package/$(PKG_NAME)
 	         +dnsmasq-distributed-hosts +lime-webui-ng \
 	         +lime-hwd-openwrt-wan +bmx6-auto-gw-mode +lime-hwd-ground-routing \
 		 +lime-docs-minimal
+	PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-debug/Makefile
+++ b/packages/lime-debug/Makefile
@@ -24,6 +24,7 @@ define Package/$(PKG_NAME)
 	DEPENDS:=+PACKAGE_lime-proto-batadv:batctl \
 		+busybox +ethtool +iwinfo +iw +mtr +ip +iputils-ping6 +iputils-ping \
 		+sprunge +safe-reboot +netperf +pv +tcpdump-mini +bwm-ng
+	PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-docs/Makefile
+++ b/packages/lime-docs/Makefile
@@ -27,6 +27,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Ilario Gelmetti <ilario@tgnu.ml>
   URL:=http://libremesh.org/docs/
   SUBMENU:=Offline Documentation
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)-it
@@ -36,6 +37,7 @@ define Package/$(PKG_NAME)-it
   MAINTAINER:=Ilario Gelmetti <ilario@tgnu.ml>
   URL:=http://libremesh.org/docs/
   SUBMENU:=Offline Documentation
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)-minimal
@@ -44,6 +46,7 @@ define Package/$(PKG_NAME)-minimal
   MAINTAINER:=Ilario Gelmetti <ilario@tgnu.ml>
   URL:=http://libremesh.org/docs/
   SUBMENU:=Offline Documentation
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-freifunk/Makefile
+++ b/packages/lime-freifunk/Makefile
@@ -24,6 +24,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
   URL:=http://libremesh.org
   DEPENDS:=+lime-basic
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-full/Makefile
+++ b/packages/lime-full/Makefile
@@ -24,6 +24,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Pau Escrich <p4u@dabax.net>
   URL:=http://libremesh.org
   DEPENDS:=+lime-basic +lime-debug +luci +lime-map-agent +lime-docs +lime-app
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-hwd-ground-routing/Makefile
+++ b/packages/lime-hwd-ground-routing/Makefile
@@ -21,6 +21,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   URL:=http://libremesh.org/projects/libremesh/wiki/Ground_routing
   DEPENDS:=+lime-system +lua +libuci-lua
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-hwd-openwrt-wan/Makefile
+++ b/packages/lime-hwd-openwrt-wan/Makefile
@@ -21,6 +21,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   URL:=http://libremesh.org
   DEPENDS:=+lime-system +lua +libuci-lua +lime-proto-wan
+  PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/lime-hwd-usbradio/Makefile
+++ b/packages/lime-hwd-usbradio/Makefile
@@ -21,6 +21,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   URL:=http://libremesh.org
   DEPENDS:=+lime-system +lua +libuci-lua
+  PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/lime-map-agent/Makefile
+++ b/packages/lime-map-agent/Makefile
@@ -23,6 +23,7 @@ define Package/$(PKG_NAME)
 	URL:=http://libremesh.org
 	DEPENDS:=+libremap-agent +luci-lib-libremap-location +luci-lib-libremap-system +luci-lib-libremap-wireless \
 		+PACKAGE_lime-proto-bmx6:luci-lib-libremap-bmx6 +luci-app-lime-location
+	PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-proto-anygw/Makefile
+++ b/packages/lime-proto-anygw/Makefile
@@ -23,6 +23,7 @@ define Package/$(PKG_NAME)
   URL:=http://libremesh.org
   DEPENDS:=+kmod-ebtables +ebtables +lime-system +lua +libuci-lua +kmod-macvlan \
 	+dnsmasq-lease-share +dnsmasq-dhcpv6 @(!PACKAGE_dnsmasq)
+  PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/lime-proto-babeld/Makefile
+++ b/packages/lime-proto-babeld/Makefile
@@ -23,6 +23,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libre-mesh.org
   DEPENDS:=+babeld +lime-system
+  PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/lime-proto-batadv/Makefile
+++ b/packages/lime-proto-batadv/Makefile
@@ -22,6 +22,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
   DEPENDS:=+lime-system +lua +libuci-lua +kmod-batman-adv +kmod-dummy
+  PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/lime-proto-bgp/Makefile
+++ b/packages/lime-proto-bgp/Makefile
@@ -22,6 +22,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Gioacchino Mazzurco <gio@diveni.re>
   URL:=http://libremesh.org
   DEPENDS:=+bird4 +bird6 +lime-system +lua
+  PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/lime-proto-bmx6/Makefile
+++ b/packages/lime-proto-bmx6/Makefile
@@ -23,6 +23,7 @@ define Package/$(PKG_NAME)
   URL:=http://libremesh.org
   DEPENDS:=+bmx6 +bmx6-json +bmx6-sms +bmx6-table +bmx6-uci-config +!PACKAGE_firewall:iptables \
   +lime-system +lua +libuci-lua +PACKAGE_lime-proto-batadv:kmod-ebtables-ipv6
+  PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/lime-proto-bmx7/Makefile
+++ b/packages/lime-proto-bmx7/Makefile
@@ -23,6 +23,7 @@ define Package/$(PKG_NAME)
   URL:=http://libremesh.org
   DEPENDS:=+bmx7 +bmx7-json +bmx7-sms +bmx7-table +bmx7-uci-config +bmx7-tun \
   +!PACKAGE_firewall:iptables +lime-system +lua +libuci-lua
+  PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/lime-proto-olsr/Makefile
+++ b/packages/lime-proto-olsr/Makefile
@@ -22,6 +22,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=leonaard <leone@inventati.org>
 	URL:=http://libremesh.org
 	DEPENDS:=+lua +libuci-lua +lime-system +olsrd +olsrd-mod-jsoninfo +kmod-ipip
+	PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/lime-proto-olsr2/Makefile
+++ b/packages/lime-proto-olsr2/Makefile
@@ -22,6 +22,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gabriel <gabriel@autistici.org>
 	URL:=http://libremesh.org
 	DEPENDS:=+lua +libuci-lua +lime-system +oonf-olsrd2
+	PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/lime-proto-olsr6/Makefile
+++ b/packages/lime-proto-olsr6/Makefile
@@ -22,6 +22,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=leonaard <leone@inventati.org>
 	URL:=http://libremesh.org
 	DEPENDS:=+lua +libuci-lua +lime-system +olsrd +olsrd-mod-jsoninfo
+	PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/lime-proto-wan/Makefile
+++ b/packages/lime-proto-wan/Makefile
@@ -22,6 +22,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
   DEPENDS:=+lime-system +lua +libuci-lua +kmod-ipt-nat +!PACKAGE_firewall:iptables
+  PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/lime-smart-wifi/Makefile
+++ b/packages/lime-smart-wifi/Makefile
@@ -13,6 +13,7 @@ define Package/$(PKG_NAME)
  MAINTAINER:=Paul Spooren <paul@spooren.de>
  URL:=http://libremesh.org
  DEPENDS:=+lime-system
+ PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/lime-system/Makefile
+++ b/packages/lime-system/Makefile
@@ -28,6 +28,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
   DEPENDS:=+libiwinfo-lua +lua +libuci-lua +luci-lib-ip +luci-lib-nixio
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/luci-app-batman-adv/Makefile
+++ b/packages/luci-app-batman-adv/Makefile
@@ -21,6 +21,7 @@ define Package/$(PKG_NAME)
   SUBMENU:=3. Applications
   TITLE:=B.A.T.M.A.N.-Adv status module
   DEPENDS:= +libc +kmod-batman-adv +luci-lib-jquery-1-4 +luci-lib-dracula +batctl
+  PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/luci-app-openairview/Makefile
+++ b/packages/luci-app-openairview/Makefile
@@ -21,6 +21,7 @@ define Package/$(PKG_NAME)
   SUBMENU:=3. Applications
   TITLE:=Visualize the spectrum and wifi neighbours
   DEPENDS:= +libc +fft-eval +luci-lib-jquery-1-4 +luci-lib-jquery-flot-0-8 +luci-lib-json
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/luci-lib-jquery-flot/Makefile
+++ b/packages/luci-lib-jquery-flot/Makefile
@@ -19,6 +19,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
   SUBMENU:=8. Libraries
   TITLE:=jQuery library - Flot chart plotting
+  PKGARCH:=all
 endef
 
 define Build/Compile

--- a/packages/luci-mod-status/Makefile
+++ b/packages/luci-mod-status/Makefile
@@ -20,6 +20,7 @@ define Package/$(PKG_NAME)
   TITLE:=LuCI status - some read-only info without login
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
   DEPENDS:= +uhttpd +luci-base +libiwinfo-lua +luci-lib-jquery-1-4 +luci-lib-jquery-flot-0-8 +luci-lib-json
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/safe-reboot/Makefile
+++ b/packages/safe-reboot/Makefile
@@ -18,6 +18,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=Utilities
   TITLE:=$(PKG_NAME) falls back to a last-known-good config after an ill-fated reboot.
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/smonit/Makefile
+++ b/packages/smonit/Makefile
@@ -18,6 +18,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Pau Escrich <p4u@dabax.et>
   URL:=http://libremesh.org
   DEPENDS:=
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/config

--- a/packages/sprunge/Makefile
+++ b/packages/sprunge/Makefile
@@ -20,6 +20,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=Utilities
   MAINTAINER:=Ilario Gelmetti <ilario@eigenlab.org>
   URL:=http://sprunge.us
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/vale/Makefile
+++ b/packages/vale/Makefile
@@ -18,6 +18,7 @@ define Package/$(PKG_NAME)
  CATEGORY:=Network
  TITLE:=$(PKG_NAME)
  MAINTAINER:=Gui Iribarren <gui@altermundi.net>
+ PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/watchping/Makefile
+++ b/packages/watchping/Makefile
@@ -18,6 +18,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=Utilities
   TITLE:=Ping a host and run customizable actions (hooks) on timeout/recovery.
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
+  PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description


### PR DESCRIPTION
Set PKGARCH to all where possible (only Lua/Bah code). This results in images install able on all devices.

This will dramatically reduce the time to compile all packages.