### PR TITLE
Add ix.io client to sprunge package

### DIFF
--- a/packages/sprunge/Makefile
+++ b/packages/sprunge/Makefile
@@ -15,16 +15,16 @@ PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
 include $(INCLUDE_DIR)/package.mk
 
 define Package/$(PKG_NAME)
-  TITLE:=sprunge.us pastebin
+  TITLE:=sprunge.us and ix.io pastebin
   SECTION:=utils
   CATEGORY:=Utilities
   MAINTAINER:=Ilario Gelmetti <ilario@eigenlab.org>
-  URL:=http://sprunge.us
+  URL:=http://ix.io
   PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description
-	sprunge.us command line pastebin
+	sprunge.us and ix.io command line pastebin
 endef
 
 define Build/Compile
@@ -33,6 +33,7 @@ endef
 define Package/$(PKG_NAME)/install
 	@mkdir -p $(1)/usr/bin/ || true
 	$(INSTALL_BIN) ./src/sprunge.sh $(1)/usr/bin/sprunge
+	$(INSTALL_BIN) ./src/ix.sh $(1)/usr/bin/ix
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/sprunge/src/ix.sh
+++ b/packages/sprunge/src/ix.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+IX_HOST="ix.io"
+
+TEMP_FILE="$(mktemp)"
+TEMP_FILE_ENCODED="$(mktemp)"
+COMMAND="$0 $@"
+
+usage()
+{
+	echo "\
+ix: Command line pastebin
+
+Suggested ways of using $0 are mainly 4:
+yourCommand arg1 arg2 | $0
+$0 -c \"yourCommand arg1 arg2\"
+$0 -f file
+$0; then EOF using Ctrl+D" 1>&2
+
+	exit 0
+}
+
+case "${1}" in
+	"-h") usage ;;
+	"--help") usage ;;
+	"-c")
+		echo "${COMMAND}" > "${TEMP_FILE}"
+		eval "${2}" | tee -a "${TEMP_FILE}"
+		;;
+	"-f")
+		echo "${COMMAND}" > "${TEMP_FILE}"
+		cat "${2}" | tee -a "${TEMP_FILE}"
+		;;
+	*) tee <&0 "${TEMP_FILE}" ;;
+esac
+
+cat "${TEMP_FILE}" | hexdump -v -e '/1 "%02x"' \
+	| sed 's/\(..\)/%\1/g' > "${TEMP_FILE_ENCODED}"
+
+echo -n "POST / HTTP/1.0
+Host: ${IX_HOST}
+Content-Length: $(( $(cat ${TEMP_FILE_ENCODED} | wc -m) + 4 ))
+Content-Type: application/x-www-form-urlencoded
+
+f:1=$(cat ${TEMP_FILE_ENCODED})" \
+	| nc "${IX_HOST}" 80 \
+	| grep "${IX_HOST}" 1>&2
+
+rm -f "${TEMP_FILE}" "${TEMP_FILE_ENCODED}"

--- a/packages/sprunge/src/sprunge.sh
+++ b/packages/sprunge/src/sprunge.sh
@@ -37,9 +37,10 @@ esac
 cat "${TEMP_FILE}" | hexdump -v -e '/1 "%02x"' \
 	| sed 's/\(..\)/%\1/g' > "${TEMP_FILE_ENCODED}"
 
-echo "POST / HTTP/1.0
+echo -n "POST / HTTP/1.0
 Host: ${SPRUNGE_HOST}
 Content-Length: $(( $(cat ${TEMP_FILE_ENCODED} | wc -m) + 8 ))
+Content-Type: application/x-www-form-urlencoded
 
 sprunge=$(cat ${TEMP_FILE_ENCODED})" \
 	| nc "${SPRUNGE_HOST}" 80 \


### PR DESCRIPTION
Waiting for the discussion in #458 to converge, this adds the ix.io client inside the sprunge package, as both sprunge.us and ix.io are very similar and the usage of one or of another usually depends on their websites up or down state.

Please note that the HTTP headers in the ix.sh script are terminated with a \r\n instead of just a \n (this was needed at the moment of writing, otherwise a 400 Bad Request error was received).