### PR TITLE
Added warning for invalid IPv4 settings

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -87,6 +87,7 @@ function network.primary_address(offset)
 	if invalid then
 		ipv4_template = mc:maxhost()
 		ipv4_template:prefix(tonumber(ipv4_maskbits))
+		print("INVALID IPv4 DETECTED, CHECK YOUR SETTINGS. USING " ..tostring(ipv4_template))
 	end
 
 	ipv6_template:prefix(tonumber(ipv6_maskbits))

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -79,15 +79,16 @@ function network.primary_address(offset)
 	ipv4_template:prefix(tonumber(ipv4_maskbits))
 	local mc = ipv4_template
 	--! Generated address is network address like 192.0.2.0/24 ?
-	local invalid = ipv4_template:equal(mc:network())
+	local invalid = ipv4_template:equal(mc:network()) and "NETWORK"
 	--! Generated address is the one reserved for anygw like 192.0.2.1/24 ?
-	invalid = invalid or ipv4_template:equal(mc:minhost())
+	invalid = invalid or ipv4_template:equal(mc:minhost()) and "ANYGW"
 	--! Generated address is the broadcast address like 192.0.2.255/24 ?
-	invalid = invalid or ipv4_template:equal(mc:broadcast())
+	invalid = invalid or ipv4_template:equal(mc:broadcast()) and "BROADCAST"
 	if invalid then
 		ipv4_template = mc:maxhost()
 		ipv4_template:prefix(tonumber(ipv4_maskbits))
-		print("INVALID IPv4 DETECTED, CHECK YOUR SETTINGS. USING " ..tostring(ipv4_template))
+		print("INVALID main_ipv4_address " ..tostring(mc).. " IDENTICAL TO RESERVED "
+			..invalid.. " ADDRESS. USING " ..tostring(ipv4_template))
 	end
 
 	ipv6_template:prefix(tonumber(ipv6_maskbits))


### PR DESCRIPTION
In case an invalid IPv4 was set in /etc/config/lime, network.lua silently sets a fallback one.
The users can have troubles in understanding what happened ([example](https://lists.libremesh.org/pipermail/lime-users/2018-November/001333.html)), this could be mitigated by a warning message.
