### PR TITLE
lime.network pass down to lime.proto specific section data

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -265,6 +265,7 @@ function network.configure()
 		if owrtIf then
 			deviceProtos = owrtIf["protocols"] or {"manual"}
 			flags["specific"] = true
+			flags["_specific_section"] = owrtIf
 		end
 
 		for _,protoParams in pairs(deviceProtos) do


### PR DESCRIPTION
this way lime.proto can reliably access to specific section data when used in a specific section