### PR TITLE
LimeApp updated to v0.2.0-alpha.7

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lime-app
-PKG_VERSION:=v0.2.0-alpha.6
+PKG_VERSION:=v0.2.0-alpha.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=941f50f47a32cd1ed4d11f5b81f975ec0bebdae2c290b3acc55a76335b56984f
+PKG_HASH:=e612dcf10f90c9cb01680f729c3c5447146095f1407b847b90a24b615085a72d
 PKG_SOURCE_URL:=https://github.com/libremesh/lime-app/releases/download/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Improves interoperability between browsers by removing the use of the crypro API, which Chrome only enables in secure sources (HTTPS and localhost).