### PR TITLE
LimeApp updated to v0.2.0-alpha.5

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -39,7 +39,7 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/lime-app.defaults $(1)/etc/uci-defaults/90_lime-app
 	$(INSTALL_BIN) ./files/95-lime-app-rpc-acl $(1)/etc/uci-defaults/
-	@mkdir -p $(1)/usr/share/rpcd/acl.d || true
+	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d || true
 endef
 
 define Package/$(PKG_NAME)/postinst

--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (C) Libremesh 2017
 #
 # This is free software, licensed under the GNU General Public License v3.
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lime-app
-PKG_VERSION:=v0.1.0-alpha.4
+PKG_VERSION:=v0.2.0-alpha.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=582148b14ccde1eabb28cafae85d8cc44232a7e223ad8b0e352b7d0842c7cbb4
+PKG_HASH:=fe54150286f82f19fce29b064df2e64e9787495c532b7941be8257e0d909fd40
 PKG_SOURCE_URL:=https://github.com/libremesh/lime-app/releases/download/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
The current version of LimeApp in lime-packages is outdated with the current state of development.
I managed to implement a **continuous integration between libremesh/lime-app and libremesh/lime-packages**. When I publish a release (via tag) it automatically creates a branch with the Makefile updated in lime-packages.
This version improves the handling of calls to UBUS to avoid congestion and the first screens of FirstBootWizard in case the ubus module is installed.
There are also several fixes and minor features like text2speach in the alignment screen.

