### PR TITLE
Add shared-state to replace alfred

### DIFF
--- a/packages/lime-proto-anygw/Makefile
+++ b/packages/lime-proto-anygw/Makefile
@@ -17,12 +17,13 @@ PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
 include $(INCLUDE_DIR)/package.mk
 
 define Package/$(PKG_NAME)
-  TITLE:=LiMe anygw proto support
-  CATEGORY:=LiMe
-  MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
-  URL:=http://libremesh.org
-  DEPENDS:=+kmod-ebtables +ebtables +lime-system +lua +libuci-lua +kmod-macvlan \
-	+dnsmasq-lease-share +dnsmasq-dhcpv6 @(!PACKAGE_dnsmasq)
+	TITLE:=LiMe anygw proto support
+	CATEGORY:=LiMe
+	MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
+	URL:=http://libremesh.org
+	DEPENDS:=+dnsmasq-dhcpv6 @(!PACKAGE_dnsmasq) +ebtables +libuci-lua \
+		+lime-system +lua +kmod-ebtables +kmod-macvlan \
+		+shared-state +shared-state-dnsmasq_leases
   PKGARCH:=all
 endef
 

--- a/packages/lime-system/files/etc/uci-defaults/90_lime-customize-profile
+++ b/packages/lime-system/files/etc/uci-defaults/90_lime-customize-profile
@@ -4,10 +4,6 @@ cat << 'EOF' >> /etc/profile
 
 # nice coloured prompt
 export PS1='\[\e]0;\u@\h: \w\a\]\[\033[00;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
-
-# mac2bat converts raw MACs to bat-names in piped output (i.e. "iwinfo scan | mac2bat"). bat2mac does the reverse.
-alias mac2bat='sed "$(sed -nr "{s/.*(..:..:..:..:..:..)[[:space:]]+([^[:space:]]+).*/s|\1|\2|Ig;/p}" /etc/bat-hosts)"'
-alias bat2mac='sed "$(sed -nr "{s/.*(..:..:..:..:..:..)[[:space:]]+([^[:space:]]+).*/s|\2|\1|Ig;/p}" /etc/bat-hosts)"'
 EOF
 
 exit 0

--- a/packages/shared-state-bat_hosts/Makefile
+++ b/packages/shared-state-bat_hosts/Makefile
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2019 Gioacchino Mazzurco <gio@altermundi.net>
+#
+# This is free software, licensed under the GNU Affero General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+PKG_NAME:=shared-state-bat_hosts
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+	TITLE:=bat-hosts module for shared-state
+	CATEGORY:=LiMe
+	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
+	URL:=http://libremesh.org
+	DEPENDS:=+@BUSYBOX_CONFIG_CROND \
+		+@BUSYBOX_CONFIG_FEATURE_CROND_SPECIAL_TIMES shared-state
+	PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/description
+	Syncronize bat-hosts beween nodes, provides also mac2bat and bat2mac.
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/shared-state-bat_hosts/Makefile
+++ b/packages/shared-state-bat_hosts/Makefile
@@ -19,8 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LiMe
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+@BUSYBOX_CONFIG_CROND \
-		+@BUSYBOX_CONFIG_FEATURE_CROND_SPECIAL_TIMES shared-state
+	DEPENDS:=+lua +luci-lib-jsonc +luci-lib-nixio shared-state
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-bat_hosts/Makefile
+++ b/packages/shared-state-bat_hosts/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LiMe
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc +luci-lib-nixio shared-state
+	DEPENDS:=+lua +luci-lib-jsonc shared-state
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-bat_hosts/Makefile
+++ b/packages/shared-state-bat_hosts/Makefile
@@ -19,7 +19,8 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LiMe
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc shared-state
+	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +lua +luci-lib-jsonc \
+		shared-state
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-bat_hosts/files/etc/bat-hosts
+++ b/packages/shared-state-bat_hosts/files/etc/bat-hosts
@@ -1,0 +1,1 @@
+../var/bat-hosts

--- a/packages/shared-state-bat_hosts/files/etc/hotplug.d/iface/shared-state-bat_hosts.sh
+++ b/packages/shared-state-bat_hosts/files/etc/hotplug.d/iface/shared-state-bat_hosts.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-[ "x$ACTION" == "xifup" ] && ((/usr/bin/shared-state-publish_bat_hosts)&)
+[ "x$ACTION" == "xifup" ] && ((sleep 30; shared-state-publish_bat_hosts; shared-state sync bat-hosts)&)

--- a/packages/shared-state-bat_hosts/files/etc/hotplug.d/iface/shared-state-bat_hosts.sh
+++ b/packages/shared-state-bat_hosts/files/etc/hotplug.d/iface/shared-state-bat_hosts.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+[ "x$ACTION" == "xifup" ] && ((/usr/bin/shared-state-publish_bat_hosts)&)

--- a/packages/shared-state-bat_hosts/files/etc/shared-state/hooks/bat-hosts/generate_bat_hosts
+++ b/packages/shared-state-bat_hosts/files/etc/shared-state/hooks/bat-hosts/generate_bat_hosts
@@ -1,0 +1,1 @@
+../../../../usr/bin/shared-state-generate_bat_hosts

--- a/packages/shared-state-bat_hosts/files/etc/shared-state/publishers/shared-state-publish_bat_hosts
+++ b/packages/shared-state-bat_hosts/files/etc/shared-state/publishers/shared-state-publish_bat_hosts
@@ -1,0 +1,1 @@
+../../../usr/bin/shared-state-publish_bat_hosts

--- a/packages/shared-state-bat_hosts/files/etc/uci-defaults/shared-state-bat_hosts-cron
+++ b/packages/shared-state-bat_hosts/files/etc/uci-defaults/shared-state-bat_hosts-cron
@@ -1,4 +1,10 @@
 #!/bin/sh
 
-echo "*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync bat-hosts)&)" >> /etc/crontabs/root
-echo "*/30 * * * * ((sleep $(($RANDOM % 1000)); shared-state-publish_bat_hosts)&)" >> /etc/crontabs/root
+unique_append()
+{
+	grep -qF "$1" "$2" || echo "$1" >> "$2"
+}
+
+unique_append \
+	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync bat-hosts)&)'\
+	/etc/crontabs/root

--- a/packages/shared-state-bat_hosts/files/etc/uci-defaults/shared-state-bat_hosts-cron
+++ b/packages/shared-state-bat_hosts/files/etc/uci-defaults/shared-state-bat_hosts-cron
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "*/30 * * * * ((sleep $(($RANDOM % 1000)); shared-state-publish_bat_hosts)&)" >> /etc/crontabs/root

--- a/packages/shared-state-bat_hosts/files/etc/uci-defaults/shared-state-bat_hosts-cron
+++ b/packages/shared-state-bat_hosts/files/etc/uci-defaults/shared-state-bat_hosts-cron
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+echo "*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync bat-hosts)&)" >> /etc/crontabs/root
 echo "*/30 * * * * ((sleep $(($RANDOM % 1000)); shared-state-publish_bat_hosts)&)" >> /etc/crontabs/root

--- a/packages/shared-state-bat_hosts/files/usr/bin/bat2mac
+++ b/packages/shared-state-bat_hosts/files/usr/bin/bat2mac
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cat | sed "$(sed -nr "{s/.*(..:..:..:..:..:..)[[:space:]]+([^[:space:]]+).*/s|\2|\1|Ig;/p}" /etc/bat-hosts)"

--- a/packages/shared-state-bat_hosts/files/usr/bin/mac2bat
+++ b/packages/shared-state-bat_hosts/files/usr/bin/mac2bat
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cat | sed "$(sed -nr "{s/.*(..:..:..:..:..:..)[[:space:]]+([^[:space:]]+).*/s|\1|\2|Ig;/p}" /etc/bat-hosts)"
+

--- a/packages/shared-state-bat_hosts/files/usr/bin/shared-state-generate_bat_hosts
+++ b/packages/shared-state-bat_hosts/files/usr/bin/shared-state-generate_bat_hosts
@@ -1,0 +1,29 @@
+#!/usr/bin/lua
+
+--! LibreMesh
+--! Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+--!
+--! This program is free software: you can redistribute it and/or modify
+--! it under the terms of the GNU Affero General Public License as
+--! published by the Free Software Foundation, either version 3 of the
+--! License, or (at your option) any later version.
+--!
+--! This program is distributed in the hope that it will be useful,
+--! but WITHOUT ANY WARRANTY; without even the implied warranty of
+--! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--! GNU Affero General Public License for more details.
+--!
+--! You should have received a copy of the GNU Affero General Public License
+--! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local fs = require("nixio.fs")
+local JSON = require("luci.jsonc")
+
+local outputTable = {}
+
+for key,value in pairs(
+	JSON.parse(io.input(io.popen("shared-state get bat-hosts")):read("*all")) ) do
+	table.insert(outputTable, key.." "..value.data)
+end
+
+io.output("/etc/bat-hosts"):write(table.concat(outputTable,"\n").."\n")

