### PR TITLE
Fix sprunge evaluating commands with redirects

### DIFF
--- a/packages/sprunge/src/sprunge.sh
+++ b/packages/sprunge/src/sprunge.sh
@@ -8,23 +8,41 @@ COMMAND="$0 $@"
 
 usage()
 {
-	echo -e "sprunge: command line paste bin\n\nSuggested ways of using $0 are mainly 4\nyourCommand arg1 arg2 | $0\n$0 [ -c \"yourCommand arg1 arg2\" ]\n$0 [ -f file ]\n$0; then EOF using Ctrl+D" 1>&2 ; exit 0
+	echo "\
+sprunge: Command line pastebin
+
+Suggested ways of using $0 are mainly 4:
+yourCommand arg1 arg2 | $0
+$0 -c \"yourCommand arg1 arg2\"
+$0 -f file
+$0; then EOF using Ctrl+D" 1>&2
+
+	exit 0
 }
 
 case "${1}" in
 	"-h") usage ;;
 	"--help") usage ;;
-	"-c") echo "${COMMAND}" > "${TEMP_FILE}" ; ${2} | tee -a "${TEMP_FILE}" ;;
-	"-f") echo "${COMMAND}" > "${TEMP_FILE}" ; cat "${2}" | tee -a "${TEMP_FILE}" ;;
+	"-c")
+		echo "${COMMAND}" > "${TEMP_FILE}"
+		eval "${2}" | tee -a "${TEMP_FILE}"
+		;;
+	"-f")
+		echo "${COMMAND}" > "${TEMP_FILE}"
+		cat "${2}" | tee -a "${TEMP_FILE}"
+		;;
 	*) tee <&0 "${TEMP_FILE}" ;;
 esac
 
-cat "${TEMP_FILE}" | hexdump -v -e '/1 "%02x"' | sed 's/\(..\)/%\1/g' > "${TEMP_FILE_ENCODED}"
+cat "${TEMP_FILE}" | hexdump -v -e '/1 "%02x"' \
+	| sed 's/\(..\)/%\1/g' > "${TEMP_FILE_ENCODED}"
 
 echo "POST / HTTP/1.0
 Host: ${SPRUNGE_HOST}
 Content-Length: $(( $(cat ${TEMP_FILE_ENCODED} | wc -m) + 8 ))
 
-sprunge=$(cat ${TEMP_FILE_ENCODED})" | nc "${SPRUNGE_HOST}" 80 | grep "${SPRUNGE_HOST}" 1>&2
+sprunge=$(cat ${TEMP_FILE_ENCODED})" \
+	| nc "${SPRUNGE_HOST}" 80 \
+	| grep "${SPRUNGE_HOST}" 1>&2
 
 rm -f "${TEMP_FILE}" "${TEMP_FILE_ENCODED}"


### PR DESCRIPTION
evaluating the command directly as ${2} didn't work well with commands
  that included redirects, use eval "${2}" for correct behaviour
Improve readability by breaking lines longer then 80 chars