### PR TITLE
Wifi client mode in backbone via BMX6

### DIFF
--- a/packages/lime-docs/files/lime-example
+++ b/packages/lime-docs/files/lime-example
@@ -113,6 +113,7 @@ option wifi radio4 # you should ensure that the chosen radio name exists, for ex
 	option client_ssid 'SomeWiFiNetwork'
 	option client_key 'SomeWPApskPassword'
 	option client_encryption 'psk' # psk for WPA or psk2 for WPA2
+	option distance 300 # maximum distance to AP, heavily affects performances
 
 config net wirelessclientWAN
 	option linux_name 'wlan0-sta' # the client interface name could be named differently, like wlan1-sta
@@ -123,6 +124,7 @@ option wifi radio5 # you should ensure that the chosen radio name exists, for ex
 	list modes 'client'
 	option channel_2ghz 'auto'
 	option client_ssid 'LibreMesh.org'
+	option distance 1000 # maximum distance to AP, heavily affects performances
 
 config net wirelessclientBackbone
 	option linux_name 'wlan0-sta' # the client interface name could be named differently, like wlan1-sta

--- a/packages/lime-docs/files/lime-example
+++ b/packages/lime-docs/files/lime-example
@@ -106,7 +106,7 @@ config wifi radio3 # you should ensure that the chosen radio name exists, for ex
 # you need two pieces of configuration the wifi specific configuration and the
 # network specific one like in the following example.
 
-## set radio4 as client of access point, both the following "wifi" and "net" sections are required
+## set radio4 as client of access point for internet access, both the following "wifi" and "net" sections are required
 option wifi radio4 # you should ensure that the chosen radio name exists, for example with "wifi status" command
 	list modes 'client'
 	option channel_2ghz 'auto'
@@ -114,9 +114,20 @@ option wifi radio4 # you should ensure that the chosen radio name exists, for ex
 	option client_key 'SomeWPApskPassword'
 	option client_encryption 'psk' # psk for WPA or psk2 for WPA2
 
-config net wirelessclient
+config net wirelessclientWAN
 	option linux_name 'wlan0-sta' # the client interface name could be named differently, like wlan1-sta
-	list protocols 'wan' # use wan to get Internet connectivity via DHCP, lan is not supported yet
+	list protocols 'wan' # use wan to get Internet connectivity via DHCP
+
+## set radio5 as client of an access point part of the LibreMesh network, both the following "wifi" and "net" sections are required
+option wifi radio5 # you should ensure that the chosen radio name exists, for example with "wifi status" command
+	list modes 'client'
+	option channel_2ghz 'auto'
+	option client_ssid 'LibreMesh.org'
+
+config net wirelessclientBackbone
+	option linux_name 'wlan0-sta' # the client interface name could be named differently, like wlan1-sta
+	list protocols 'client' # needed for setting up the new interface
+	list protocols 'bmx6:0' # use BMX6 routing on client interface. The :0 is needed for disabling the VLAN, as the AP usually does not have VLAN. In case VLAN is needed, it has to be set also as specific AP configuration, not implemented. LAN is not supported by wireless drivers. BATMAN-adv would need specific AP configuration, not implemented. Having both BMX6 and BATMAN-adv is hindered by the fact that BMX6 sets the proto of the interface as static.
 
 ### Network interface specific options ( override general option )
 ### Available protocols: bmx6, bmx7, batadv, olsr, olsr6, olsr2, bgp, wan, lan, manual, static

--- a/packages/lime-system/files/usr/lib/lua/lime/proto/client.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/proto/client.lua
@@ -1,0 +1,31 @@
+#!/usr/bin/lua
+
+local client_mode = require("lime.mode.client")
+
+local client = {}
+
+client.configured = false
+
+function client.configure(args)
+	client.configured = true
+end
+
+function client.setup_interface(ifname, args)
+	if ifname:match("^wlan%d+."..client_mode.wifi_mode) then
+		local libuci = require "uci"
+		local uci = libuci:cursor()
+
+		--! sanitize passed ifname for constructing uci section name
+		--! because only alphanumeric and underscores are allowed
+		local networkInterfaceName = network.limeIfNamePrefix..ifname:gsub("[^%w_]", "_")
+
+		uci:set("network", networkInterfaceName, "interface")
+		uci:set("network", networkInterfaceName, "proto", "none")
+		uci:set("network", networkInterfaceName, "mtu", "1536")
+		uci:set("network", networkInterfaceName, "auto", "1")
+
+		uci:save("network")
+	end
+end
+
+return client


### PR DESCRIPTION
For the original discussion see #415, of which this PR is a partial solution.
Partial as it allows to use BMX6 on client-AP links, but does not allow yet BATMAN-adv and even less BATMAN-adv+BMX6.

TL;DR
--------
As including client interfaces in bridges is not possible (see #415 and #127), we can include them between the interfaces used by the routing protocols and obtain the same result. This can be done via specific interface configuration.

BMX6 on client-AP link
-----------------------------
This PR allows this. Adding a `proto/client.lua` (I just copied `proto/ieee80211s.lua` and replaced "ieee80211s" with "client") was needed in order to set up the interface. For running this new proto, a `list protocols 'client'` has to be included in the specific interface configuration. On the AP side the wlanX-ap interface is included in br-lan, which is used by BMX6. As the wlanX-ap interface does not have a VLAN ID, we have to explicitly set 0 as the VLAN ID also on the client side, with a configuration resulting in:

```
option wifi radio0
	list modes 'client'
	option channel_2ghz 'auto'
	option client_ssid 'LibreMesh.org'
	option distance 1000
config net wirelessclientBackbone
	option linux_name 'wlan0-sta'
	list protocols 'client'
	list protocols 'bmx6:0'
```

In case VLAN is needed, it has to be set also as specific AP configuration, which is not implemented yet. 

BATMAN-adv on client-AP link
--------------------------------------
BATMAN-adv would need specific AP configuration as currently is not included in bat0 (decided in 2014 213efd0). Specific AP configuration is not implemented yet.

BATMAN-adv+BMX6 on client-AP link
-----------------------------------------------
Additionally to what just exposed, having both BMX6 and BATMAN-adv is hindered by the fact that BMX6 sets the `proto` field of the interface as `static`, while BATMAN-adv requires it to be set as `batadv` otherwise the interface does not get included in bat0. This behaviour of BMX6 comes from a 2014 workaround 83e5a2d trying to fix [this issue](http://old.libremesh.org/issues/38), which wouldn't be present if the proto is set by BATMAN-adv.




The problem of this is that it does not setup the sta interface, so the resulting /etc/config/network is broken.
We need a proto/client.lua (copying the proto/ieee80211s and replacing all ieee80211s occurrences with client works) and then, important, the specific configuration has to include a list protocols 'client' in order to activate proto/client.lua


