### PR TITLE
Ubus - Spectral scan in lime-openairview

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -20,7 +20,7 @@ define Package/$(PKG_NAME)
 	TITLE:=LimeApp
 	MAINTAINER:=Marcos Gutierrez <gmarcos@altermundi.net>
 	URL:=http://github.com/libremesh/lime-app
-	DEPENDS:=+uhttpd +uhttpd-mod-ubus +ubus-lime-batman-adv +ubus-lime-bmx6 \
+	DEPENDS:=+uhttpd +uhttpd-mod-ubus \
 		+ubus-lime-location +ubus-lime-metrics +ubus-lime-utils \
 		+ubus-lime-openairview +ubus-lime-grondrouting
 	PKGARCH:=all

--- a/packages/ubus-lime-batman-adv/Makefile
+++ b/packages/ubus-lime-batman-adv/Makefile
@@ -13,7 +13,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Marcos Gutierrez <gmarcos87@gmail.com>
   SUBMENU:=3. Applications
   TITLE:=B.A.T.M.A.N.-Adv ubus status module
-  DEPENDS:= +lua +libubox-lua +libubus-lua +kmod-batman-adv +batctl +luci-lib-nixio +lime-system
+  DEPENDS:= +lua +libubox-lua +libubus-lua +luci-lib-nixio +lime-system
   PKGARCH:=all
 endef
 

--- a/packages/ubus-lime-openairview/Makefile
+++ b/packages/ubus-lime-openairview/Makefile
@@ -14,7 +14,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Marcos Gutierrez <gmarcos87@gmail.com>
   SUBMENU:=3. Applications
   TITLE:=Openairview ubus module
-  DEPENDS:= +lua +libubox-lua +libubus-lua +libiwinfo-lua +luci-lib-nixio +luci-lib-json
+  DEPENDS:= +lua +libubox-lua +libubus-lua +libiwinfo-lua +luci-lib-nixio +luci-lib-json +fft-eval
   PKGARCH:=all
 endef
 

--- a/packages/ubus-lime-openairview/Readme.md
+++ b/packages/ubus-lime-openairview/Readme.md
@@ -1,36 +1,38 @@
-
 # Openairview (Align / Spectrun scan) ubus status module
 
-|Path     |Procedure     |Signature     |Description
-|---  |---  |---  |---
-|luci2.openairview |interfaces     |{}     | Get list of adhoc interfaces
-|luci2.openairview |get_stations     |{device:STRING}     | List of stations transmitting on the same frequency as the selected device/interface.
+| Path             | Procedure          | Signature                          | Description                                                                                                                                |
+| ---------------- | ------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| lime-openairview | get_interfaces     | {}                                 | Get list of adhoc interfaces                                                                                                               |
+| lime-openairview | get_stations       | {device:STRING}                    | List of stations transmitting on the same frequency as the selected device/interface.                                                      |
+| lime-openairview | get_iface_stations | {iface:STRING}                     | List of stations attached to the interface.                                                                                                |
+| lime-openairview | get_station_signal | {station_mac:STRING, iface:STRING} | Get the signal level with which an interface sees a particular device                                                                      |
+| lime-openairview | spectral_scan      | {device:STRING, spectrum:STRING}   | Get the fft-eval scan results. specturm can by: 2ghz, 5ghz or current. "current" means scan only the channel on which the interface is set |
 
 ## Examples
 
-### ubus -v list luci2.openairview
+### ubus -v list lime-openairview
+
 If the openairview was never established, return the openairview of the community
 
 ```
-'luci2.openairview' @4bd5f4f5
-  "get_interfaces":{}
-  "get_stations":{"device":"String"}
-  "spectral_scan":{"device":"String","spectrum":"String"}
-
+'lime-openairview' @4bd5f4f5
+	"get_interfaces":{"no_params":"Integer"}
+ "get_stations":{"device":"String"}
+	"get_iface_stations":{"iface":"String"}
+	"get_station_signal":{"station_mac":"String","iface":"String"}
+	"spectral_scan":{"device":"String","spectrum":"String"}
 ```
 
-### ubus call luci2.openairview get_interfaces
+### ubus call lime-openairview get_interfaces
+
 ```json
 {
-  "interfaces": [
-    "wlan1-adhoc",
-    "wlan0-adhoc"
-  ]
+  "interfaces": ["wlan1-adhoc", "wlan0-adhoc"]
 }
-
 ```
 
