### PR TITLE
PKGARCH:=all at lime-basic and luci, bmx7-mdns

### DIFF
--- a/packages/bmx7-mdns/Makefile
+++ b/packages/bmx7-mdns/Makefile
@@ -39,6 +39,7 @@ define Package/$(PKG_NAME)
   TITLE:=bmx7 distributed DNS system
   URL:=http://bmx6.net
   MAINTAINER:=Pau Escrich <p4u@dabax.net>
+  PKGARCH:=all
   DEPENDS:=+bmx7 +bmx7-sms
 endef
 

--- a/packages/lime-basic/Makefile
+++ b/packages/lime-basic/Makefile
@@ -23,6 +23,7 @@ define Package/$(PKG_NAME)
 	SUBMENU:=Collections
 	MAINTAINER:=Pau Escrich <p4u@dabax.net>
 	URL:=http://libremesh.org
+	PKGARCH:=all
 	DEPENDS:=+lime-system +lime-proto-bmx6 +lime-proto-batadv +kmod-ebtables \
 	         +lime-proto-anygw +lime-proto-wan +dnsmasq-lease-share \
 	         +dnsmasq-distributed-hosts +lime-webui \
@@ -37,6 +38,7 @@ define Package/$(PKG_NAME)-no-ui
 	SUBMENU:=Collections
 	MAINTAINER:=Pau Escrich <p4u@dabax.net>
 	URL:=http://libremesh.org
+	PKGARCH:=all
 	DEPENDS:=+lime-system +lime-proto-bmx6 +lime-proto-batadv +kmod-ebtables \
 	         +lime-proto-anygw +lime-proto-wan +dnsmasq-lease-share \
 	         +dnsmasq-distributed-hosts \

--- a/packages/luci-app-lime-location/Makefile
+++ b/packages/luci-app-lime-location/Makefile
@@ -20,6 +20,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=NicoEchaniz <nicoechaniz@altermundi.net>
   SUBMENU:=3. Applications
   TITLE:=luci app to handle LibreMap location
+  PKGARCH:=all
   DEPENDS:= +libc +libremap-agent
 endef
 


### PR DESCRIPTION
else we get this error
Package bmx7-mdns version 0.1-1 has no valid architecture, ignoring.
Package lime-basic-no-ui version 2019-01-31-1548943035 has no valid architecture, ignoring.
Package lime-basic version 2019-01-31-1548943035 has no valid architecture, ignoring.
Package lime-webui version 2019-01-31-1548943035 has no valid architecture, ignoring.