--- a/packages/shared-state-bat_hosts/files/usr/bin/shared-state-generate_bat_hosts
+++ b/packages/shared-state-bat_hosts/files/usr/bin/shared-state-generate_bat_hosts
@@ -16,13 +16,12 @@
 --! You should have received a copy of the GNU Affero General Public License
 --! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-local fs = require("nixio.fs")
 local JSON = require("luci.jsonc")
 
 local outputTable = {}
 
 for key,value in pairs(
-	JSON.parse(io.input(io.popen("shared-state get bat-hosts")):read("*all")) ) do
+	JSON.parse(io.stdin:read("*all")) ) do
 	table.insert(outputTable, key.." "..value.data)
 end
 

--- a/packages/shared-state-bat_hosts/files/usr/bin/shared-state-publish_bat_hosts
+++ b/packages/shared-state-bat_hosts/files/usr/bin/shared-state-publish_bat_hosts
@@ -24,10 +24,14 @@ local hostname = io.input("/proc/sys/kernel/hostname"):read("*line")
 
 local batHostTable = {}
 
+local ignoredIf = { lo=true, anygw=true }
+
 for ifname in fs.dir(ifacesPath) do
-	local macaddr = io.input(ifacesPath..ifname.."/address"):read("*line")
-	if type(macaddr) == "string" and macaddr:len() == 17 then
-		batHostTable[macaddr] = string.gsub(hostname.."_"..ifname, "%W", "_")
+	if not ignoredIf[ifname] then
+		local macaddr = io.input(ifacesPath..ifname.."/address"):read("*line")
+		if type(macaddr) == "string" and macaddr:len() == 17 then
+			batHostTable[macaddr] = string.gsub(hostname.."_"..ifname, "%W", "_")
+		end
 	end
 end
 

--- a/packages/shared-state-bat_hosts/files/usr/bin/shared-state-publish_bat_hosts
+++ b/packages/shared-state-bat_hosts/files/usr/bin/shared-state-publish_bat_hosts
@@ -1,0 +1,34 @@
+#!/usr/bin/lua
+
+--! LibreMesh
+--! Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+--!
+--! This program is free software: you can redistribute it and/or modify
+--! it under the terms of the GNU Affero General Public License as
+--! published by the Free Software Foundation, either version 3 of the
+--! License, or (at your option) any later version.
+--!
+--! This program is distributed in the hope that it will be useful,
+--! but WITHOUT ANY WARRANTY; without even the implied warranty of
+--! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--! GNU Affero General Public License for more details.
+--!
+--! You should have received a copy of the GNU Affero General Public License
+--! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local fs = require("nixio.fs")
+local JSON = require("luci.jsonc")
+
+local ifacesPath = "/sys/class/net/"
+local hostname = io.input("/proc/sys/kernel/hostname"):read("*line")
+
+local batHostTable = {}
+
+for ifname in fs.dir(ifacesPath) do
+	local macaddr = io.input(ifacesPath..ifname.."/address"):read("*line")
+	if type(macaddr) == "string" and macaddr:len() == 17 then
+		batHostTable[macaddr] = string.gsub(hostname.."_"..ifname, "%W", "_")
+	end
+end
+
+io.popen("shared-state insert bat-hosts", "w"):write(JSON.stringify(batHostTable))

--- a/packages/shared-state-date/Makefile
+++ b/packages/shared-state-date/Makefile
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2019 Gioacchino Mazzurco <gio@altermundi.net>
+#
+# This is free software, licensed under the GNU Affero General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+PKG_NAME:=shared-state-date
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+	TITLE:=date time module for shared-state
+	CATEGORY:=LiMe
+	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
+	URL:=http://libremesh.org
+	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +jsonfilter +lua \
+		+luci-lib-jsonc shared-state
+	PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/description
+	Syncronize time beween nodes, if NTP is not available nodes converges to
+	higher time available
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/shared-state-date/files/etc/shared-state/hooks/date/set_date
+++ b/packages/shared-state-date/files/etc/shared-state/hooks/date/set_date
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+<< COPYRIGHT
+
+LibreMesh
+Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+COPYRIGHT
+
+mCandDate="$(cat - | jsonfilter -e '$.date.data')"
+mCandDateS="$(date --utc +%s "$mCandDate")"
+mCurrDateS="$(date --utc +%s)"
+mDiffS="$(($mCandDateS-$mCurrDateS))"
+
+[ "${mDiffS}" -lt "600" ] && exit 0
+
+((
+ntpd -w -q -p ::1 || {
+	date --utc --set "$mCandDate"
+	[ "${mDiffS#-}" -gt "1200" ] &&
+		for pub in /etc/shared-state/publishers/* ; do
+			[ -x "$pub" ] && "$pub";
+		done
+}
+)&)

--- a/packages/shared-state-date/files/etc/shared-state/publishers/date
+++ b/packages/shared-state-date/files/etc/shared-state/publishers/date
@@ -1,0 +1,27 @@
+#!/usr/bin/lua
+
+--! LibreMesh
+--! Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+--!
+--! This program is free software: you can redistribute it and/or modify
+--! it under the terms of the GNU Affero General Public License as
+--! published by the Free Software Foundation, either version 3 of the
+--! License, or (at your option) any later version.
+--!
+--! This program is distributed in the hope that it will be useful,
+--! but WITHOUT ANY WARRANTY; without even the implied warranty of
+--! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--! GNU Affero General Public License for more details.
+--!
+--! You should have received a copy of the GNU Affero General Public License
+--! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local fs = require("nixio.fs")
+local JSON = require("luci.jsonc")
+
+local cstdOut = io.popen('date --utc "+%Y-%m-%d %H:%M:%S"', "r")
+local dateStr = cstdOut:read("*l")
+cstdOut:close()
+
+local dateTable = { date=dateStr }
+io.popen("shared-state insert date", "w"):write(JSON.stringify(dateTable))

--- a/packages/shared-state-date/files/etc/uci-defaults/shared-state-date-cron
+++ b/packages/shared-state-date/files/etc/uci-defaults/shared-state-date-cron
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+uci set system.ntp.enabled=1
+uci set system.ntp.enable_server=1
+uci commit system
+
+unique_append()
+{
+	grep -qF "$1" "$2" || echo "$1" >> "$2"
+}
+
+unique_append \
+	'*/4 * * * * ((sleep $(($RANDOM % 90)); shared-state sync date)&)'\
+	/etc/crontabs/root
+
+unique_append \
+	'*/2 * * * * ((sleep $(($RANDOM % 30)); /etc/shared-state/publishers/date)&)'\
+	/etc/crontabs/root

--- a/packages/shared-state-dnsmasq_hosts/Makefile
+++ b/packages/shared-state-dnsmasq_hosts/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2019 Gioacchino Mazzurco <gio@altermundi.net>
+#
+# This is free software, licensed under the GNU Affero General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+PKG_NAME:=shared-state-dnsmasq_hosts
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+	TITLE:=dnsmasq hosts module for shared-state
+	CATEGORY:=LiMe
+	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
+	URL:=http://libremesh.org
+	DEPENDS:=+lua +luci-lib-jsonc shared-state
+	PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/description
+	Syncronize dnsmasq hosts beween nodes.
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/shared-state-dnsmasq_hosts/Makefile
+++ b/packages/shared-state-dnsmasq_hosts/Makefile
@@ -19,7 +19,8 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LiMe
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc shared-state
+	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +lua +luci-lib-jsonc \
+		shared-state
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-dnsmasq_hosts/files/etc/shared-state/hooks/dnsmasq-hosts/generate_dnsmasq_hosts
+++ b/packages/shared-state-dnsmasq_hosts/files/etc/shared-state/hooks/dnsmasq-hosts/generate_dnsmasq_hosts
@@ -1,0 +1,1 @@
+../../../../usr/bin/shared-state-generate_dnsmasq_hosts

--- a/packages/shared-state-dnsmasq_hosts/files/etc/shared-state/publishers/shared-state-publish_dnsmasq_hosts
+++ b/packages/shared-state-dnsmasq_hosts/files/etc/shared-state/publishers/shared-state-publish_dnsmasq_hosts
@@ -1,0 +1,1 @@
+../../../usr/bin/shared-state-publish_dnsmasq_hosts

--- a/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
+++ b/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "*/3 * * * * ((sleep $(($RANDOM % 60)); shared-state sync dnsmasq-hosts)&)" >> /etc/crontabs/root
+echo "*/30 * * * * ((sleep $(($RANDOM % 1000)); shared-state-publish_dnsmasq_hosts)&)" >> /etc/crontabs/root

--- a/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
+++ b/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
@@ -1,3 +1,10 @@
 #!/bin/sh
-echo "*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-hosts)&)" >> /etc/crontabs/root
-echo "*/30 * * * * ((sleep $(($RANDOM % 1000)); shared-state-publish_dnsmasq_hosts)&)" >> /etc/crontabs/root
+
+unique_append()
+{
+	grep -qF "$1" "$2" || echo "$1" >> "$2"
+}
+
+unique_append \
+	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-hosts)&)'\
+	/etc/crontabs/root

--- a/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
+++ b/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
@@ -1,3 +1,3 @@
 #!/bin/sh
-echo "*/3 * * * * ((sleep $(($RANDOM % 60)); shared-state sync dnsmasq-hosts)&)" >> /etc/crontabs/root
+echo "*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-hosts)&)" >> /etc/crontabs/root
 echo "*/30 * * * * ((sleep $(($RANDOM % 1000)); shared-state-publish_dnsmasq_hosts)&)" >> /etc/crontabs/root

--- a/packages/shared-state-dnsmasq_hosts/files/usr/bin/shared-state-generate_dnsmasq_hosts
+++ b/packages/shared-state-dnsmasq_hosts/files/usr/bin/shared-state-generate_dnsmasq_hosts
@@ -21,7 +21,7 @@ local JSON = require("luci.jsonc")
 local outputTable = {}
 
 for key,value in pairs(
-	JSON.parse(io.input(io.popen("shared-state get dnsmasq-hosts")):read("*all")) ) do
+	JSON.parse(io.stdin:read("*all")) ) do
 	if value.data then table.insert(outputTable, key) end
 end
 