-### ubus call luci2.openairview get_stations '{"device":"wlan1-adhoc"}'
+### ubus call lime-openairview get_stations '{"device":"wlan1-adhoc"}'
+
 ```json
 {
   "stations": [

--- a/packages/ubus-lime-openairview/files/usr/libexec/rpcd/lime-openairview
+++ b/packages/ubus-lime-openairview/files/usr/libexec/rpcd/lime-openairview
@@ -121,6 +121,82 @@ function get_interfaces(msg)
 	printJson(result)
 end
 
+local function spectral_scan(msg)
+
+	local device = msg.device
+	local spectrum = msg.spectrum
+
+	local result = {
+		spectrum = {}
+	}
+	local fd = assert(io.open("/sys/class/net/" .. device .. "/phy80211/name"))
+    local phy = assert(fd:read("*l"))
+    fd:close()
+
+    local path_ath9k = "/sys/kernel/debug/ieee80211/" .. phy .. "/ath9k/"
+
+    local freqs = { }
+    freqs["2ghz"] = { 2412, 2422, 2432, 2442, 2452, 2462 }
+    freqs["5ghz"] = { } -- scan all possible channels
+
+    if spectrum == "2ghz" or spectrum == "5ghz" then
+        samples = sample_whole_spectrum(device, path_ath9k, freqs[spectrum])
+    elseif spectrum == "current" then
+        samples = sample_current_channel(path_ath9k)
+    end
+
+	samples = json.decode( samples )
+
+	-- Convert values to string (avoid ubus bug)
+	for _, dev in pairs(samples[1].data) do
+		samples[1].data[_][1] = tostring(samples[1].data[_][1])
+		samples[1].data[_][2] = tostring(samples[1].data[_][2])
+	end
+
+	local json_reply = {
+		samples = samples,
+		epoch = os.time()
+	}
+
+    result.spectrum = json_reply
+	printJson(result)
+end
+
+function sample_current_channel(path_ath9k)
+    -- sample current channel only, no freq hopping
+    -- grab only one sample per trigger
+    nixio.fs.writefile(path_ath9k .. "spectral_count", "1")
+    -- empty buffer
+    nixio.fs.readfile(path_ath9k .. "spectral_scan0")
+    -- trigger sampling
+    nixio.fs.writefile(path_ath9k .. "spectral_scan_ctl", "manual")
+    nixio.fs.writefile(path_ath9k .. "spectral_scan_ctl", "trigger")
+	print("fft_eval " .. path_ath9k .. "spectral_scan0")
+    local samples = shell("fft_eval " .. path_ath9k .. "spectral_scan0")
+    nixio.fs.writefile(path_ath9k .. "spectral_scan_ctl", "disable")
+
+    return samples
+end
+
+function sample_whole_spectrum(device, path_ath9k, freqs)
+    -- grab samples over the whole spectrum
+    -- grab only one sample per trigger
+    nixio.fs.writefile(path_ath9k .. "spectral_count", "1")
+    -- empty buffer
+    nixio.fs.readfile(path_ath9k .. "spectral_scan0")
+    -- trigger sampling hopping channels
+    nixio.fs.writefile(path_ath9k .. "spectral_scan_ctl", "chanscan")
+
+    local cmd = "iw dev " .. device .. " scan"
+    if #freqs > 0 then cmd = cmd .. " freq " .. table.concat(freqs, " ") end
+    shell(cmd)
+
+    nixio.fs.writefile(path_ath9k .. "spectral_scan_ctl", "disable")
+    local samples = shell("fft_eval " .. path_ath9k .. "spectral_scan0")
+
+    return samples
+end
+
 local function get_station_signal(msg)
     local iface = msg.iface
     local mac = msg.station_mac
@@ -158,6 +234,7 @@ end
 local methods = {
 	get_stations = { device = 'value' },
 	get_interfaces = { no_params = 0 },
+	spectral_scan = { device = 'value', spectrum = 'value' },
 	get_station_signal = { iface = 'value', station_mac = 'value' },
 	get_iface_stations = { iface = 'value' }
 }
@@ -171,8 +248,9 @@ if arg[1] == 'call' then
     msg = json.decode(msg)
     if       arg[2] == 'get_stations'           then get_stations(msg)
     elseif   arg[2] == 'get_interfaces'         then get_interfaces(msg)
+    elseif   arg[2] == 'spectral_scan'          then spectral_scan(msg)
     elseif   arg[2] == 'get_station_signal'     then get_station_signal(msg)
     elseif   arg[2] == 'get_iface_stations'     then get_iface_stations(msg)
-    else                                        printJson({ error = "Method not found" })
+    else      printJson({ error = "Method not found" })
     end
 end


### PR DESCRIPTION
Expose via ubus the result of the spectrum analysis obtained by fft-eval
### Usage
`ubus call lime-openairview spectral_scan '{"device":"wlan1-adhoc", "spectrum":"5ghz"`

