### PR TITLE
safe-reboot via Ubus

### DIFF
--- a/packages/ubus-lime-utils/README.md
+++ b/packages/ubus-lime-utils/README.md
@@ -1,9 +1,13 @@
-
 # Utils Libremesh ubus status module
 
-|Path   	|Procedure   	|Signature   	|Description
-|---  |---  |---  |---
-|lime.utils |get_cloud_nodes   	|{}   	| Get cloud nodes
+| Path       | Procedure       | Signature                                                         | Description                                                                                                                                                                                                                                                                                                                           |
+| ---------- | --------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| lime-utils | get_cloud_nodes | {}                                                                | Get cloud nodes                                                                                                                                                                                                                                                                                                                       |
+| lime-utils | safe_reboot     | { "action": "status" }                                            | Get safe-reboot status                                                                                                                                                                                                                                                                                                                |
+| lime-utils | safe_reboot     | { "action": "start", "value": {"wait": TIME, "fallback": TIME } } | After backing up /overlay/upper/etc, wait for TIME (value.wait) before reboot (Default: 5min). After boot, wait for TIME (value.fallback) before reverting /overlay/upper/etc from backup found in /overlay/upper/.etc.last-good.tgz (Default: 10min).<br> _TIME examples: 1hour 60min 60m 3600sec 3600 (all of them are equivalent)_ |
+| lime-utils | safe_reboot     | { "action": "now" }                                               | Do not make /overlay/upper/etc backup; instead check that there's one already in place (/overlay/upper/.etc.last-good.tgz,then reboot and wait for fallback timeout.                                                                                                                                                                  |
+| lime-utils | safe_reboot     | { "action": "cancel" }                                            | Remove /overlay/upper/.etc.last-good.tgz (useful after a successful reboot)                                                                                                                                                                                                                                                           |
+| lime-utils | safe_reboot     | { "action": "discard" }                                           | Restores /overlay/upper/etc from /overlay/upper/.etc.last-good.tgz (useful to discard changes)                                                                                                                                                                                                                                        |
 
 ## Examples
 
@@ -17,4 +21,5 @@
 	"change_config":{"name":"String","ip":"String"}
 	"get_notes":{"no_params":"Integer"}
 	"get_node_status":{"no_params":"Integer"}
+	"safe_reboot":{"action":"String","value":"Table"}
 ```

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
@@ -189,13 +189,81 @@ local function change_config (msg)
     end
 end
 
+local function safe_reboot(msg)
+  local result = {}
+  local function getStatus()
+    local f = io.open('/overlay/upper/.etc.last-good.tgz', "rb")
+    if f then f:close() end
+    return f ~= nil
+  end
+
+  -- Get safe-reboot status
+  if msg.action == nil then
+    return printJson({ error = true })
+  end
+  if msg.action == 'status' then
+    result.stauts = getStatus()
+  end
+
+  --  Start safe-reboot
+  if msg.action =='start' then
+    local args = ''
+    if msg.value ~= nil then
+      if msg.value.wait ~= nil then
+        args = args..' -w '..msg.value.wait
+      end
+      if msg.value.fallback ~= nil then
+        args = args..' -f '..msg.value.fallback
+      end
+    end
+    local sr = assert(io.popen('safe-reboot'))
+    sr:close()
+    result.status = getStatus()
+    if result.status == true then
+      result.started = true
+    end
+  end
+
+  -- Rreboot now and wait for fallback timeout
+  if msg.action == 'now' then
+    local sr = assert(io.popen('safe-reboot now'))
+    result.status = getStatus()
+    result.now = result.status
+  end
+
+  -- Keep changes and stop safe-reboot
+  if msg.action =='cancel' then
+    result.status = true
+    result.canceled = false
+    local sr = assert(io.popen('safe-reboot cancel'))
+    sr:close()
+    if getStatus() == false then
+      result.status = false
+      result.canceled = true
+    end
+  end
+
+  --  Discard changes - Restore previous state and reboot
+  if msg.action =='discard' then
+    local sr = assert(io.popen('safe-reboot discard'))
+    sr:close()
+    result.status = getStatus()
+    if result.status == true then
+      result.started = true
+    end
+  end
+
+  return printJson(result)
+end
+
 local methods = {
     get_cloud_nodes = { no_params = 0 },
     get_node_status = { no_params = 0 },
     get_notes = { no_params = 0},
     set_notes = { text = 'value' },
     get_community_settings = { no_params = 0},
-    change_config = { name = 'value', ip = 'value' }
+    change_config = { name = 'value', ip = 'value' },
+    safe_reboot = { action = 'value', value = 'value' }
 }
 
 if arg[1] == 'list' then
@@ -211,6 +279,7 @@ if arg[1] == 'call' then
     elseif  arg[2] == 'set_notes' then set_notes(msg)
     elseif  arg[2] == 'get_community_settings' then get_community_settings(msg)
     elseif  arg[2] == 'change_config' then change_config(msg)
+    elseif  arg[2] == 'safe_reboot' then safe_reboot(msg)
     else printJson({ error = "Method not found" })
     end
 end

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
@@ -216,7 +216,7 @@ local function safe_reboot(msg)
         args = args..' -f '..msg.value.fallback
       end
     end
-    local sr = assert(io.popen('safe-reboot'))
+    local sr = assert(io.popen('safe-reboot '..args))
     sr:close()
     result.status = getStatus()
     if result.status == true then


### PR DESCRIPTION
# Safe reboot in ubus-lime-utils
Exposing safe-reboot methods via ubus is going to be useful to make changes from the ui safely.
It would be very interesting to have the timestamp of the next scheduled restart. Currently safe-reboot doesn't have how to get this information or I don't know where to extract it from.

| Path       | Procedure       | Signature                                                         | Description                                                                                                                                                                                                                                                                                                                           |
| ---------- | --------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| lime-utils | safe_reboot     | { "action": "status" }                                            | Get safe-reboot status                                                                                                                                                                                                                                                                                                                |
| lime-utils | safe_reboot     | { "action": "start", "value": {"wait": TIME, "fallback": TIME } } | After backing up /overlay/upper/etc, wait for TIME (value.wait) before reboot (Default: 5min). After boot, wait for TIME (value.fallback) before reverting /overlay/upper/etc from backup found in /overlay/upper/.etc.last-good.tgz (Default: 10min).<br> _TIME examples: 1hour 60min 60m 3600sec 3600 (all of them are equivalent)_ |
| lime-utils | safe_reboot     | { "action": "now" }                                               | Do not make /overlay/upper/etc backup; instead check that there's one already in place (/overlay/upper/.etc.last-good.tgz,then reboot and wait for fallback timeout.                                                                                                                                                                  |
| lime-utils | safe_reboot     | { "action": "cancel" }                                            | Remove /overlay/upper/.etc.last-good.tgz (useful after a successful reboot)                                                                                                                                                                                                                                                           |
| lime-utils | safe_reboot     | { "action": "discard" }                                           | Restores /overlay/upper/etc from /overlay/upper/.etc.last-good.tgz (useful to discard changes)                                                                                                                                                                                                                                       