--- a/packages/shared-state-dnsmasq_hosts/files/usr/bin/shared-state-generate_dnsmasq_hosts
+++ b/packages/shared-state-dnsmasq_hosts/files/usr/bin/shared-state-generate_dnsmasq_hosts
@@ -1,0 +1,32 @@
+#!/usr/bin/lua
+
+--! LibreMesh
+--! Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+--!
+--! This program is free software: you can redistribute it and/or modify
+--! it under the terms of the GNU Affero General Public License as
+--! published by the Free Software Foundation, either version 3 of the
+--! License, or (at your option) any later version.
+--!
+--! This program is distributed in the hope that it will be useful,
+--! but WITHOUT ANY WARRANTY; without even the implied warranty of
+--! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--! GNU Affero General Public License for more details.
+--!
+--! You should have received a copy of the GNU Affero General Public License
+--! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local JSON = require("luci.jsonc")
+
+local outputTable = {}
+
+for key,value in pairs(
+	JSON.parse(io.input(io.popen("shared-state get dnsmasq-hosts")):read("*all")) ) do
+	if value.data then table.insert(outputTable, key) end
+end
+
+local outputFile = io.open("/var/hosts/shared-state-dnsmasq_hosts", "w")
+outputFile:write(table.concat(outputTable,"\n").."\n")
+outputFile:close()
+
+os.execute("killall -HUP dnsmasq 2>/dev/null")

--- a/packages/shared-state-dnsmasq_hosts/files/usr/bin/shared-state-publish_dnsmasq_hosts
+++ b/packages/shared-state-dnsmasq_hosts/files/usr/bin/shared-state-publish_dnsmasq_hosts
@@ -1,0 +1,34 @@
+#!/usr/bin/lua
+
+--! LibreMesh
+--! Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+--!
+--! This program is free software: you can redistribute it and/or modify
+--! it under the terms of the GNU Affero General Public License as
+--! published by the Free Software Foundation, either version 3 of the
+--! License, or (at your option) any later version.
+--!
+--! This program is distributed in the hope that it will be useful,
+--! but WITHOUT ANY WARRANTY; without even the implied warranty of
+--! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--! GNU Affero General Public License for more details.
+--!
+--! You should have received a copy of the GNU Affero General Public License
+--! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local JSON = require("luci.jsonc")
+
+local recordsTable = {}
+
+for line in io.input("/etc/hosts"):lines() do
+	if line ~= "" and
+		not line:match("^%s*$") and
+		not line:match("^%s*127\.") and
+		not line:match("^%s*::1%s") and
+		not line:match("^%s*ff02::1%s") and
+		not line:match("^%s*ff02::2%s") then
+		recordsTable[line] = true
+	end
+end
+
+io.popen("shared-state insert dnsmasq-hosts", "w"):write(JSON.stringify(recordsTable))

--- a/packages/shared-state-dnsmasq_leases/Makefile
+++ b/packages/shared-state-dnsmasq_leases/Makefile
@@ -19,7 +19,8 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LiMe
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +libuci-lua +luci-lib-jsonc shared-state
+	DEPENDS:=@(!PACKAGE_dnsmasq-lease-share) +libuci-lua +lua \
+		+luci-lib-jsonc shared-state
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-dnsmasq_leases/Makefile
+++ b/packages/shared-state-dnsmasq_leases/Makefile
@@ -20,7 +20,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=@(!PACKAGE_dnsmasq-lease-share) +libuci-lua +lua \
-		+luci-lib-jsonc shared-state
+		+luci-lib-jsonc shared-state +shared-state-dnsmasq_hosts
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-dnsmasq_leases/Makefile
+++ b/packages/shared-state-dnsmasq_leases/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2019 Gioacchino Mazzurco <gio@altermundi.net>
+#
+# This is free software, licensed under the GNU Affero General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+PKG_NAME:=shared-state-dnsmasq_leases
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+	TITLE:=dnsmasq leases module for shared-state
+	CATEGORY:=LiMe
+	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
+	URL:=http://libremesh.org
+	DEPENDS:=+lua +libuci-lua +luci-lib-jsonc shared-state
+	PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/description
+	Syncronize dnsmasq leases beween nodes.
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/shared-state-dnsmasq_leases/files/etc/shared-state/hooks/dnsmasq-leases/generate_dnsmasq_leases
+++ b/packages/shared-state-dnsmasq_leases/files/etc/shared-state/hooks/dnsmasq-leases/generate_dnsmasq_leases
@@ -1,0 +1,1 @@
+../../../../usr/bin/shared-state-generate_dnsmasq_leases

--- a/packages/shared-state-dnsmasq_leases/files/etc/shared-state/publishers/shared-state-publish_dnsmasq_leases
+++ b/packages/shared-state-dnsmasq_leases/files/etc/shared-state/publishers/shared-state-publish_dnsmasq_leases
@@ -1,0 +1,1 @@
+../../../usr/bin/shared-state-publish_dnsmasq_leases

--- a/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
+++ b/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+uci set dhcp.@dnsmasq[0].dhcpscript=/usr/bin/dnsmasq-lease-share.sh
+uci set dhcp.@dnsmasq[0].dhcphostsfile=/tmp/dhcp.hosts_remote
+uci commit dhcp
+
+exit 0

--- a/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
+++ b/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
@@ -1,9 +1,22 @@
 #!/bin/sh
 
+dhcpHostsFile="/tmp/dhcp.hosts_remote"
+
 uci set dhcp.@dnsmasq[0].dhcpscript=/usr/bin/dnsmasq-lease-share.sh
-uci set dhcp.@dnsmasq[0].dhcphostsfile=/tmp/dhcp.hosts_remote
+uci set dhcp.@dnsmasq[0].dhcphostsfile=$dhcpHostsFile
 uci commit dhcp
 
-echo "*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-leases)&)" >> /etc/crontabs/root
+unique_append()
+{
+	grep -qF "$1" "$2" || echo "$1" >> "$2"
+}
+
+# needed because init script ignore +dhcphostsfile+ if the file doesn't exists
+unique_append "dhcp-hostsfile=$dhcpHostsFile"\
+	"/etc/dnsmasq.d/shared-state-dhcp-leases"
+
+unique_append \
+	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-leases)&)'\
+	/etc/crontabs/root
 
 exit 0

--- a/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
+++ b/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
@@ -4,4 +4,6 @@ uci set dhcp.@dnsmasq[0].dhcpscript=/usr/bin/dnsmasq-lease-share.sh
 uci set dhcp.@dnsmasq[0].dhcphostsfile=/tmp/dhcp.hosts_remote
 uci commit dhcp
 
+echo "*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-leases)&)" >> /etc/crontabs/root
+
 exit 0

--- a/packages/shared-state-dnsmasq_leases/files/usr/bin/dnsmasq-lease-share.sh
+++ b/packages/shared-state-dnsmasq_leases/files/usr/bin/dnsmasq-lease-share.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+lua /usr/bin/shared-state-publish_dnsmasq_leases $@

--- a/packages/shared-state-dnsmasq_leases/files/usr/bin/dnsmasq-lease-share.sh
+++ b/packages/shared-state-dnsmasq_leases/files/usr/bin/dnsmasq-lease-share.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-((shared-state-publish_dnsmasq_leases $@; shared-state sync dnsmasq-leases)&)
+((shared-state-publish_dnsmasq_leases $@; shared-state sync dnsmasq-leases; shared-state sync dnsmasq-hosts)&)

--- a/packages/shared-state-dnsmasq_leases/files/usr/bin/dnsmasq-lease-share.sh
+++ b/packages/shared-state-dnsmasq_leases/files/usr/bin/dnsmasq-lease-share.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-((/usr/bin/shared-state-publish_dnsmasq_leases $@)&)
+((shared-state-publish_dnsmasq_leases $@; shared-state sync dnsmasq-leases)&)

