### PR TITLE
Introduce new package bmx7-mdns

### DIFF
--- a/libremesh.sdk.config
+++ b/libremesh.sdk.config
@@ -30,6 +30,7 @@ CONFIG_PACKAGE_lime-system=m
 CONFIG_PACKAGE_lime-webui=m
 CONFIG_PACKAGE_bmx7-auto-gw-mode=m
 CONFIG_PACKAGE_bmx7-auto-gw-bw-mode=m
+CONFIG_PACKAGE_bmx7-mdns=m
 CONFIG_LIMEWEBUI_ES=y
 CONFIG_PACKAGE_lime-app=m
 CONFIG_PACKAGE_luci-app-bmx7=m

--- a/packages/bmx7-mdns/Makefile
+++ b/packages/bmx7-mdns/Makefile
@@ -1,0 +1,76 @@
+#    Copyright (C) 2018 Pau Escrich
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License along
+#    with this program; if not, write to the Free Software Foundation, Inc.,
+#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#    The full GNU General Public License is included in this distribution in
+#    the file called "COPYING".
+#
+# Contributors:
+#	Pau Escrich <p4u@dabax.net>
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=bmx7-mdns
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  TITLE:=bmx7 distributed DNS system
+  URL:=http://bmx6.net
+  MAINTAINER:=Pau Escrich <p4u@dabax.net>
+  DEPENDS:=+bmx7 +bmx7-sms
+endef
+
+define Package/$(PKG_NAME)/config
+  select CONFIG_BUSYBOX_CONFIG_CROND
+  select CONFIG_BUSYBOX_CONFIG_CRONTAB
+endef
+
+define Package/$(PKG_NAME)/description
+ Distributed DNS system using bmx7 sms plugin
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/etc/config
+	$(CP) ./files/etc/init.d/bmx7-mdns $(1)/etc/init.d/bmx7-mdns
+	chmod 755 $(1)/etc/init.d/bmx7-mdns
+	$(CP) ./files/etc/config/bmx7-mdns $(1)/etc/config/bmx7-mdns
+	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/model/cbi/
+	$(CP) ./files/luci/bmx7-mdns.lua $(1)/usr/lib/lua/luci/model/cbi/bmx7-mdns.lua
+endef
+
+$(eval $(call BuildPackage,bmx7-mdns))

--- a/packages/bmx7-mdns/files/etc/config/bmx7-mdns
+++ b/packages/bmx7-mdns/files/etc/config/bmx7-mdns
@@ -1,0 +1,7 @@
+config bmx7-mdns domains
+	option publish_hostname '1'
+	list domain4 'mesh'
+	list domain6 'mesh6'
+	list host_example 'guifi.mesh6@2a00:1508::5'
+	list host_example 'cfns.mesh@1.1.1.1'
+	list host_example 'myOwnNode'

