### PR TITLE
lime-proto-bmx7: use auto rate

### DIFF
--- a/packages/lime-proto-bmx7/src/bmx7.lua
+++ b/packages/lime-proto-bmx7/src/bmx7.lua
@@ -215,14 +215,12 @@ function bmx7.setup_interface(ifname, args)
 	uci:set(bmx7.f, owrtInterfaceName, "dev")
 	uci:set(bmx7.f, owrtInterfaceName, "dev", linux802adIfName)
 
-	-- BEGIN [Workaround issue 40]
 	if ifname:match("^wlan%d+") then
-		local rateMax = config.get("network", "bmx7_wifi_rate_max", 54000000)
-		if rateMax then
+		local rateMax = config.get("network", "bmx7_wifi_rate_max", "auto")
+		if rateMax ~= "auto" then
 			uci:set(bmx7.f, owrtInterfaceName, "rateMax", rateMax)
 		end
 	end
-	--- END [Workaround issue 40]
 
 	uci:save(bmx7.f)
 end

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -38,7 +38,7 @@ config lime network
 	option bmx7_publish_ownip false
 	option bmx7_over_batman false
 	option bmx7_pref_gw none
-	option bmx7_wifi_rate_max 54000000
+	option bmx7_wifi_rate_max 'auto'
 	option anygw_mac "aa:aa:aa:%N1:%N2:aa"
 	option use_odhcpd false
 


### PR DESCRIPTION
bmx7 estimates the maxRate of wifi interfaces by iteself, thereby don't
set a static value of 54M in times of AC mesh connections

Signed-off-by: Paul Spooren <mail@aparcar.org>