--- a/packages/shared-state-dnsmasq_leases/files/usr/bin/dnsmasq-lease-share.sh
+++ b/packages/shared-state-dnsmasq_leases/files/usr/bin/dnsmasq-lease-share.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-lua /usr/bin/shared-state-publish_dnsmasq_leases $@
+((/usr/bin/shared-state-publish_dnsmasq_leases $@)&)

--- a/packages/shared-state-dnsmasq_leases/files/usr/bin/shared-state-generate_dnsmasq_leases
+++ b/packages/shared-state-dnsmasq_leases/files/usr/bin/shared-state-generate_dnsmasq_leases
@@ -23,12 +23,6 @@ local outputTable = {}
 for key,value in pairs(JSON.parse(io.stdin:read("*all"))) do
 	if value.data then
 		local hwaddr = value.data.mac
-
-		local id = ",*"
-		if string.len(value.data.id) > 1 then
-			id = ",id:"..value.data.id
-		end
-
 		local ipaddr = key
 		if ipaddr:find(":") then ipaddr = "[" .. ipaddr .. "]" end
 		ipaddr = ","..ipaddr
@@ -38,7 +32,7 @@ for key,value in pairs(JSON.parse(io.stdin:read("*all"))) do
 			hostname = ","..value.data.hostname
 		end
 
-		table.insert(outputTable, hwaddr..id..ipaddr..hostname)
+		table.insert(outputTable, hwaddr..ipaddr..hostname)
 	end
 end
 

--- a/packages/shared-state-dnsmasq_leases/files/usr/bin/shared-state-generate_dnsmasq_leases
+++ b/packages/shared-state-dnsmasq_leases/files/usr/bin/shared-state-generate_dnsmasq_leases
@@ -1,0 +1,50 @@
+#!/usr/bin/lua
+
+--! LibreMesh
+--! Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+--!
+--! This program is free software: you can redistribute it and/or modify
+--! it under the terms of the GNU Affero General Public License as
+--! published by the Free Software Foundation, either version 3 of the
+--! License, or (at your option) any later version.
+--!
+--! This program is distributed in the hope that it will be useful,
+--! but WITHOUT ANY WARRANTY; without even the implied warranty of
+--! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--! GNU Affero General Public License for more details.
+--!
+--! You should have received a copy of the GNU Affero General Public License
+--! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local JSON = require("luci.jsonc")
+
+local outputTable = {}
+
+for key,value in pairs(JSON.parse(io.stdin:read("*all"))) do
+	if value.data then
+		local hwaddr = value.data.mac
+
+		local id = ",*"
+		if string.len(value.data.id) > 1 then
+			id = ",id:"..value.data.id
+		end
+
+		local ipaddr = key
+		if ipaddr:find(":") then ipaddr = "[" .. ipaddr .. "]" end
+		ipaddr = ","..ipaddr
+
+		local hostname = ""
+		if string.len(value.data.hostname) > 1 then
+			hostname = ","..value.data.hostname
+		end
+
+		table.insert(outputTable, hwaddr..id..ipaddr..hostname)
+	end
+end
+
+local outFile = io.open("/tmp/dhcp.hosts_remote", "w")
+outFile:write(table.concat(outputTable,"\n").."\n")
+outFile:close()
+outFile = nil
+
+os.execute("killall -HUP dnsmasq 2>/dev/null")

--- a/packages/shared-state-dnsmasq_leases/files/usr/bin/shared-state-publish_dnsmasq_leases
+++ b/packages/shared-state-dnsmasq_leases/files/usr/bin/shared-state-publish_dnsmasq_leases
@@ -32,7 +32,7 @@ function add_lease(client_mac, client_ip, client_hostname, client_id)
 	leaseData[client_ip] = { hostname=client_hostname, id=client_id,
 	                         mac=client_mac }
 	local cStdin = io.popen("shared-state insert dnsmasq-leases", "w")
-	cStdin:write(JSON.stringify(leasesTable))
+	cStdin:write(JSON.stringify(leaseData))
 	cStdin:close()
 end
 
@@ -47,6 +47,7 @@ end
 local command = arg[1]
 local client_mac = arg[2]
 local client_ip = arg[3]
+
 local client_hostname
 if (arg[4] and (arg[4]:len() > 0)) then client_hostname = arg[4]
 else client_hostname = "" end

--- a/packages/shared-state-dnsmasq_leases/files/usr/bin/shared-state-publish_dnsmasq_leases
+++ b/packages/shared-state-dnsmasq_leases/files/usr/bin/shared-state-publish_dnsmasq_leases
@@ -27,13 +27,57 @@ function string:split(sep)
 	return ret
 end
 
+function add_tmp_dhcp_leases()
+	local leasesTable = {}
+	local hostTable = {}
+
+	for line in io.lines("/tmp/dhcp.leases") do
+		_, client_mac, client_ip, client_hostname, client_id = unpack(line:split(" "))
+		leasesTable[client_ip] = { hostname=client_hostname, --id=client_id,
+		                           mac=client_mac }
+		hostTable[client_ip.." "..client_hostname] = true
+	end
+
+	local jsonstring = JSON.stringify(leasesTable)
+
+	local cStdin = io.popen("shared-state insert dnsmasq-leases", "w")
+	cStdin:write(jsonstring)
+	cStdin:close()
+
+	local cStdin = io.popen("shared-state insert dnsmasq-hosts", "w")
+	cStdin:write(JSON.stringify(hostTable))
+	cStdin:close()
+end
+
 function add_lease(client_mac, client_ip, client_hostname, client_id)
 	local leaseData = {}
