### PR TITLE
ubus-lime-location: remove libremap-agent

### DIFF
--- a/packages/ubus-lime-location/Makefile
+++ b/packages/ubus-lime-location/Makefile
@@ -13,7 +13,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Marcos Gutierrez <gmarcos87@gmail.com>
   SUBMENU:=3. Applications
   TITLE:=Libremap ubus status module
-  DEPENDS:= +lua +libubox-lua +libubus-lua +libuci +libremap-agent
+  DEPENDS:= +lua +libubox-lua +libubus-lua +libuci
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
This causes trouble as libremap-agent seems outdated and is no longer available.