--- a/packages/bmx7-mdns/files/etc/init.d/bmx7-mdns
+++ b/packages/bmx7-mdns/files/etc/init.d/bmx7-mdns
@@ -1,0 +1,229 @@
+#!/bin/sh /etc/rc.common
+#    Copyright (C) 2018 Pau Escrich <p4u@dabax.net>
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License along
+#    with this program; if not, write to the Free Software Foundation, Inc.,
+#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#    The full GNU General Public License is included in this distribution in
+#    the file called "COPYING".
+
+START=99
+STOP=99
+
+# Configuration variables
+HOSTF="/tmp/mdns.hosts"
+SMSF="/var/run/bmx7/sms/sendSms/mdns"
+SMSTMP="/tmp/sms-mdns.tmp"
+SMSR="/var/run/bmx7/sms/rcvdSms"
+DNSMASQ="/etc/dnsmasq.conf"
+DNSMASQ_PID_DIR="/var/run/dnsmasq/"
+[ ! -f $HOSTF ] && touch $HOSTF
+[ ! -f $SMSF ] && touch $SMSF
+
+DOMAINS4="$(uci -q get bmx7-mdns.domains.domain4)"
+DOMAINS6="$(uci -q get bmx7-mdns.domains.domain6)"
+
+start() {
+	if ! cat /etc/crontabs/root | grep -q mdns; then
+		local rnd=$(awk 'BEGIN{srand();print int(rand()*60)}')
+		echo "$rnd * * * * /etc/init.d/bmx7-mdns reload" >> /etc/crontabs/root
+		/etc/init.d/cron enable
+		/etc/init.d/cron start
+	fi
+	/etc/init.d/bmx7-mdns reload
+}
+
+stop() {
+	sed -i -e '/.*\/etc\/init\.d\/bmx7-mdns reload$/d' /etc/crontabs/root
+	/etc/init.d/cron restart
+	[ -f $SMSF ] && rm -f $SMSF
+}
+
+reload() {
+	init
+	publish_my_domains
+	get_domains
+	finish
+}
+
+refresh() {
+	reload
+}
+
+log() {
+	logger -s -t "bmx7-mdns" $1
+}
+
+error() {
+	log "ERROR $1"
+	exit 1
+}
+
+init() {
+	[ ! -x /etc/init.d/dnsmasq ] && error "dnsmasq not enabled"
+	log "preparing bmx7"
+	bmx7 -c --syncSms mdns || error "cannot enable bmx7 sms"
+
+	cat $DNSMASQ | egrep "^addn-hosts=$HOSTF" -q || {
+		log "adding addn-host entry to dnsmasq config file"
+		echo "addn-hosts=$HOSTF" >> $DNSMASQ
+		log "reloading dnsmasq daemon"
+		/etc/init.d/dnsmasq restart
+	}
+	log "cleaning files"
+	[ -f $HOSTF ] && rm -f $HOSTF
+	touch $HOSTF
+}
+
+check_domain() {
+		local v="$1"
+		local d="$2"
+		local valid=1
+		local domains=""
+
+		[ $v == "4" ] && domains="$DOMAINS4"
+		[ $v == "6" ] && domains="$DOMAINS6"
+		[ $v == "all" ] && domains="$DOMAINS4 $DOMAINS6"
+
+		for D in $domains; do
+			echo "$d" | egrep "\.$D"$ -q && valid=0 && break
+		done
+
+		return $valid
+}
+
+get_my_domains() {
+	local v=${1:-4}
+	local my_domains=""
+	local domains=""
+
+	for d in $(uci -q get bmx7-mdns.domains.host); do
+		echo "$d" | grep -q -v "@" && my_tmp_domains="$d $my_tmp_domains"
+	done
+
+	[ "$v" == "4" ] && domains="$DOMAINS4"
+	[ "$v" == "6" ] && domains="$DOMAINS6"
+
+	for t in $my_tmp_domains; do
+		for d in $domains; do
+			my_domains="$t.$d $my_domains"
+		done
+	done
+	[ "$(uci -q get bmx7-mdns.domains.publish_hostname)" == "1" ] && {
+		for d in $domains; do
+			my_domains="$(cat /proc/sys/kernel/hostname).$d $my_domains"
+		done
+	}
+	echo $my_domains
+}
+
+get_myext_domains() {
+	local ext_domains=""
+	local d ip domain
+	local my_ext_domains=""
+
+	for d in $(uci -q get bmx7-mdns.domains.host); do
+		echo "$d" | grep -q @ && ext_domains="$d $ext_domains"
+	done
+
+	for d in $ext_domains; do
+		ip="$(echo $d | grep @ | cut -d@ -f2)"
+		domain="$(echo $d | grep @ | cut -d@ -f1)"
+		[ -z "$ip" -o -z "$domain" ] && continue
+		my_ext_domains="$ip $domain\n$my_ext_domains"
+	done
+
+	echo -e "$my_ext_domains"
+}
+
+get_my_ip4() {
+	[ -z $IPV4 ] && \
+		bmx7 -cp | grep tun4Address | awk '{print $2}' | awk -F / '{print $1}' || \
+	echo "$IPV4"
+}
+
+get_my_ip6() {
+	[ -z $IPV6 ] && \
+		bmx7 -cp | grep tun6Address | awk '{print $2}' | awk -F / '{print $1}' || \
+	echo "$IPV6"
+}
+
+publish_my_domains() {
+	local d domains ext_domains
+	local ip4="$(get_my_ip4)"
+	local ip6="$(get_my_ip6)"
+
+	echo -n "" > $SMSTMP
+	[ -z "$ip4$ip6" ] && error "cannot get ip address"
+	[ -n "$ip4" ] && {
+		domains="$(get_my_domains 4)"
+		[ -n "$domains" ] && {
+			log "publishing own IPv4 domains: $domains"
+			echo "$ip4 $domains" >> $SMSTMP
+			echo "$ip4 $domains" >> $HOSTF
+		}
+	}
+
+	[ -n "$ip6" ] && {
+		domains="$(get_my_domains 6)"
+		[ -n "$domains" ] && {
+			log "publishing own IPv6 domains: $domains"
+			echo "$ip6 $domains" >> $SMSTMP
+			echo "$ip6 $domains" >> $HOSTF
+		}
+	}
+
+	ext_domains="$(get_myext_domains)"
+	[ -n "$ext_domains" ] && {
+		log "publishing own external domains: $ext_domains"
+		echo -e "$ext_domains" >> $SMSTMP
+		echo -e "$ext_domains" >> $HOSTF
+	}
+
+	sed '/./!d' -i $SMSTMP $HOSTF
+	[ $(md5sum $SMSTMP $SMSF | awk '{print $1}' | uniq | wc -l) -gt 1 ] && cp -f $SMSTMP $SMSF
+}
+
+get_domains() {
+	local f d domline ip line n i
+	ls $SMSR/*:mdns 2>/dev/null >/dev/null && {
+	  # for each received file
+	  for f in $SMSR/*:mdns; do
+			n=$(cat $f | wc -l)
+			# for each line inside the file
+			for i in $(seq $n); do
+				line=$(cat $f | awk "NR==$i")
+				ip="$(echo $line | awk '{print $1}')"
+				[ -z $ip ] && continue
+				domains=""
+				# for each domain (first is IP)
+				for d in $(echo "$line" | awk '{$1=""; print $0}'); do
+					check_domain all $d && domains="$d $domains"
+				done
+
+				[ -n "$domains" ] && echo "$ip $domains" >> $HOSTF
+				log "added remote domains $domains= $ip"
+		  done
+  	done
+
+	  } || log "not published domains found in the network"
+}
+
+finish() {
+	for pidfile in $DNSMASQ_PID_DIR*; do
+		kill -SIGHUP $(cat $pidfile)
+	done
+}
+
+$@

--- a/packages/bmx7-mdns/files/luci/bmx7-mdns.lua
+++ b/packages/bmx7-mdns/files/luci/bmx7-mdns.lua
@@ -1,0 +1,79 @@
+--[[
+    Copyright (C) 2019 Pau Escrich
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    The full GNU General Public License is included in this distribution in
+    the file called "COPYING".
+--]]
+
+require("luci.sys")
+local fs = require "nixio.fs"
+local mdns = Map("bmx7-mdns", "mDNS")
+
+local domains = mdns:section(NamedSection, "domains", "domains", translate("Mesh Domains"))
+domains.addremove = false
+
+local publish_hostname = domains:option(Flag,"publish_hostname",translate("Publish hostname"),
+  translate("Automatically publish own hostname as domain name in the mesh network"))
+publish_hostname.disabled = "0"
+publish_hostname.enabled = "1"
+publish_hostname.rmempty = false
+
+local domains4 = domains:option(DynamicList,"domain4",translate("IPv4 TLD"),
+  translate("IPv4 top level domains managed by mDNS. Other TLDs will be ignored"))
+
+local domains6 = domains:option(DynamicList,"domain6",translate("IPv6 TLD"),
+  translate("IPv6 top level domains managed by mDNS. Other TLDs will be ignored"))
+
+local hosts = domains:option(DynamicList,"host",translate("Own domains"),
+  translate([[Domains and hosts to publish in the mesh network.
+<br>Syntax <b>domain.tld@ip</b> will announce domain attached to specified ip
+<br>Syntax <b>domain.tld</b> (without ip) own node ip will be automatically announed for the domain]]))
+
+local mdns_hosts = fs.readfile("/tmp/mdns.hosts") or ""
+local mdns_hosts_text = [[
+<div class="cbi-section-node">
+  <div class="table" id="mdns_hosts_div">
+   <div class="tr table-titles">
+    <div class="th">Host</div>
+    <div class="th">Announced domains</div>
+   </div>
+]]
+for s in mdns_hosts:gmatch("[^\r\n]+") do
+    local first=1
+    local line=""
+    for word in s:gmatch("%S+") do
+        if first == 1 then
+            first = 0
+            line = '<div class="tr">\n<div class="td">'..word..'</div>\n<div class="td">\n'
+        else
+            line = line..'<a target="_blank" href="http://'..word..'">'..word..'</a>\n'
+        end
+    end
+    mdns_hosts_text=mdns_hosts_text..line.."</div>\n</div>\n"
+end
+mdns_hosts_text=mdns_hosts_text..'</div></div>\n'
+
+h = domains:option(DummyValue, "hosts", translate("mDNS global status"))
+h.rawhtml = true
+h.default = mdns_hosts_text
+h.rmempty = false
+
+function mdns.on_commit(self,map)
+    luci.sys.call('/etc/init.d/bmx7-mdns reload')
+end
+
+return mdns


### PR DESCRIPTION
bmx7 mesh DNS is a tool to provide simple distributed DNS functionality to the mesh network.
Uses bmx7-sms plugin to announce domains and IPs and dnsmasq for local resolve.
TLD are by default ".mesh" and ".mesh6" but can be changed, not matching TLDs are ignored (to avoid poisoning).
Node hostname is automatically announced, but also other domains can be published using syntax name.tld@IP
Comes with a simple LUCI interface to monitor announced domains and add new ones to the mesh network.
It's based on 2013 qmp.cat mDNS for bmx6 code.

Signed-off-by: p4u <p4u@dabax.net>