### Output
```
{  
   "spectrum":{  
      "epoch":1550326676,
      "samples":[  
         {  
            "noise":-93,
            "central_freq":5520,
            "rssi":9,
            "data":[  
               [  
                  "5510",
                  "-108.596024"
               ],
               [  
                  "5510.356934",
                  "-106.097244"
               ],
               [  
                  "5510.714355",
                  "-108.596024"
               ],
               [  
                  "5511.071289",
                  "-102.575424"
               ],
               [  
                  "5511.428711",
                  "-100.076645"
               ],
               [  
                  "5511.785645",
                  "-96.554825"
               ],
               [  
                  "5512.143066",
                  "-106.097244"
               ],
               [  
                  "5512.5",
                  "-106.097244"
               ],
               [  
                  "5512.856934",
                  "-96.554825"
               ],
               [  
                  "5513.214355",
                  "-93.529465"
               ],
               [  
                  "5513.571289",
                  "-112.117844"
               ],
               [  
                  "5513.928711",
                  "-97.310593"
               ],
               [  
                  "5514.285645",
                  "-106.097244"
               ],
               [  
                  "5514.643066",
                  "-106.097244"
               ],
               [  
                  "5515",
                  "-118.138443"
               ],
               [  
                  "5515.356934",
                  "-108.596024"
               ],
               [  
                  "5515.714355",
                  "-108.596024"
               ],
               [  
                  "5516.071289",
                  "-112.117844"
               ],
               [  
                  "5516.428711",
                  "-101.236481"
               ],
               [  
                  "5516.785645",
                  "-102.575424"
               ],
               [  
                  "5517.143066",
                  "-104.159042"
               ],
               [  
                  "5517.5",
                  "-106.097244"
               ],
               [  
                  "5517.856934",
                  "-98.138443"
               ],
               [  
                  "5518.214355",
                  "-106.097244"
               ],
               [  
                  "5518.571289",
                  "-106.097244"
               ],
               [  
                  "5518.928711",
                  "-108.596024"
               ],
               [  
                  "5519.285645",
                  "-100.076645"
               ],
               [  
                  "5519.643066",
                  "-102.575424"
               ],
               [  
                  "5520",
                  "-103.331192"
               ],
               [  
                  "5520.356934",
                  "-104.159042"
               ],
               [  
                  "5520.714355",
                  "-106.097244"
               ],
               [  
                  "5521.071289",
                  "-102.575424"
               ],
               [  
                  "5521.428711",
                  "-108.596024"
               ],
               [  
                  "5521.785645",
                  "-112.117844"
               ],
               [  
                  "5522.143066",
                  "-101.236481"
               ],
               [  
                  "5522.5",
                  "-99.053596"
               ],
               [  
                  "5522.856934",
                  "-112.117844"
               ],
               [  
                  "5523.214355",
                  "-99.053596"
               ],
               [  
                  "5523.571289",
                  "-96.554825"
               ],
               [  
                  "5523.928711",
                  "-108.596024"
               ],
               [  
                  "5524.285645",
                  "-96.554825"
               ],
               [  
                  "5524.643066",
                  "-95.859573"
               ],
               [  
                  "5525",
                  "-102.575424"
               ],
               [  
                  "5525.356934",
                  "-108.596024"
               ],
               [  
                  "5525.714355",
                  "-100.076645"
               ],
               [  
                  "5526.071289",
                  "-98.138443"
               ],
               [  
                  "5526.428711",
                  "-112.117844"
               ],
               [  
                  "5526.785645",
                  "-106.097244"
               ],
               [  
                  "5527.143066",
                  "-98.138443"
               ],
               [  
                  "5527.5",
                  "-104.159042"
               ],
               [  
                  "5527.856934",
                  "-104.159042"
               ],
               [  
                  "5528.214355",
                  "-104.159042"
               ],
               [  
                  "5528.571289",
                  "-100.076645"
               ],
               [  
                  "5528.928711",
                  "-108.596024"
               ],
               [  
                  "5529.285645",
                  "-106.097244"
               ],
               [  
                  "5529.643066",
                  "-108.596024"
               ]
            ],
            "tsf":2147483647
         }
      ]
   }
}
```

This pull also includes some small modifications in other ubus-lime-* dependencies that I noticed wrong when trying the software.
