### PR TITLE
lime-system: use lime-profile if available

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/config.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/config.lua
@@ -26,11 +26,17 @@ function config.sanitize()
 	end
 end
 
+function config.defaults_file()
+    if os.rename("/etc/config/lime-profile", "/etc/config/lime-profile") then
+        return "lime-profile"
+    else
+        return "lime-defaults"
+
 function config.get(sectionname, option, fallback)
 	local limeconf = config.uci:get("lime", sectionname, option)
 	if limeconf then return limeconf end
 
-	local defcnf = config.uci:get("lime-defaults", sectionname, option)
+	local defcnf = config.uci:get(config.defaults_file(), sectionname, option)
 	if ( defcnf ~= nil ) then
 		config.set(sectionname, option, defcnf)
 	elseif ( fallback ~= nil ) then
@@ -53,7 +59,7 @@ end
 
 function config.get_all(sectionname)
 	local lime_section = config.uci:get_all("lime", sectionname)
-	local lime_def_section = config.uci:get_all("lime-defaults", sectionname)
+	local lime_def_section = config.uci:get_all(config.defaults_file(), sectionname)
 
 	if lime_section or lime_def_section then
 		local ret = lime_section or {}


### PR DESCRIPTION
Network profiles are somewhat popular, but cause problems when they're
used as packages, as lime-system and the packaged profile both supply
the file `/etc/config/lime-defaults`. A solution is to introduce
`lime-profile` which is then used instead of lime-defaults.

This has the advantage that new releases with different defaults don't
break compatiblity.

Signed-off-by: Paul Spooren <mail@aparcar.org>