### PR TITLE
Add last_internet script

### DIFF
--- a/packages/ubus-lime-metrics/Makefile
+++ b/packages/ubus-lime-metrics/Makefile
@@ -25,6 +25,8 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/
 	$(CP) ./files/* $(1)/
 	@chmod a+x $(1)/usr/libexec/rpcd/lime-metrics
+	@chmod a+x $(1)/etc/uci-defaults/99-save-last-known-path-to-internet
+	@chmod a+x $(1)/usr/sbin/last_internet
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/ubus-lime-metrics/files/etc/uci-defaults/99-save-last-known-path-to-internet
+++ b/packages/ubus-lime-metrics/files/etc/uci-defaults/99-save-last-known-path-to-internet
@@ -1,0 +1,5 @@
+#!/bin/sh
+echo "adding cron to save last known path to the Internet"
+sed "\| \* \* \* .*last_internet_path.*|d" -i /etc/crontabs/root
+echo "*/30 * * * * /usr/sbin/internet_path > /tmp/last_internet; if [ -s /tmp/last_internet ] && [\ "$(md5sum /tmp/last_internet | awk '{ print $1 }')\" != \"$(md5sum /etc/last_internet |  awk '{ print $1 }
+')\" ]; then cp /tmp/last_internet /etc/last_internet; fi" >>  /etc/crontabs/root

--- a/packages/ubus-lime-metrics/files/usr/sbin/last_internet
+++ b/packages/ubus-lime-metrics/files/usr/sbin/last_internet
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# TO DO:
+ # This script needs some volunteer work
+ # It currently gets the path through bmx6 (currently the default of libremesh), 
+ # but it should actually be able to detect which protocol is being used and 
+ # use a strategy for each case.
+
+default_dev=`ip r | grep "default dev" | cut -d' ' -f3`;
+gw=`bmx6 -c show tunnels | grep $default_dev | grep inet4 | awk '{ print $10 }'`;
+
+# if 8.8.8.8 is accessible, save internet path to file
+if ping -q -c5 -w10 8.8.8.8 &>/dev/null
+    then path=`mtr -6 -r -c 1 $gw.mesh  | grep "\.|" |  awk '{ print $2}' | cut -d'.' -f1`
+    printf "$path"
+fi


### PR DESCRIPTION
Recovers the ability to remember in the node the last route to the Internet. At the moment it does it only for bmx6 but it should contemplate other protocols layer 3.
The script runs every 30 minutes but only writes changes if it detects a difference with the previous route.
It is important to diagnose network problems, such as nodes gone off or broken links.
LimeApp uses this route to check for problems when the internet is not detected.

This recovers the work done by @nicoechaniz  in lime-orange-rpc (https://github.com/libremesh/lime-ui-ng/blob/8a4fb7df3ec9809d1f4dbf50ad590428a4b3bf1f/lime-api-orange-rpc/files/usr/sbin/internet_path)