### PR TITLE
Add First Boot Wizard and ubus-lime-fbw packages

### DIFF
--- a/packages/first-boot-wizard/Makefile
+++ b/packages/first-boot-wizard/Makefile
@@ -1,0 +1,30 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=first-boot-wizard
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+    TITLE:=$(PKG_NAME)
+    CATEGORY:=LiMe
+    MAINTAINER:=Marcos Gutierrez <gmarcos87@gmail.com>
+    URL:=http://libremesh.org
+
+endef
+
+define Package/$(PKG_NAME)/description
+	Scans surrounding LibreMesh networks and joins them.
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(CP) ./files/* $(1)/
+	@chmod a+x $(1)/etc/init.d/firstbootwizard
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/first-boot-wizard/files/bin/firstbootwizard
+++ b/packages/first-boot-wizard/files/bin/firstbootwizard
@@ -1,0 +1,6 @@
+#!/usr/bin/lua
+
+local fbw = require('firstbootwizard')
+
+print("[FBW] Scanning...")
+get_all_networks()

--- a/packages/first-boot-wizard/files/etc/init.d/firstbootwizard
+++ b/packages/first-boot-wizard/files/etc/init.d/firstbootwizard
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+USE_PROCD=1
+NAME=firstbootwizard
+PROG=/bin/firstbootwizard
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_close_instance
+}
+
+rescan() {
+	service_reload $PROG
+}

--- a/packages/first-boot-wizard/files/etc/uci-defaults/zzzz-serve-lime-config
+++ b/packages/first-boot-wizard/files/etc/uci-defaults/zzzz-serve-lime-config
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ln -s /etc/config/lime-defaults /www/lime-defaults

--- a/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
+++ b/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
@@ -1,0 +1,364 @@
+#!/usr/bin/lua
+
+require "ubus"
+local json = require 'luci.json'
+local ft = require('firstbootwizard.functools')
+local iwinfo = require("iwinfo")
+local wireless = require("lime.wireless")
+local fs = require("nixio.fs")
+local uci = require("uci")
+local nixio = require "nixio"
+
+local conn = ubus.connect()
+if not conn then
+    error("Failed to connect to ubus")
+end
+
+local function execute(cmd)
+    local f = assert(io.popen(cmd, 'r'))
+    local s = assert(f:read('*a'))
+    f:close()
+    return s
+end
+
+local function eui64(mac)
+    local cmd = [[
+    function eui64 {
+        mac="$(echo "$1" | tr -d : | tr A-Z a-z)"
+        mac="$(echo "$mac" | head -c 6)fffe$(echo "$mac" | tail -c +7)"
+        let "b = 0x$(echo "$mac" | head -c 2)"
+        let "b ^= 2"
+        printf "%02x" "$b"
+        echo "$mac" | tail -c +3 | head -c 2
+        echo -n :
+        echo "$mac" | tail -c +5 | head -c 4
+        echo -n :
+        echo "$mac" | tail -c +9 | head -c 4
+        echo -n :
+        echo "$mac" | tail -c +13
+    }
+    echo -n `eui64 ]]..mac..'`'
+    return 'fe80::'..execute(cmd)
+end
+
+function file_exists(filename)
+    return fs.stat(filename, "type") == "reg"
+end
+
+local function check_file_exists(file)
+    local f = io.open(file, "rb")
+    if f then f:close() end
+    return f ~= nil
+end  
+
+local function split(str, sep)
+    local sep, fields = sep or ":", {}
+    local pattern = string.format("([^%s]+)", sep)
+    str:gsub(pattern, function(c) fields[#fields+1] = c end)
+    return fields
+end
+
+-- splits a multiline string in a list of strings, one per line
+local function lsplit(mlstring)
+    return split(mlstring, "\n")
+end
+
+local function phy_to_idx(phy)
+    local substr = string.gsub(phy, "phy", "")
+    return tonumber(substr)
+end
+
+function get_networks()
+    local thisBssids = {}
+    local wirelessConfig = conn:call("network.wireless", "status", {})
+    local allRadios = wireless.scandevices()
+    -- nixio.syslog("crit", "FBW radios "..json.encode(allRadios))
+    local all_networks = {}
+    local phys = {}
+    for _, radio in pairs (allRadios) do
+        if wireless.is5Ghz(radio[".name"]) then
+            local phyIndex = radio[".name"].sub(radio[".name"], -1)
+            phys[#phys+1] = "phy"..phyIndex
+            -- nixio.syslog("crit", "FBW thisBssids"..json.encode(wirelessConfig["radio"..phyIndex]))
+            table.insert(thisBssids, wirelessConfig["radio"..phyIndex].interfaces[1].config.bssid)
+        end
+    end
+    -- -- nixio.syslog("crit", "FBW thisBssids"..json.encode(thisBssids))
+    -- -- nixio.syslog("crit", "FBW phys"..json.encode(phys))
+    for idx, phy in pairs(phys) do
+        networks = iwinfo.nl80211.scanlist(phy)
+        -- nixio.syslog("crit", "FBW networs"..json.encode(networks))
+        for k,network in pairs(networks) do
+            if network.signal ~= -256 then
+                network["phy"] = phy
+                network["phy_idx"] = phy_to_idx(phy)
+                all_networks[#all_networks+1] = network
+            end
+        end
+    end
+    return all_networks
+end
+
+function backup_wifi_config()
+    execute("cp /etc/config/wireless /tmp/wireless-temp")
+end
+
+function restore_wifi_config()
+    execute("cp /tmp/wireless-temp /etc/config/wireless")
+    local allRadios = wireless.scandevices()
+    for _, radio in pairs (allRadios) do
+        if wireless.is5Ghz(radio[".name"]) then
+            local phyIndex = radio[".name"].sub(radio[".name"], -1)
+            execute("wifi down radio"..phyIndex.."; wifi up radio"..phyIndex)
+        end
+    end
+end
+
+function connect(mesh_network)
+    local phy_idx = mesh_network["phy_idx"]
+    local mode = mesh_network.mode == "Mesh Point" and 'mesh' or 'adhoc'
+    local device_name = "lm_wlan"..phy_idx..""..mode.."_radio"..phy_idx
+
+    -- nixio.syslog("crit", "FBW Connection to "..mesh_network.ssid)
+    -- nixio.syslog("crit", "FBW in "..device_name)
+
+    local uci_cursor = uci.cursor()
+    -- remove networks
+    uci_cursor:foreach("wireless", "wifi-iface", function(entry)
+        if entry['.name'] == device_name then
+            uci_cursor:delete("wireless", entry['.name']) 
+        end
+    end)
+
+    -- set wifi config
+    uci_cursor:set("wireless", 'radio'..phy_idx, "channel", mesh_network.channel)
+    uci_cursor:set("wireless", device_name, "wifi-iface")
+    uci_cursor:set("wireless", device_name, "device", 'radio'..phy_idx)
+    uci_cursor:set("wireless", device_name, "ifname", 'wlan'..phy_idx..'-'..mode)
+    uci_cursor:set("wireless", device_name, "network", 'lm_net_wlan'..phy_idx..'_'..mode)
+    uci_cursor:set("wireless", device_name, "distance", '1000')
+    uci_cursor:set("wireless", device_name, "mode", mode)
+    uci_cursor:set("wireless", device_name, "mesh_id", 'LiMe')
+    uci_cursor:set("wireless", device_name, "ssid", 'LiMe')
+    uci_cursor:set("wireless", device_name, "mesh_fwding", '0')
+    uci_cursor:set("wireless", device_name, "bssid", 'ca:fe:00:c0:ff:ee')
+    uci_cursor:set("wireless", device_name, "mcast_rate", '24000')
+
+    uci_cursor:commit("wireless")
+
+    -- nixio.syslog("crit", "FBW applying WIFI ")
+    -- apply wifi config
+    execute("wifi down radio"..phy_idx.."; wifi up radio"..phy_idx)
+end
+
+function fetch_config(data)
+    print(json.encode(data))
+    local host = data.host
+    local signal = data.signal
+    local ssid = data.ssid
+    local filename = "/tmp/lime-defaults__signal__"..(signal * -1).."__ssid__"..ssid.."__host__"..host
+    -- nixio.syslog("crit", "FBW fetching "..host)
+    os.execute("sleep 5s")
+    os.execute("/bin/wget http://["..host.."]/lime-defaults -O "..filename.." &")
+    return file_exists(filename) and filename or nil
+end
+
+function get_stations_macs(network)
+    -- nixio.syslog("crit", "FBW get_stations_macs "..network)
+    return lsplit(execute('iw dev '..network..' station dump | grep ^Station | cut -d\\  -f 2'))
+end
+
+local function getAp(path)
+    local uci_cursor = uci.cursor("/tmp")
+    local ap_ssid = uci_cursor:get(path, "wifi", "ap_ssid")
+    if ap_ssid ~= nil then
+	return ap_ssid
+    end
+    return ""
+end
+
+function read_configs()
+    local tempFiles = fs.dir("/tmp/")
+    local result = {}
+    for file in tempFiles do
+        if (file ~= nil and file:sub(1, 12) == "lime-default") then
+            local ap = getAp(file)
+	    print(file)
+            table.insert(result, {
+                ap = string.gsub(ap, "\"", ""),
+                file = file
+            })
+        end
+    end
+    return result
+end
+
+function read_file(file)
+    local lines = lines_from("/tmp/"..file)
+    -- for k,v in pairs(lines) do
+    --     -- nixio.syslog("crit", 'line[' .. k .. ']'..v)
+    -- end
+    return lines
+end
+
+local function tableEmpty(self)
+    for _, _ in pairs(self) do
+        return false
+    end
+    return true
+end
+
+function get_config(mesh_network)
+    local mode = mesh_network.mode == "Mesh Point" and 'mesh' or 'adhoc'
+    local dev_id = 'wlan'..mesh_network['phy_idx']..'-'..mode
+    -- nixio.syslog("crit", "FBW MESH_NETWORK "..json.encode(mesh_network))
+    connect(mesh_network)
+    -- check if connected if not sleep some more until connected or ignore if 10s passed
+    local isAssociated = iwinfo.nl80211.assoclist(dev_id)
+    local i = 0
+    while (tableEmpty(isAssociated)) and i < 5 do
+        isAssociated = iwinfo.nl80211.assoclist(dev_id)
+        -- nixio.syslog("crit", "FBW trying to associate "..json.encode(isAssociated)..i)
+        i = i + 1
+        os.execute("sleep 5s")
+    end
+    local stations = get_stations_macs(dev_id)
+    
+    local append_network = ft.curry(function (s1, s2) return s2..'%'..s1 end, 2) (dev_id)
+    local linksLocalIpv6 = ft.map(eui64, stations)
+    local hosts = ft.map(append_network, linksLocalIpv6)
+    -- nixio.syslog("crit", "FBW DEV ID "..json.encode(dev_id))
+    -- nixio.syslog("crit", "FBW LINKS LOCALS "..json.encode(linksLocalIpv6))
+    -- nixio.syslog("crit", "FBW HOSTS "..json.encode(hosts))
+    
+    local function addData (host)
+    	return {host = host, signal = mesh_network.signal, ssid = mesh_network.ssid }
+    end
+
+    local data = ft.map(addData, hosts)
+
+    configs = ft.map(fetch_config, data)
+    return ft.filter(function(el) return el ~= nil end, configs)
+end
+
+function unpack_table(t)
+    local unpacked = {}
+    for k,v in ipairs(t) do
+        for sk, sv in ipairs(v) do
+            unpacked[#unpacked+1] = sv
+        end
+    end
+    return unpacked
+end
+
+function hash_file(file)
+    return execute("md5sum "..file.." | awk '{print $1}'")
+end
+
+function are_files_different(file1, file2)
+    return hash_file(file1) ~= hash_file(file2)
+end
+
+function clean_lime_config()
+    local f = io.open("/etc/config/lime", "w")
+    local command = [[
+        config lime system
+        config lime network
+        config lime wifi
+    ]]
+    local s = f:write(command)
+    f:close()
+end
+
+function apply_config(file)
+    -- TODO: check if config is valid
+    local filePath = "/tmp/"..file
+    check_file_exists(filePath)
+    -- nixio.syslog("crit", "FBW FILE EXISTS ")
+    execute("rm /etc/config/lime")
+    execute("cp "..filePath.." /etc/config/lime-defaults")
+    -- nixio.syslog("crit", "FBW FILE COPIED ")
+    clean_lime_config()
+    -- nixio.syslog("crit", "FBW LIME CONFIG CLEANED ")
+    execute("/rom/etc/uci-defaults/91_lime-config")
+    execute("rm /etc/first_run")
+    -- nixio.syslog("crit", "APPLY CONFIGS ")
+    os.execute("(( /usr/bin/lime-config && /usr/bin/lime-apply && reboot 0<&- &>/dev/null &) &)")
+end
+
+function filter_mesh(n)
+    return n.mode == "Ad-Hoc" or n.mode == "Mesh Point"
+end
+
+local function start_scan_file()
+    local file = io.open("/tmp/scanning", "w")
+    file:write("true")
+    file:close()
+end
+
+local function stop_scan()
+    local file = io.open("/tmp/scanning", "w")
+    file:write("false")
+    file:close()
+end
+
+function check_scan_file()
+    local file = io.open("/tmp/scanning", "r")
+    if(file == nil) then
+        return nil
+    end
+    return assert(file:read("*a"), nil)
+end
+
+function check_lock_file()
+    local file = io.open("/etc/first_run", "r")
+    if(file == nil) then
+        return false
+    end
+    return true
+end
+
+function remove_lock_file()
+    execute("rm /etc/first_run")
+end
+
+function apply_user_configs(configs)
+    local name = configs.ssid
+    local uci_cursor = uci.cursor()
+    -- nixio.syslog("crit", "FBW apply_user_configs ssid "..ssid)
+    uci_cursor:set("lime-defaults", 'wifi', 'ap_ssid', name)
+    uci_cursor:set("lime-defaults", 'wifi', 'apname_ssid', name..'/%H')
+    uci_cursor:set("lime-defaults", 'wifi', 'adhoc_ssid', 'LiMe.'..name..'/%H')
+    uci_cursor:set("lime-defaults", 'wifi', 'ieee80211s_mesh_id', 'LiMe.'..name..'/%H')
+    uci_cursor:commit("lime-defaults")
+
+    -- Apply config and reboot
+    execute("rm /etc/config/lime")
+    clean_lime_config()
+    execute("/rom/etc/uci-defaults/91_lime-config")
+    execute("rm /etc/first_run")
+    os.execute("(( /usr/bin/lime-config && /usr/bin/lime-apply && reboot 0<&- &>/dev/null &) &)")
+
+    return { configs = configs }
+end
+
+local function printParam(text,campo) 
+    return function(objeto) 
+        -- nixio.syslog("crit", text..': '..objeto[campo])
+    end
+end
+
+function get_all_networks()
+    start_scan_file()
+    local networks = get_networks()
+    ft.map(printParam('FBW MESH - All Networlk ssid','ssid'), networks)
+    local all_mesh = ft.filter(filter_mesh, networks)
+    ft.map(printParam('FBW MESH - Only mesh Network ssid','ssid'), all_mesh)
+    backup_wifi_config()
+    local configs = unpack_table(ft.map(get_config, all_mesh))
+    restore_wifi_config()
+
+    local equal_than_mine = ft.curry(are_files_different)('/etc/config/lime-defaults')
+    -- local configs = ft.filter(equal_than_mine, configs)
+    stop_scan()
+end

--- a/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard/functools.lua
+++ b/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard/functools.lua
@@ -1,0 +1,124 @@
+functools = {}
+
+-- Lua implementation of the curry function
+-- Developed by tinylittlelife.org
+-- released under the WTFPL (http://sam.zoy.org/wtfpl/)
+
+-- curry(func, num_args) : take a function requiring a tuple for num_args arguments
+--              and turn it into a series of 1-argument functions
+-- e.g.: you have a function dosomething(a, b, c)
+--       curried_dosomething = curry(dosomething, 3) -- we want to curry 3 arguments
+--       curried_dosomething (a1) (b1) (c1)  -- returns the result of dosomething(a1, b1, c1)
+--       partial_dosomething1 = curried_dosomething (a_value) -- returns a function
+--       partial_dosomething2 = partial_dosomething1 (b_value) -- returns a function
+--       partial_dosomething2 (c_value) -- returns the result of dosomething(a_value, b_value, c_value)
+function functools.curry(func, num_args)
+
+    -- currying 2-argument functions seems to be the most popular application
+    num_args = num_args or 2
+
+    -- helper
+    local function curry_h(argtrace, n)
+        if 0 == n then
+            -- reverse argument list and call function
+            return func(functools.reverse(argtrace()))
+        else
+            -- "push" argument (by building a wrapper function) and decrement n
+            return function (onearg)
+                return curry_h(function () return onearg, argtrace() end, n - 1)
+            end
+        end
+    end
+
+    -- no sense currying for 1 arg or less
+    if num_args > 1 then
+        return curry_h(function () return end, num_args)
+    else
+        return func
+    end
+end
+
+-- reverse(...) : take some tuple and return a tuple of	elements in reverse order
+--
+-- e.g.	"reverse(1,2,3)" returns 3,2,1
+function functools.reverse(...)
+
+    --reverse args by building a function to do it, similar to the unpack() example
+    local function reverse_h(acc, v, ...)
+        if 0 == select('#', ...) then
+            return v, acc()
+        else
+            return reverse_h(function () return v, acc() end, ...)
+        end
+    end
+
+    -- initial acc is the end of the list
+    return reverse_h(function () return end, ...)
+end
+
+
+function functools.map(func, tbl)
+    local newtbl = {}
+    for i,v in pairs(tbl) do
+        newtbl[i] = func(v)
+    end
+    return newtbl
+end
+
+function functools.filter(func, tbl)
+    local newtbl= {}
+    local index=1;
+    for i,v in pairs(tbl) do
+        if func(v, i) then
+            newtbl[index]=v
+            index = index + 1
+        end
+    end
+    return newtbl
+end
+
+function functools.search(func, tbl)
+    for i,v in pairs(tbl) do
+        if func(v, i) then
+            return i
+        end
+    end
+
+    return 0
+end
+
+function functools.print_r ( t )
+    local print_r_cache={}
+    local function sub_print_r(t,indent)
+        if (print_r_cache[tostring(t)]) then
+            print(indent.."*"..tostring(t))
+        else
+            print_r_cache[tostring(t)]=true
+            if (type(t)=="table") then
+                for pos,val in pairs(t) do
+                    if (type(val)=="table") then
+                        print(indent.."["..pos.."] => "..tostring(t).." {")
+                        sub_print_r(val,indent..string.rep(" ",string.len(pos)+8))
+                        print(indent..string.rep(" ",string.len(pos)+6).."}")
+                    elseif (type(val)=="string") then
+                        print(indent.."["..pos..'] => "'..val..'"')
+                    else
+                        print(indent.."["..pos.."] => "..tostring(val))
+                    end
+                end
+            else
+                print(indent..tostring(t))
+            end
+        end
+    end
+    if (type(t)=="table") then
+        print(tostring(t).." {")
+        sub_print_r(t," ")
+        print("}")
+    else
+        sub_print_r(t," ")
+    end
+    print()
+end
+
+return functools

--- a/packages/ubus-lime-fbw/Makefile
+++ b/packages/ubus-lime-fbw/Makefile
@@ -1,0 +1,30 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ubus-lime-fbw
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=ubus
+  CATEGORY:=Ubus
+  MAINTAINER:=Marcos Gutierrez <gmarcos87@gmail.com>
+  SUBMENU:=3. Applications
+  TITLE:=Libremesh first boot wizard ubus module
+  DEPENDS:= +lua +libubox-lua +libubus-lua +libuci
+  PKGARCH:=all
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(CP) ./files/* $(1)/
+	@chmod a+x $(1)/usr/libexec/daemon/lime-fbw
+	@chmod a+x $(1)/etc/init.d/ubus-lime-fbw
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/ubus-lime-fbw/README.md
+++ b/packages/ubus-lime-fbw/README.md
@@ -1,0 +1,20 @@
+# FirstBootWizard Libremesh ubus module
+
+| Path     | Procedure       | Signature          | Description                               |
+| -------- | --------------- | ------------------ | ----------------------------------------- |
+| lime-fbw | status          | {}                 | Get FBW status (scanning, lock, disabled) |
+| lime-fbw | create_network  | {"name": "string"} | Create network                            |
+| lime-fbw | search_networks | {"scan": true      | false}                                    | Get all networks (true force rescan) |
+| lime-fbw | set_network     | {"file": "string"} | Use one of the results                    |
+
+## Examples
+
+### ubus -v list lime-fbw
+
+```
+''lime-fbw' @4c5b89e0
+	"status":{}
+	"create_network":{"name":"String"}
+	"search_networks":{"scan":"Boolean"}
+	"set_network":{"file":"String"}
+```

--- a/packages/ubus-lime-fbw/files/etc/init.d/ubus-lime-fbw
+++ b/packages/ubus-lime-fbw/files/etc/init.d/ubus-lime-fbw
@@ -1,0 +1,21 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+USE_PROCD=1
+NAME=fbw
+PROG=/usr/libexec/daemon/lime-fbw
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_close_instance
+}
+
+stop() {
+	service_stop $PROG
+}
+
+reload() {
+	service_reload $PROG
+}

--- a/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
+++ b/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
@@ -1,0 +1,83 @@
+#!/usr/bin/lua
+
+require "ubus"
+require "uloop"
+local fbw = require 'firstbootwizard'
+local nixio = require "nixio"
+local json = require 'luci.json'
+
+uloop.init()
+
+local conn = ubus.connect()
+if not conn then
+	error("Failed to connect to ubus")
+end
+
+local methods = {
+    ['lime-fbw'] = {
+        search_networks = {
+            function(req, msg)
+                local scan_file = check_scan_file()
+                local status
+                if(scan_file == nil) or (msg.scan == true) then
+                    os.execute("rm /tmp/scanning")
+                    os.execute("(( /usr/bin/lua /bin/firstbootwizard 0<&- &>/dev/null &) &)")
+                end
+                if (scan_file == nil) or (scan_file == "true") or (msg.scan == true) then
+                    status = 'scanning'
+                else
+                    status = 'scanned'
+                end
+                conn:reply(req, {status= status, networks = read_configs()})
+
+            end, { scan = ubus.BOOLEAN }
+        },
+        status = {
+            function(req, msg)
+                local scan_status
+                local scan_file = check_scan_file()
+                -- if no scan file return 0
+                if scan_file == nil then scan_status = 0
+                -- if scanning return 1
+                elseif scan_file == "true" then scan_status = 1
+                -- if done scanning return 2
+                elseif scan_file == "false" then scan_status = 2
+                end
+                local lock_file = check_lock_file()
+                local status = {
+                    lock = lock_file,
+                    scan = scan_status
+                }
+                conn:reply(req, status)
+            end, {}
+        },
+        set_network = {
+            function(req, msg)
+                local file = msg.file
+                -- apply lime config
+                conn:reply(req, { status = 'configuring' })
+                -- os.execute('sleep 2s')
+                apply_config(file)
+                -- remove lock?
+                -- remove_lock_file()
+            end, { file = ubus.STRING }
+        },
+        create_network = {
+            function(req, msg)
+                local configs = {}
+                if (msg.name ~= nil) then
+                    configs["ssid"] = msg.name
+                end
+                if (configs ~= nil) then
+                    apply_user_configs(configs)
+                end
+                -- remove lock?
+                -- remove_lock_file()
+                conn:reply(req, { status = 'done' })
+            end, { name = ubus.STRING }
+        }
+    }
+}
+
+conn:add(methods)
+uloop.run()

--- a/packages/ubus-lime-fbw/files/usr/share/rpcd/acl.d/lime-fbw.json
+++ b/packages/ubus-lime-fbw/files/usr/share/rpcd/acl.d/lime-fbw.json
@@ -1,0 +1,15 @@
+{
+    "lime-app": {
+        "description": "First Boot Wizard ubus interface",
+        "read": {
+            "ubus": {
+                "lime-fbw": ["*"]
+            }
+        },
+        "write": {
+            "ubus": {
+                "lime-fbw": ["*"]
+            }
+        }
+    }
+}


### PR DESCRIPTION
# first-boot-wizard
First Boot Wizar allows you to analyze nearby mesh nodes and extract the base configuration to be part of the network. Once copied the configurations the user can select in LimeApp which one to use to configure his node or if he wants to create a new network.

**How does it work?**

If when turning on the node detects that it does not have a configuration applied (/etc/first_run exist) it scans all the networks and selects the mesh and ad-hocs. Then switch to the channel of each network and try to make a wget via fe80 to extract the configuration. After doing the full scan it goes back to the previous configuration.
The downloaded lime-default files are saved in /tmp and are exposed via lime-app to the user.
There are still many things to improve and optimize, but this version meets the MVP requirements we had planned.

# ubus-lime-fbw
| Path     | Procedure       | Signature          | Description                               |
| -------- | --------------- | ------------------ | ----------------------------------------- |
| lime-fbw | status          | {}                 | Get FBW status (scanning, lock, disabled) |
| lime-fbw | create_network  | {"name": "string"} | Create network                            |
| lime-fbw | search_networks | {"scan": true      | false}                                    | Get all networks (true force rescan) |
| lime-fbw | set_network     | {"file": "string"} | Use one of the results                    |

## Examples

### ubus -v list lime-fbw

```
''lime-fbw' @4c5b89e0
	"status":{}
	"create_network":{"name":"String"}
	"search_networks":{"scan":"Boolean"}
	"set_network":{"file":"String"}
```

## Disclaimer
>This pull request does not add any dependencies, so the feature will be available only if you indicate that you want to install the package.