### PR TITLE
Static proto: add setting for gateway and clean IPv6 setting

### DIFF
--- a/packages/lime-docs/files/lime-example
+++ b/packages/lime-docs/files/lime-example
@@ -126,7 +126,11 @@ config net wirelessclient
 #config net port5					# Do not put any "." in the section name
 #	option linux_name 'eth1.5'			# Put here the actual name of the interface
 #	list protocols 'wan'				# Some of these protocols require the relative package "lime-proto-..."
-#	list protocols 'static:172.23.0.1/24'		# Set up a static IP (both IPv4 and IPv6 supported, specify twice one per IP type)
+#	list protocols 'static:172.23.0.1/24'		# Set up a static IP (both IPv4 and IPv6 supported)
+#	option static_ipv4 '192.168.1.2/24'
+#	option static_gateway_ipv4 '192.168.1.1'
+#	option static_ipv6 '2a00:1508:0a00::1234/64'
+#	option static_gateway_ipv6 'fe80::1'
 
 
 ### Ground routing specific sections

--- a/packages/lime-docs/files/lime-example
+++ b/packages/lime-docs/files/lime-example
@@ -126,7 +126,7 @@ config net wirelessclient
 #config net port5					# Do not put any "." in the section name
 #	option linux_name 'eth1.5'			# Put here the actual name of the interface
 #	list protocols 'wan'				# Some of these protocols require the relative package "lime-proto-..."
-#	list protocols 'static:172.23.0.1/24'		# Set up a static IP (both IPv4 and IPv6 supported)
+#	list protocols 'static'				# Set up a static IP (both IPv4 and IPv6 supported)
 #	option static_ipv4 '192.168.1.2/24'
 #	option static_gateway_ipv4 '192.168.1.1'
 #	option static_ipv6 '2a00:1508:0a00::1234/64'

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -305,10 +305,14 @@ function network.createStaticIface(linuxBaseIfname, openwrtNameSuffix, ipAddr, g
 		local mask = addr:mask():string()
 		uci:set("network", owrtInterfaceName, "ipaddr", host)
 		uci:set("network", owrtInterfaceName, "netmask", mask)
-		uci:set("network", owrtInterfaceName, "gateway", gwAddr)
+		if gwAddr then
+			uci:set("network", owrtInterfaceName, "gateway", gwAddr)
+		end
 	elseif addr:is6() then
 		uci:set("network", owrtInterfaceName, "ip6addr", addr:string())
-		uci:set("network", owrtInterfaceName, "ip6gw", gwAddr)
+		if gwAddr then
+			uci:set("network", owrtInterfaceName, "ip6gw", gwAddr)
+		end
 	else
 		uci:delete("network", owrtInterfaceName, "interface")
 	end

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -288,7 +288,7 @@ end
 -- Creates a network Interface with static protocol
 -- ipAddr can be IPv4 or IPv6
 -- the function can be called twice to set both IPv4 and IPv6
-function network.createStaticIface(linuxBaseIfname, openwrtNameSuffix, ipAddr)
+function network.createStaticIface(linuxBaseIfname, openwrtNameSuffix, ipAddr, gwAddr)
 	local openwrtNameSuffix = openwrtNameSuffix or ""
 	local owrtInterfaceName = network.sanitizeIfaceName(linuxBaseIfname) .. openwrtNameSuffix
 	local uci = libuci:cursor()

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -305,8 +305,10 @@ function network.createStaticIface(linuxBaseIfname, openwrtNameSuffix, ipAddr, g
 		local mask = addr:mask():string()
 		uci:set("network", owrtInterfaceName, "ipaddr", host)
 		uci:set("network", owrtInterfaceName, "netmask", mask)
+		uci:set("network", owrtInterfaceName, "gateway", gwAddr:string())
 	elseif addr:is6() then
 		uci:set("network", owrtInterfaceName, "ip6addr", addr:string())
+		uci:set("network", owrtInterfaceName, "ip6gw", gwAddr:string())
 	else
 		uci:delete("network", owrtInterfaceName, "interface")
 	end

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -305,10 +305,10 @@ function network.createStaticIface(linuxBaseIfname, openwrtNameSuffix, ipAddr, g
 		local mask = addr:mask():string()
 		uci:set("network", owrtInterfaceName, "ipaddr", host)
 		uci:set("network", owrtInterfaceName, "netmask", mask)
-		uci:set("network", owrtInterfaceName, "gateway", gwAddr:string())
+		uci:set("network", owrtInterfaceName, "gateway", gwAddr)
 	elseif addr:is6() then
 		uci:set("network", owrtInterfaceName, "ip6addr", addr:string())
-		uci:set("network", owrtInterfaceName, "ip6gw", gwAddr:string())
+		uci:set("network", owrtInterfaceName, "ip6gw", gwAddr)
 	else
 		uci:delete("network", owrtInterfaceName, "interface")
 	end

--- a/packages/lime-system/files/usr/lib/lua/lime/proto/static.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/proto/static.lua
@@ -15,11 +15,6 @@ end
 
 function static.setup_interface(ifname, args)
 	if not args["specific"] then return end
-	-- kept for back compatibility
-	if #args > 1 then
-		local ipaddr = args[2]
-		network.createStaticIface(ifname, '_static', ipaddr)
-	end
 	local table = args._specific_section
 	local ipAddrIPv4 = table["static_ipv4"]
 	if ipAddrIPv4 then

--- a/packages/lime-system/files/usr/lib/lua/lime/proto/static.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/proto/static.lua
@@ -15,7 +15,6 @@ end
 
 function static.setup_interface(ifname, args)
 	if not args["specific"] then return end
-	local uci = libuci:cursor()
 	-- kept for back compatibility
 	if #args > 1 then
 		local ipaddr = args[2]

--- a/packages/lime-system/files/usr/lib/lua/lime/proto/static.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/proto/static.lua
@@ -16,11 +16,21 @@ end
 function static.setup_interface(ifname, args)
 	if not args["specific"] then return end
 	local uci = libuci:cursor()
+	-- kept for back compatibility
 	if #args > 1 then
 		local ipaddr = args[2]
-		-- workaround to support ipv6
-		for i,v in ipairs(args) do if i > 2 then ipaddr=ipaddr..':'..v end end
 		network.createStaticIface(ifname, '_static', ipaddr)
+	end
+	local table = args._specific_section
+	local ipAddrIPv4 = table["static_ipv4"]
+	if ipAddrIPv4 then
+		local gwAddrIPv4 = table["static_gateway_ipv4"]
+		network.createStaticIface(ifname, '_static', ipAddrIPv4, gwAddrIPv4)
+	end
+	local ipAddrIPv6 = table["static_ipv6"]
+	if ipAddrIPv6 then
+		local gwAddrIPv6 = table["static_gateway_ipv6"]
+		network.createStaticIface(ifname, '_static', ipAddrIPv6, gwAddrIPv6)
 	end
 end
 


### PR DESCRIPTION
Depends on #420 
This should fix #409 and #408 
Changes the settings of a static IP from
```
	list protocols 'static:1.2.3.4/24'
	list protocols 'static:1:2:3:4:5:6:7:8/64'
```
to
```
	list protocols 'static'
	option static_ipv4 '192.168.1.2/24'
	option static_gateway_ipv4 '192.168.1.1'
	option static_ipv6 '2a00:1508:0a00::1234/64'
	option static_gateway_ipv6 'fe80::1'
```
the advantages are: possibility to set a gateway, support for any IPv6 format (compressed with :: or not).