-	leaseData[client_ip] = { hostname=client_hostname, id=client_id,
+	leaseData[client_ip] = { hostname=client_hostname, --id=client_id,
 	                         mac=client_mac }
 	local cStdin = io.popen("shared-state insert dnsmasq-leases", "w")
 	cStdin:write(JSON.stringify(leaseData))
 	cStdin:close()
+
+	local hostTable = {}
+	hostTable[client_ip.." "..client_hostname] = true
+	local cStdin = io.popen("shared-state insert dnsmasq-hosts", "w")
+	cStdin:write(JSON.stringify(hostTable))
+	cStdin:close()
+end
+
+function add_own()
+	local leasesTable = {}
+
+	local uci_conf = uci.cursor()
+	local own_ipv4 = uci_conf:get("network", "lan", "ipaddr")
+	local own_ipv6 = uci_conf:get("network", "lan", "ip6addr")
+	uci_conf = nil
+	if own_ipv6 then own_ipv6 = own_ipv6:gsub("/.*$", "") end
+
+	local own_hostname = io.input("/proc/sys/kernel/hostname"):read("*line")
+	local own_mac = io.input("/sys/class/net/br-lan/address"):read("*line")
+
+	add_lease(own_mac, own_ipv4, own_hostname, "*")
+	add_lease(own_mac, own_ipv6, own_hostname, "*")
 end
 
 function del_lease(client_ip)
@@ -41,6 +85,12 @@ function del_lease(client_ip)
 	table.insert(keysArr, client_ip)
 	local cStdin = io.popen("shared-state remove dnsmasq-leases", "w")
 	cStdin:write(JSON.stringify(keysArr))
+	cStdin:close()
+
+	local hostArr = {}
+	table.insert(hostArr, client_ip.." "..client_hostname)
+	local cStdin = io.popen("shared-state remove dnsmasq-hosts", "w")
+	cStdin:write(JSON.stringify(hostArr))
 	cStdin:close()
 end
 
@@ -57,34 +107,13 @@ if ((not client_id) or (client_id:len() <= 0)) then client_id = "*" end
 
 if command == "add" then
 	add_lease(client_mac, client_ip, client_hostname, client_id)
+	add_own()
 
 elseif command == "del" then
 	del_lease(client_ip)
+	add_own()
 
 elseif command == nil or command:match("^%s*$") then
-	local leasesTable = {}
-
-	local uci_conf = uci.cursor()
-	local own_ipv4 = uci_conf:get("network", "lan", "ipaddr")
-	local own_ipv6 = uci_conf:get("network", "lan", "ip6addr")
-	uci_conf = nil
-	if own_ipv6 then own_ipv6 = own_ipv6:gsub("/.*$", "") end
-
-	local own_hostname = io.input("/proc/sys/kernel/hostname"):read("*line")
-	local own_mac = io.input("/sys/class/net/br-lan/address"):read("*line")
-
-	leasesTable[own_ipv4] = { hostname=own_hostname, id="*", mac=own_mac }
-	leasesTable[own_ipv6] = { hostname=own_hostname, id="*", mac=own_mac }
-
-	for line in io.lines("/tmp/dhcp.leases") do
-		_, client_mac, client_ip, client_hostname, client_id = unpack(line:split(" "))
-		leasesTable[client_ip] = { hostname=client_hostname, id=client_id,
-		                           mac=client_mac }
-	end
-
-	local jsonstring = JSON.stringify(leasesTable)
-
-	local cStdin = io.popen("shared-state insert dnsmasq-leases", "w")
-	cStdin:write(jsonstring)
-	cStdin:close()
+	add_tmp_dhcp_leases()
+	add_own()
 end

--- a/packages/shared-state-dnsmasq_leases/files/usr/bin/shared-state-publish_dnsmasq_leases
+++ b/packages/shared-state-dnsmasq_leases/files/usr/bin/shared-state-publish_dnsmasq_leases
@@ -1,0 +1,89 @@
+#!/usr/bin/lua
+
+--! LibreMesh
+--! Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+--!
+--! This program is free software: you can redistribute it and/or modify
+--! it under the terms of the GNU Affero General Public License as
+--! published by the Free Software Foundation, either version 3 of the
+--! License, or (at your option) any later version.
+--!
+--! This program is distributed in the hope that it will be useful,
+--! but WITHOUT ANY WARRANTY; without even the implied warranty of
+--! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--! GNU Affero General Public License for more details.
+--!
+--! You should have received a copy of the GNU Affero General Public License
+--! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local JSON = require("luci.jsonc")
+local uci = require("uci")
+
+function string:split(sep)
+	local ret = {}
+	for token in self:gmatch("[^"..sep.."]+") do
+		table.insert(ret, token)
+	end
+	return ret
+end
+
+function add_lease(client_mac, client_ip, client_hostname, client_id)
+	local leaseData = {}
+	leaseData[client_ip] = { hostname=client_hostname, id=client_id,
+	                         mac=client_mac }
+	local cStdin = io.popen("shared-state insert dnsmasq-leases", "w")
+	cStdin:write(JSON.stringify(leasesTable))
+	cStdin:close()
+end
+
+function del_lease(client_ip)
+	local keysArr = {}
+	table.insert(keysArr, client_ip)
+	local cStdin = io.popen("shared-state remove dnsmasq-leases", "w")
+	cStdin:write(JSON.stringify(keysArr))
+	cStdin:close()
+end
+
+local command = arg[1]
+local client_mac = arg[2]
+local client_ip = arg[3]
+local client_hostname
+if (arg[4] and (arg[4]:len() > 0)) then client_hostname = arg[4]
+else client_hostname = "" end
+
+local client_id = os.getenv("DNSMASQ_CLIENT_ID")
+if ((not client_id) or (client_id:len() <= 0)) then client_id = "*" end
+
+if command == "add" then
+	add_lease(client_mac, client_ip, client_hostname, client_id)
+
+elseif command == "del" then
+	del_lease(client_ip)
+
+elseif command == nil or command:match("^%s*$") then
+	local leasesTable = {}
+
+	local uci_conf = uci.cursor()
+	local own_ipv4 = uci_conf:get("network", "lan", "ipaddr")
+	local own_ipv6 = uci_conf:get("network", "lan", "ip6addr")
+	uci_conf = nil
+	if own_ipv6 then own_ipv6 = own_ipv6:gsub("/.*$", "") end
+
+	local own_hostname = io.input("/proc/sys/kernel/hostname"):read("*line")
+	local own_mac = io.input("/sys/class/net/br-lan/address"):read("*line")
+
+	leasesTable[own_ipv4] = { hostname=own_hostname, id="*", mac=own_mac }
+	leasesTable[own_ipv6] = { hostname=own_hostname, id="*", mac=own_mac }
+
+	for line in io.lines("/tmp/dhcp.leases") do
+		_, client_mac, client_ip, client_hostname, client_id = unpack(line:split(" "))
+		leasesTable[client_ip] = { hostname=client_hostname, id=client_id,
+		                           mac=client_mac }
+	end
+
+	local jsonstring = JSON.stringify(leasesTable)
+
+	local cStdin = io.popen("shared-state insert dnsmasq-leases", "w")
+	cStdin:write(jsonstring)
+	cStdin:close()
+end

--- a/packages/shared-state/Makefile
+++ b/packages/shared-state/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2019 Gioacchino Mazzurco <gio@altermundi.net>
+#
+# This is free software, licensed under the GNU Affero General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+PKG_NAME:=shared-state
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+	TITLE:=Very minimal state sharing betwen nodes
+	CATEGORY:=LiMe
+	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
+	URL:=http://libremesh.org
+	DEPENDS:=+lua +luci-lib-httpclient +luci-lib-jsonc +luci-lib-nixio
+	PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/description
+	LiMe utilities to avoid alfred pitfalls
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/shared-state/files/etc/uci-defaults/shared-state-publishers-cron
+++ b/packages/shared-state/files/etc/uci-defaults/shared-state-publishers-cron
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+unique_append()
+{
+	grep -qF "$1" "$2" || echo "$1" >> "$2"
+}
+
+unique_append \
+	'*/30 * * * * ((sleep $(($RANDOM % 1000)); for publisher in /etc/shared-state/publishers/* ; do [ -x "$publisher" ] && "$publisher"; done )&)'\
+	/etc/crontabs/root

--- a/packages/shared-state/files/usr/bin/shared-state
+++ b/packages/shared-state/files/usr/bin/shared-state
@@ -20,14 +20,15 @@ local fs = require("nixio.fs")
 local http = require("luci.httpclient")
 local JSON = require("luci.jsonc")
 local nixio = require("nixio")
+require("nixio.util")
 
 sharedState = {}
 
 --! Map<Key, {timeout, author, data}>
 sharedState.storage = {}
 
+sharedState.storageFD = nil
 sharedState.changed = false
-sharedState.locked = false
 sharedState.dataType = "unspecified"
 sharedState.dataDir = "/var/shared-state/data/"
 sharedState.hooksDir = "/etc/shared-state/hooks/"
@@ -65,8 +66,6 @@ function sharedState.sync(stateSlice, notifyInsert)
 		else
 			local lv = sharedState.storage[key]
 			if( lv == nil ) then
-				log("Load entry for: "..key.." will expire on: ")
-				log(os.date("%c", rv.timeout).."\n")
 				sharedState.storage[key] = rv
 				sharedState.changed = sharedState.changed or notifyInsert
 			elseif ( lv.timeout < rv.timeout ) then
@@ -80,34 +79,22 @@ function sharedState.sync(stateSlice, notifyInsert)
 	end
 end
 
-function sharedState.load(mPath)
-	mPath = mPath or sharedState.dataStorePath()
-	if(fs.stat(mPath) ~= nil) then
-		sharedState.sync(JSON.parse(io.input(mPath):read("*all")), false)
-	end
-end
-
 function sharedState.toJsonString()
 	return JSON.stringify(sharedState.storage)
 end
 
-function sharedState.save(mPath)
-	mPath = mPath or sharedState.dataStorePath()
-	fs.mkdirr(fs.dirname(mPath))
-	local outStr = sharedState.toJsonString()
-	if mPath == "/dev/stdout" then print(outStr)
-	else
-		local outFile = io.open(mPath, "w")
-		outFile:write(outStr)
-		outFile:close()
-	end
-end
-
 if arg[2] then sharedState.dataType = arg[2] end
 
-for i=1,10 do
-	if not os.execute("mkdir "..sharedState.dataStorePath()..".lock >/dev/null 2>&1") then
-		nixio.nanosleep(0, 10000000000)
+fs.mkdirr(fs.dirname(sharedState.dataStorePath()))
+sharedState.storageFD = nixio.open(
+	sharedState.dataStorePath(),
+	nixio.open_flags("rdwr", "creat") )
+
+sharedState.locked = false
+
+for i=1,3 do
+	if not sharedState.storageFD:lock("tlock") then
+		nixio.nanosleep(1)
 	else
 		sharedState.locked = true
 		break
@@ -115,18 +102,17 @@ for i=1,10 do
 end
 
 if not sharedState.locked then
-	log(arg[0].."Failed acquiring lock of data\n")
-	os.exit(false)
+	log(arg[0].." Failed acquiring lock on data\n")
+	os.exit(-165)
 end
 
-sharedState.load()
-
+sharedState.sync(JSON.parse(sharedState.storageFD:readall()), false)
 
 if arg[1] == "insert" then
 	local inputTable = JSON.parse(io.stdin:read("*all")) or {}
 	for key, lv in pairs(inputTable) do sharedState.insert(key, lv) end
 elseif arg[1] == "get" then
-	sharedState.save("/dev/stdout")
+	print(sharedState.toJsonString())
 elseif arg[1] == "sync" then
 	local urls = {}
 
@@ -154,7 +140,7 @@ elseif arg[1] == "sync" then
 	end
 elseif arg[1] == "reqsync" then
 	sharedState.sync(JSON.parse(io.stdin:read("*all")))
-	sharedState.save("/dev/stdout")
+	print(sharedState.toJsonString())
 elseif arg[1] == "remove" then
 	local inputTable = JSON.parse(io.stdin:read("*all"))
 	if inputTable ~= nil then
@@ -165,14 +151,24 @@ else
 	return -22
 end
 
-if sharedState.changed then sharedState.save() end
-os.execute("rmdir "..sharedState.dataStorePath()..".lock")
+local jsonString = sharedState.toJsonString()
+
+if sharedState.changed then
+	local outFd = io.open(sharedState.dataStorePath(), "w")
+	outFd:write(jsonString)
+	outFd:close()
+	outFd = nil
+end
+sharedState.storageFD:lock("ulock")
+sharedState.storageFD:close()
+sharedState.storageFD = nil
 
 
 if sharedState.changed then
 	for hook in fs.dir(sharedState.hooksDir..sharedState.dataType) do
 		local hookPath = sharedState.hooksDir..sharedState.dataType.."/"..hook
-		local retval = os.execute(hookPath);
-		log("Executed hook: "..hookPath.." "..retval.."\n")
+		local cStdin = io.popen(hookPath, "w")
+		cStdin:write(jsonString)
+		cStdin:close()
 	end
 end

--- a/packages/shared-state/files/usr/bin/shared-state
+++ b/packages/shared-state/files/usr/bin/shared-state
@@ -119,7 +119,7 @@ sharedState.storageFD = nixio.open(
 
 sharedState.locked = false
 
-for i=1,3 do
+for i=1,10 do
 	if not sharedState.storageFD:lock("tlock") then
 		nixio.nanosleep(1)
 	else

--- a/packages/shared-state/files/usr/bin/shared-state
+++ b/packages/shared-state/files/usr/bin/shared-state
@@ -98,10 +98,13 @@ function sharedState.sync(urls)
 		options.method = 'POST'
 		options.body = sharedState.toJsonString()
 
-		local response = http.request_to_buffer(url, options)
-		if type(response) == "string" and response:len() > 1  then
+		local success, response = pcall(http.request_to_buffer, url, options)
+
+		if success and type(response) == "string" and response:len() > 1  then
 			local parsedJson = JSON.parse(response)
 			if parsedJson then sharedState.merge(parsedJson) end
+		else
+			log( "debug", "httpclient interal error requesting "..url )
 		end
 	end
 end
@@ -139,7 +142,6 @@ sharedState.merge(JSON.parse(sharedState.storageFD:readall()), false)
 
 if arg[1] == "insert" then
 	local inputString = (io.stdin:read("*all"))
-	log("debug", "handling reqsync >>>"..inputString.."<<<")
 	local inputTable = JSON.parse(inputString) or {}
 	for key, lv in pairs(inputTable) do sharedState.insert(key, lv) end
 elseif arg[1] == "get" then
@@ -150,7 +152,7 @@ elseif arg[1] == "sync" then
 	sharedState.sync(urls)
 elseif arg[1] == "reqsync" then
 	local inputString = (io.stdin:read("*all"))
-	log("debug", "handling reqsync >>>"..inputString.."<<<")
+	log("debug", "handling reqsync "..sharedState.dataType.." >>>"..inputString.."<<<")
 	sharedState.merge(JSON.parse(inputString))
 	print(sharedState.toJsonString())
 elseif arg[1] == "remove" then

--- a/packages/shared-state/files/usr/bin/shared-state
+++ b/packages/shared-state/files/usr/bin/shared-state
@@ -37,7 +37,7 @@ function sharedState.dataStorePath()
 	return sharedState.dataDir..sharedState.dataType..".json"
 end
 
-local function log(str) io.stderr:write(str) end
+local log = nixio.syslog
 
 function sharedState.insert(key, data, timeout)
 	timeout = timeout or (os.time() + 3600)
@@ -55,8 +55,8 @@ function sharedState.merge(stateSlice, notifyInsert)
 
 	for key, rv in pairs(stateSlice) do
 		if(rv.timeout < os.time()) then
-			log("sharedState.merge got expired entry: "..key)
-			log(" expired on: "..os.date("%c", rv.timeout).."\n")
+			log( "debug", "sharedState.merge got expired entry: "..key..
+			     " expired on: "..os.date("%c", rv.timeout) )
 			sharedState.changed = true
 		else
 			local lv = sharedState.storage[key]
@@ -64,9 +64,9 @@ function sharedState.merge(stateSlice, notifyInsert)
 				sharedState.storage[key] = rv
 				sharedState.changed = sharedState.changed or notifyInsert
 			elseif ( lv.timeout < rv.timeout ) then
-				log("Updating entry for: "..key.." older: ")
-				log(os.date("%c", lv.timeout).." newer: ")
-				log(os.date("%c", rv.timeout).."\n")
+				log( "debug", "Updating entry for: "..key.." older: "..
+				     os.date("%c", lv.timeout).." newer: "..
+				     os.date("%c", rv.timeout) )
 				sharedState.storage[key] = rv
 				sharedState.changed = sharedState.changed or notifyInsert
 			end
@@ -110,6 +110,8 @@ function sharedState.toJsonString()
 	return JSON.stringify(sharedState.storage)
 end
 
+nixio.openlog("shared-state")
+
 if arg[2] then sharedState.dataType = arg[2] end
 
 fs.mkdirr(fs.dirname(sharedState.dataStorePath()))
@@ -129,14 +131,16 @@ for i=1,10 do
 end
 
 if not sharedState.locked then
-	log(arg[0].." Failed acquiring lock on data\n")
+	print(arg[0].." Failed acquiring lock on data!")
 	os.exit(-165)
 end
 
 sharedState.merge(JSON.parse(sharedState.storageFD:readall()), false)
 
 if arg[1] == "insert" then
-	local inputTable = JSON.parse(io.stdin:read("*all")) or {}
+	local inputString = (io.stdin:read("*all"))
+	log("debug", "handling reqsync >>>"..inputString.."<<<")
+	local inputTable = JSON.parse(inputString) or {}
 	for key, lv in pairs(inputTable) do sharedState.insert(key, lv) end
 elseif arg[1] == "get" then
 	print(sharedState.toJsonString())
@@ -145,7 +149,9 @@ elseif arg[1] == "sync" then
 	if arg[3] ~= nil then for i=3,#arg do table.insert(urls, arg[i]) end end
 	sharedState.sync(urls)
 elseif arg[1] == "reqsync" then
-	sharedState.merge(JSON.parse(io.stdin:read("*all")))
+	local inputString = (io.stdin:read("*all"))
+	log("debug", "handling reqsync >>>"..inputString.."<<<")
+	sharedState.merge(JSON.parse(inputString))
 	print(sharedState.toJsonString())
 elseif arg[1] == "remove" then
 	local inputTable = JSON.parse(io.stdin:read("*all"))
@@ -153,11 +159,9 @@ elseif arg[1] == "remove" then
 		for _,key in ipairs(inputTable) do sharedState.remove(key) end
 	end
 else
-	log(arg[0].." is not able to self manage, needs a command\n")
+	print(arg[0].." is not able to self manage, needs a command")
 	return -22
 end
-
-if sharedState.changed and arg[1] ~= "sync" then sharedState.sync() end
 
 local jsonString = sharedState.toJsonString()
 
@@ -180,3 +184,5 @@ if sharedState.changed then
 		cStdin:close()
 	end
 end
+
+nixio.closelog()

--- a/packages/shared-state/files/usr/bin/shared-state
+++ b/packages/shared-state/files/usr/bin/shared-state
@@ -1,0 +1,156 @@
+#!/usr/bin/lua
+
+--! LibreMesh
+--! Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+--!
+--! This program is free software: you can redistribute it and/or modify
+--! it under the terms of the GNU Affero General Public License as
+--! published by the Free Software Foundation, either version 3 of the
+--! License, or (at your option) any later version.
+--!
+--! This program is distributed in the hope that it will be useful,
+--! but WITHOUT ANY WARRANTY; without even the implied warranty of
+--! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--! GNU Affero General Public License for more details.
+--!
+--! You should have received a copy of the GNU Affero General Public License
+--! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local fs = require("nixio.fs")
+local http = require("luci.httpclient")
+local JSON = require("luci.jsonc")
+
+sharedState = {}
+
+--! Map<Key, {timeout, author, data}>
+sharedState.storage = {}
+
+sharedState.changed = false
+sharedState.dataType = "unspecified"
+sharedState.dataDir = "/var/shared-state/data/"
+sharedState.hooksDir = "/etc/shared-state/hooks/"
+
+function sharedState.dataStorePath()
+	return sharedState.dataDir..sharedState.dataType..".json"
+end
+
+local function log(str) io.stderr:write(str) end
+
+function sharedState.insert(key, data, timeout)
+	timeout = timeout or (os.time() + 3600)
+	sharedState.storage[key] = {
+		timeout=timeout,
+		author=io.input("/proc/sys/kernel/hostname"):read("*line"),
+		data=data
+	}
+	sharedState.changed = true
+end
+
+function sharedState.remove(key)
+	if(sharedState.storage[key] ~= nil and sharedState.storage[key].data ~= nil)
+	then sharedState.insert(key, nil) end
+end
+
+function sharedState.sync(stateSlice, notifyInsert)
+	local stateSlice = stateSlice or {}
+	if(notifyInsert == nil) then notifyInsert = true end
+
+	for key, rv in pairs(stateSlice) do
+		if(rv.timeout < os.time()) then
+			log("sharedState.sync got expired entry: "..key)
+			log(" expired on: "..os.date("%c", rv.timeout).."\n")
+			sharedState.changed = true
+		else
+			local lv = sharedState.storage[key]
+			if( lv == nil ) then
+				log("Load entry for: "..key.." will expire on: ")
+				log(os.date("%c", rv.timeout).."\n")
+				sharedState.storage[key] = rv
+				sharedState.changed = sharedState.changed or notifyInsert
+			elseif ( lv.timeout < rv.timeout ) then
+				log("Updating entry for: "..key.." older: ")
+				log(os.date("%c", lv.timeout).." newer: ")
+				log(os.date("%c", rv.timeout).."\n")
+				sharedState.storage[key] = rv
+				sharedState.changed = sharedState.changed or notifyInsert
+			end
+		end
+	end
+end
+
+function sharedState.load(mPath)
+	mPath = mPath or sharedState.dataStorePath()
+	if(fs.stat(mPath) ~= nil) then
+		sharedState.sync(JSON.parse(io.input(mPath):read("*all")), false)
+	end
+end
+
+function sharedState.toJsonString()
+	return JSON.stringify(sharedState.storage)
+end
+
+function sharedState.save(mPath)
+	mPath = mPath or sharedState.dataStorePath()
+	fs.mkdirr(fs.dirname(mPath))
+	local outStr = sharedState.toJsonString()
+	if mPath == "/dev/stdout" then print(outStr)
+	else io.output(mPath):write(outStr) end
+end
+
+
+
+
+
+if arg[2] then sharedState.dataType = arg[2] end
+sharedState.load()
+
+
+if arg[1] == "insert" then
+	local inputTable = JSON.parse(io.stdin:read("*all"))
+	for key, lv in pairs(inputTable) do sharedState.insert(key, lv) end
+elseif arg[1] == "get" then
+	sharedState.save("/dev/stdout")
+elseif arg[1] == "pull" then
+	local urls = {}
+
+	if arg[3] == nil then
+		io.input(io.popen(arg[0].."-get_candidates_neigh"))
+		for line in io.lines() do
+			table.insert(
+				urls,
+				"http://["..line.."]/cgi-bin/shared-state/"..sharedState.dataType )
+		end
+	else for i=3,#arg do table.insert(urls, arg[i]) end end
+
+	for _,url in ipairs(urls) do
+		local options = {}
+		options.sndtimeo = 3
+		options.rcvtimeo = 3
+		options.method = 'POST'
+		options.body = sharedState.toJsonString()
+
+		local response = http.request_to_buffer(url, options)
+		if type(response) == "string" and response:len() > 1  then
+			local parsedJson = JSON.parse(response)
+			if parsedJson then sharedState.sync(parsedJson) end
+		end
+	end
+elseif arg[1] == "push" then
+	sharedState.sync(JSON.parse(io.stdin:read("*all")))
+	sharedState.save("/dev/stdout")
+elseif arg[1] == "remove" then
+	local inputTable = JSON.parse(io.stdin:read("*all"))
+	if inputTable ~= nil then
+		for _,key in ipairs(inputTable) do sharedState.remove(key) end
+	end
+else
+	log(arg[0].." is not able to self manage, needs a command\n")
+	return -22
+end
+
+if sharedState.changed then
+	sharedState.save()
+	for hook in fs.dir(sharedState.hooksDir..sharedState.dataType) do
+		os.execute(sharedState.hooksDir..sharedState.dataType.."/"..hook);
+	end
+end

--- a/packages/shared-state/files/usr/bin/shared-state
+++ b/packages/shared-state/files/usr/bin/shared-state
@@ -19,6 +19,7 @@
 local fs = require("nixio.fs")
 local http = require("luci.httpclient")
 local JSON = require("luci.jsonc")
+local nixio = require("nixio")
 
 sharedState = {}
 
@@ -26,6 +27,7 @@ sharedState = {}
 sharedState.storage = {}
 
 sharedState.changed = false
+sharedState.locked = false
 sharedState.dataType = "unspecified"
 sharedState.dataDir = "/var/shared-state/data/"
 sharedState.hooksDir = "/etc/shared-state/hooks/"
@@ -94,19 +96,34 @@ function sharedState.save(mPath)
 	fs.mkdirr(fs.dirname(mPath))
 	local outStr = sharedState.toJsonString()
 	if mPath == "/dev/stdout" then print(outStr)
-	else io.output(mPath):write(outStr) end
+	else
+		local outFile = io.open(mPath, "w")
+		outFile:write(outStr)
+		outFile:close()
+	end
 end
 
-
-
-
-
 if arg[2] then sharedState.dataType = arg[2] end
+
+for i=1,10 do
+	if not os.execute("mkdir "..sharedState.dataStorePath()..".lock >/dev/null 2>&1") then
+		nixio.nanosleep(0, 10000000000)
+	else
+		sharedState.locked = true
+		break
+	end
+end
+
+if not sharedState.locked then
+	log(arg[0].."Failed acquiring lock of data\n")
+	os.exit(false)
+end
+
 sharedState.load()
 
 
 if arg[1] == "insert" then
-	local inputTable = JSON.parse(io.stdin:read("*all"))
+	local inputTable = JSON.parse(io.stdin:read("*all")) or {}
 	for key, lv in pairs(inputTable) do sharedState.insert(key, lv) end
 elseif arg[1] == "get" then
 	sharedState.save("/dev/stdout")
@@ -148,9 +165,14 @@ else
 	return -22
 end
 
+if sharedState.changed then sharedState.save() end
+os.execute("rmdir "..sharedState.dataStorePath()..".lock")
+
+
 if sharedState.changed then
-	sharedState.save()
 	for hook in fs.dir(sharedState.hooksDir..sharedState.dataType) do
-		os.execute(sharedState.hooksDir..sharedState.dataType.."/"..hook);
+		local hookPath = sharedState.hooksDir..sharedState.dataType.."/"..hook
+		local retval = os.execute(hookPath);
+		log("Executed hook: "..hookPath.." "..retval.."\n")
 	end
 end

--- a/packages/shared-state/files/usr/bin/shared-state
+++ b/packages/shared-state/files/usr/bin/shared-state
@@ -110,7 +110,7 @@ if arg[1] == "insert" then
 	for key, lv in pairs(inputTable) do sharedState.insert(key, lv) end
 elseif arg[1] == "get" then
 	sharedState.save("/dev/stdout")
-elseif arg[1] == "pull" then
+elseif arg[1] == "sync" then
 	local urls = {}
 
 	if arg[3] == nil then
@@ -135,7 +135,7 @@ elseif arg[1] == "pull" then
 			if parsedJson then sharedState.sync(parsedJson) end
 		end
 	end
-elseif arg[1] == "push" then
+elseif arg[1] == "reqsync" then
 	sharedState.sync(JSON.parse(io.stdin:read("*all")))
 	sharedState.save("/dev/stdout")
 elseif arg[1] == "remove" then

--- a/packages/shared-state/files/usr/bin/shared-state
+++ b/packages/shared-state/files/usr/bin/shared-state
@@ -49,18 +49,13 @@ function sharedState.insert(key, data, timeout)
 	sharedState.changed = true
 end
 
-function sharedState.remove(key)
-	if(sharedState.storage[key] ~= nil and sharedState.storage[key].data ~= nil)
-	then sharedState.insert(key, nil) end
-end
-
-function sharedState.sync(stateSlice, notifyInsert)
+function sharedState.merge(stateSlice, notifyInsert)
 	local stateSlice = stateSlice or {}
 	if(notifyInsert == nil) then notifyInsert = true end
 
 	for key, rv in pairs(stateSlice) do
 		if(rv.timeout < os.time()) then
-			log("sharedState.sync got expired entry: "..key)
+			log("sharedState.merge got expired entry: "..key)
 			log(" expired on: "..os.date("%c", rv.timeout).."\n")
 			sharedState.changed = true
 		else
@@ -75,6 +70,38 @@ function sharedState.sync(stateSlice, notifyInsert)
 				sharedState.storage[key] = rv
 				sharedState.changed = sharedState.changed or notifyInsert
 			end
+		end
+	end
+end
+
+function sharedState.remove(key)
+	if(sharedState.storage[key] ~= nil and sharedState.storage[key].data ~= nil)
+	then sharedState.insert(key, nil) end
+end
+
+function sharedState.sync(urls)
+	urls = urls or {}
+
+	if #urls < 1 then
+		io.input(io.popen(arg[0].."-get_candidates_neigh"))
+		for line in io.lines() do
+			table.insert(
+				urls,
+				"http://["..line.."]/cgi-bin/shared-state/"..sharedState.dataType )
+		end
+	end
+
+	for _,url in ipairs(urls) do
+		local options = {}
+		options.sndtimeo = 3
+		options.rcvtimeo = 3
+		options.method = 'POST'
+		options.body = sharedState.toJsonString()
+
+		local response = http.request_to_buffer(url, options)
+		if type(response) == "string" and response:len() > 1  then
+			local parsedJson = JSON.parse(response)
+			if parsedJson then sharedState.merge(parsedJson) end
 		end
 	end
 end
@@ -106,7 +133,7 @@ if not sharedState.locked then
 	os.exit(-165)
 end
 
-sharedState.sync(JSON.parse(sharedState.storageFD:readall()), false)
+sharedState.merge(JSON.parse(sharedState.storageFD:readall()), false)
 
 if arg[1] == "insert" then
 	local inputTable = JSON.parse(io.stdin:read("*all")) or {}
@@ -115,31 +142,10 @@ elseif arg[1] == "get" then
 	print(sharedState.toJsonString())
 elseif arg[1] == "sync" then
 	local urls = {}
-
-	if arg[3] == nil then
-		io.input(io.popen(arg[0].."-get_candidates_neigh"))
-		for line in io.lines() do
-			table.insert(
-				urls,
-				"http://["..line.."]/cgi-bin/shared-state/"..sharedState.dataType )
-		end
-	else for i=3,#arg do table.insert(urls, arg[i]) end end
-
-	for _,url in ipairs(urls) do
-		local options = {}
-		options.sndtimeo = 3
-		options.rcvtimeo = 3
-		options.method = 'POST'
-		options.body = sharedState.toJsonString()
-
-		local response = http.request_to_buffer(url, options)
-		if type(response) == "string" and response:len() > 1  then
-			local parsedJson = JSON.parse(response)
-			if parsedJson then sharedState.sync(parsedJson) end
-		end
-	end
+	if arg[3] ~= nil then for i=3,#arg do table.insert(urls, arg[i]) end end
+	sharedState.sync(urls)
 elseif arg[1] == "reqsync" then
-	sharedState.sync(JSON.parse(io.stdin:read("*all")))
+	sharedState.merge(JSON.parse(io.stdin:read("*all")))
 	print(sharedState.toJsonString())
 elseif arg[1] == "remove" then
 	local inputTable = JSON.parse(io.stdin:read("*all"))
@@ -150,6 +156,8 @@ else
 	log(arg[0].." is not able to self manage, needs a command\n")
 	return -22
 end
+
+if sharedState.changed and arg[1] ~= "sync" then sharedState.sync() end
 
 local jsonString = sharedState.toJsonString()
 

--- a/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
+++ b/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
@@ -20,6 +20,22 @@
 
 COPYRIGHT
 
+get_uptime()
+{
+	awk '{print $1}' /proc/uptime | awk -F. '{print $1}'
+}
+
+cacheFile="/tmp/shared-state-get_candidates_neigh.cache"
+lastRunFile="/tmp/shared-state-get_candidates_neigh.lastrun"
+lastRun=$(cat "$lastRunFile" 2>/dev/null || echo -9999)
+currUptime="$(get_uptime)"
+
+[ "$(($currUptime - $lastRun))" -lt "90" ] &&
+{
+	cat "$cacheFile"
+	exit 0
+}
+
 possiblyAvoidIfaces="anygw br-lan lo"
 
 candidateAddresses="$(
@@ -48,4 +64,5 @@ $(echo "$candidateAddresses" | grep -v "$cIp")"
 
 done
 
-echo "$candidateAddresses"
+echo "$candidateAddresses" | tee "$cacheFile"
+get_uptime > "$lastRunFile"

--- a/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
+++ b/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
@@ -30,6 +30,10 @@ for iface in $(ls /sys/class/net/) ; do
 		awk '{if ($3 == "from") print substr($4, 1, length($4)-1)'"\"%$iface\""'}'
 done | sort -u -r)"
 
+candidateAddresses="$candidateAddresses
+$(ping6 -c 2 ff02::1%br-lan | \
+	awk '{if ($3 == "from" && substr($7,6)+0 < 2) print substr($4, 1, length($4)-1)"%br-lan" }' | sort -u)"
+
 for ownAddr in $(ip -6 address show | awk '{if ($1 == "inet6") print $2}' | awk -F/ '{print $1}') ; do
 	candidateAddresses="$(echo "$candidateAddresses" | grep -v "$ownAddr")"
 done

--- a/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
+++ b/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+<< COPYRIGHT
+
+ LibreMesh
+ Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as
+ published by the Free Software Foundation, either version 3 of the
+ License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+COPYRIGHT
+
+possiblyAvoidIfaces="anygw br-lan lo"
+
+candidateAddresses="$(
+for iface in $(ls /sys/class/net/) ; do
+	echo $possiblyAvoidIfaces | grep -q $iface && continue
+
+	ping6 -c 2 ff02::1%${iface} 2> /dev/null | \
+		awk '{if ($3 == "from") print substr($4, 1, length($4)-1)'"\"%$iface\""'}'
+done | sort -u -r)"
+
+for ownAddr in $(ip -6 address show | awk '{if ($1 == "inet6") print $2}' | awk -F/ '{print $1}') ; do
+	candidateAddresses="$(echo "$candidateAddresses" | grep -v "$ownAddr")"
+done
+
+# Deduplicate addresses visible from muliple interfaces
+for cAddr in $(echo "$candidateAddresses"); do
+	cIp="$(echo "$cAddr" | awk -F% '{print $1}')"
+	cIface="$(echo "$cAddr" | awk -F% '{print $2}')"
+
+	candidateAddresses="$cAddr
+$(echo "$candidateAddresses" | grep -v "$cIp")"
+
+done
+
+echo "$candidateAddresses"

