### PR TITLE
Indicate to which kind of radios we want to apply wireless modes

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
@@ -95,6 +95,7 @@ function wireless.configure()
 		local ignoredSuffix
 		local distance
 		local htmode
+		local modeSuffix
 		if modes[1] ~= "manual" then
 			if wireless.is5Ghz(radioName) then
 				freqSuffix = "_5ghz"
@@ -131,6 +132,8 @@ function wireless.configure()
 
 			for _,modeName in pairs(modes) do
 				local args = {}
+				modeSuffix = utils.split(modeName, "_")[2]	
+				modeName = utils.split(modeName, "_")[1]	
 				local mode = require("lime.mode."..modeName)
 
 				for key,value in pairs(options) do
@@ -154,7 +157,10 @@ function wireless.configure()
 					end
 				end
 
-				mode.setup_radio(radio, args)
+				if ( modeSuffix == nil ) or ("_"..modeSuffix == freqSuffix) then
+					mode.setup_radio(radio, args)
+				end
+
 			end
 		end
 	end


### PR DESCRIPTION
These modifications allow to indicate to which radios we want to apply the modes.
For example if I want to open an ap but only in the 2ghz radio the configuration in lime-config is:

```
config lime 'wifi'
	list modes 'ap_2ghz'
	list modes 'adhoc'
	...
```
In the same way it could indicate that I only want to raise the mesh in 5ghz

```
config lime 'wifi'
	list modes 'ap_2ghz'
	list modes 'adhoc_5ghz'
	...
```
If no particular frequency is indicated, the mode apply to all radios.