### PR TITLE
Add stale github bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,58 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 356
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 30
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+    release-blocker
+    "user story"
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: wontfix
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
# Automatic housekeeping for pull-request and issues
I was recently reviewing the issues and pull-request of lime-packages. It is a very arduous and repetitive task. It occurred to me to look for some tool to do that monitoring and to warn of issues or pull-request abandoned, since many of them can be important. I found that github has its own bot to perform this task: stale.
This pull request incorporates the configuration for this bot, the proposed operation is as follows:
- Alert about issues without activity for X days (one year, two months, whatever we want)
- If after that warning there is no activity after Y number of days the issue or pull request is closed and a particular tag (autoclose, wontfix, etc) is applied.
- The bot ignores the issues marked with the tags we want (release-blocker, bug, user history, etc).

I think it's a very good tool, if you agree we can use this pull-request to polish the options of days and tags.

## My proposal is:
- Days for the first alert: 60
- Subsequent days to close if there is no activity: 15
- Tags to ignore: release-blocker, bug, user history
- Closed Tag: closed-by-bot