### PR TITLE
Introduce bmx7-auto-gw-bw-mode package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,10 @@ deploy:
       branch: master
   - provider: script
     script:
-    - rsync --delete-after -L -r -v -e "sshpass -p $SSH_PASS ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $CI_PORT"
-          "/output/" "${CI_USER}@${CI_SERVER}:${CI_STORE_PATH}/$STORE_PATH/branches/$TRAVIS_BRANCH/"
+    - rsync --rsync-path="mkdir -p ${CI_STORE_PATH}/$STORE_PATH/branches/$TRAVIS_BRANCH/ && rsync"
+        --delete-after -L -r -v
+        -e "sshpass -p $SSH_PASS ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $CI_PORT"
+        "/output/" "${CI_USER}@${CI_SERVER}:${CI_STORE_PATH}/$STORE_PATH/branches/$TRAVIS_BRANCH/"
     on:
       all_branches: true
       condition: $TRAVIS_BRANCH != master

--- a/libremesh.sdk.config
+++ b/libremesh.sdk.config
@@ -29,6 +29,7 @@ CONFIG_PACKAGE_lime-proto-wan=m
 CONFIG_PACKAGE_lime-system=m
 CONFIG_PACKAGE_lime-webui=m
 CONFIG_PACKAGE_bmx7-auto-gw-mode=m
+CONFIG_PACKAGE_bmx7-auto-gw-bw-mode=m
 CONFIG_LIMEWEBUI_ES=y
 CONFIG_PACKAGE_lime-app=m
 CONFIG_PACKAGE_luci-app-bmx7=m

--- a/packages/bmx7-auto-gw-bw-mode/Makefile
+++ b/packages/bmx7-auto-gw-bw-mode/Makefile
@@ -1,0 +1,42 @@
+# 
+# Copyright (C) 2018 Pau Escrich
+#
+# This is free software, licensed under the GNU General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bmx7-auto-gw-bw-mode
+PKG_VERSION=0.1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  CATEGORY:=LiMe
+  Section:=net
+  TITLE:= bmx7 auto Internet gateway bandwidth module
+  MAINTAINER:=Pau Escrich <p4u@dabax.et>
+  URL:=http://libremesh.org
+  DEPENDS:=+bmx7-auto-gw-mode +pv
+  PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/config
+  select CONFIG_BUSYBOX_CONFIG_CROND
+  select CONFIG_BUSYBOX_CONFIG_CRONTAB
+endef
+
+
+define Package/$(PKG_NAME)/description
+  	Watchping hooks to set bmx7 Internet bandwidth announcement
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/bmx7-auto-gw-bw-mode/files/etc/init.d/bmx7-auto-bw
+++ b/packages/bmx7-auto-gw-bw-mode/files/etc/init.d/bmx7-auto-bw
@@ -1,0 +1,29 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+BIN="/usr/sbin/bmx7-auto-bw-test"
+CRONTAB="/etc/crontabs/root"
+SAVE="/tmp/bmx7-internet-bw.log"
+
+start() {
+  echo "Ensuring bmx7-auto-bw-test is run by cron"
+  if ! ( grep -q "$BIN" "$CRONTAB" 2>/dev/null ) ; then
+	# run twice and random sleep for better entropy
+    local rnd=$(awk 'BEGIN{srand();print int(rand()*3)}')
+	sleep $rnd
+    rnd=$(awk 'BEGIN{srand();print int(rand()*60)}')
+    echo "$rnd */6 * * * SAVE=$SAVE $BIN" >> "$CRONTAB"
+    /etc/init.d/cron enable
+    /etc/init.d/cron restart
+  fi
+}
+
+stop() {
+  echo "Removing bmx7-auto-bw-test from crontab"
+  sed "\|$BIN|d" -i "$CRONTAB"
+  /etc/init.d/cron restart
+}
+
+reload() {
+  $BIN
+}

--- a/packages/bmx7-auto-gw-bw-mode/files/etc/watchping/wan-ok.d/bmx7-gw-bwtest
+++ b/packages/bmx7-auto-gw-bw-mode/files/etc/watchping/wan-ok.d/bmx7-gw-bwtest
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/sbin/bmx7-auto-bw-test

--- a/packages/bmx7-auto-gw-bw-mode/files/usr/sbin/bmx7-auto-bw-test
+++ b/packages/bmx7-auto-gw-bw-mode/files/usr/sbin/bmx7-auto-bw-test
@@ -1,0 +1,42 @@
+#!/bin/sh
+TRIES=3
+
+bw_test() {
+  local bw=""
+  local try=0
+  while [ -z "$bw" -a $try -lt $TRIES ]; do
+    test=$({ wget -T5 -q $1 -O- | pv -n -b -t >/dev/null; } 2>&1)
+    bw=$(echo $test | awk '{printf "%.0f",$NF/$(NF-1)*8}')
+    try=$(($try+1))
+  done
+  echo $bw
+}
+
+random_test() {
+  sv0="http://www.ovh.net/files/10Mio.dat"
+  sv1="http://frf1-speed-02.host.twtelecom.net.prod.hosts.ooklaserver.net:8080/download?size=12000000"
+  sv2="http://speedtest.catnix.cat.prod.hosts.ooklaserver.net:8080/download?size=12000000"
+  sv3="http://cdn.kernel.org/pub/linux/kernel/v4.x/patch-4.9.gz"
+  sv4="http://ubuntu.inode.at/ubuntu/dists/bionic/main/installer-amd64/current/images/hd-media/initrd.gz"
+  sv5="http://ftp.belnet.be/ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/hd-media/initrd.gz"
+  sv6="http://cloudharmony.com/probe/test10mb.jpg"
+  sv7="http://cdn.google.cloudharmony.net/probe/test10mb.jpg"
+  sv8="http://speedtest-lon1.digitalocean.com/10mb.test"
+  sv9="http://aka.azureedge.net/probe/test10mb.jpg"
+  sv10="http://speedtest.serverius.net/files/10mb.bin"
+
+  rnd=$(awk 'BEGIN{srand();print int(rand()*11)}')
+  svid="sv$rnd"
+  sv=$(eval echo \$$svid)
+  logger -t bmx7-auto-gw "Testing bandwidth [$sv]"
+  bw_test "$sv"
+}
+
+cat /var/run/bmx7/json/parameters | jsonfilter -e '@["OPTIONS"][*]' | grep tunIn | grep -q "0.0.0.0" && {
+  bw=$(random_test)
+  [ -n "$bw" -a $bw -gt 1000 ] && {
+    logger -t bmx7-auto-gw "Got bandwidth of $bw bit/s"
+    bmx7 -c tunIn inet4 /b $bw /n 0.0.0.0/0
+    [ -n "$SAVE" ] && echo $(date +"%Y.%m.%d.%H.%M") $bw >> $SAVE
+  }
+}


### PR DESCRIPTION
If the node is an Internet gateway, checks the bandwidth (downloads a
10MB file) and announces it to the mesh. It integrates with watchping
and bmx7-auto-gw-mode.

The check is automatically done via crontab every 6 hours.

Signed-off-by: p4u <p4u@dabax.net>