--- a/packages/shared-state/files/www/cgi-bin/shared-state
+++ b/packages/shared-state/files/www/cgi-bin/shared-state
@@ -1,0 +1,34 @@
+#!/usr/bin/lua
+
+--! LibreMesh
+--! Copyright (C) 2019  Marcos Gutierrez <gmarcos@altermundi.net>
+--! Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+--!
+--! This program is free software: you can redistribute it and/or modify
+--! it under the terms of the GNU Affero General Public License as
+--! published by the Free Software Foundation, either version 3 of the
+--! License, or (at your option) any later version.
+--!
+--! This program is distributed in the hope that it will be useful,
+--! but WITHOUT ANY WARRANTY; without even the implied warranty of
+--! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--! GNU Affero General Public License for more details.
+--!
+--! You should have received a copy of the GNU Affero General Public License
+--! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local nixio = require("nixio")
+
+io.stdout:write("\rContent-Type: application/json\n\n")
+
+local httpMethod = os.getenv('REQUEST_METHOD')
+local tableName = nixio.getenv('PATH_INFO')
+
+if httpMethod == "POST" and type(tableName) == "string" then
+	local tmpPath = os.tmpname()
+	tableName = tableName:gsub("%/", "")
+	local pIn = io.popen("shared-state push "..tableName.." > "..tmpPath)
+	pIn:write(io.stdin:read("*all")); pIn:close()
+	io.stdout:write(io.input(tmpPath):read("*all"))
+	os.remove(tmpPath)
+end

--- a/packages/shared-state/files/www/cgi-bin/shared-state
+++ b/packages/shared-state/files/www/cgi-bin/shared-state
@@ -27,7 +27,7 @@ local tableName = nixio.getenv('PATH_INFO')
 if httpMethod == "POST" and type(tableName) == "string" then
 	local tmpPath = os.tmpname()
 	tableName = tableName:gsub("%/", "")
-	local pIn = io.popen("shared-state reqsync "..tableName.." > "..tmpPath)
+	local pIn = io.popen("shared-state reqsync "..tableName.." > "..tmpPath, "w")
 	pIn:write(io.stdin:read("*all")); pIn:close()
 	io.stdout:write(io.input(tmpPath):read("*all"))
 	os.remove(tmpPath)

--- a/packages/shared-state/files/www/cgi-bin/shared-state
+++ b/packages/shared-state/files/www/cgi-bin/shared-state
@@ -27,7 +27,7 @@ local tableName = nixio.getenv('PATH_INFO')
 if httpMethod == "POST" and type(tableName) == "string" then
 	local tmpPath = os.tmpname()
 	tableName = tableName:gsub("%/", "")
-	local pIn = io.popen("shared-state push "..tableName.." > "..tmpPath)
+	local pIn = io.popen("shared-state reqsync "..tableName.." > "..tmpPath)
 	pIn:write(io.stdin:read("*all")); pIn:close()
 	io.stdout:write(io.input(tmpPath):read("*all"))
 	os.remove(tmpPath)


### PR DESCRIPTION
shared-state provide a way to keep maps of data in sync between hosts
in the network, the design is minimal and completely insecure, it aims
to be a quick and dirty replacement for alfred which tend to fail
unpredictably and flood our network to death with unnecessary traffic
when there is enough alfred master nodes