### PR TITLE
LimeApp updated to v0.2.0-alpha.9 - Fix api calls

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lime-app
-PKG_VERSION:=v0.2.0-alpha.7
+PKG_VERSION:=v0.2.0-alpha.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=e612dcf10f90c9cb01680f729c3c5447146095f1407b847b90a24b615085a72d
+PKG_HASH:=cf1b6bffe2070c39d3d1547eac27683ef57260eec0c6d87719a0a487f56cd2ba
 PKG_SOURCE_URL:=https://github.com/libremesh/lime-app/releases/download/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Remove window.crypto. Chrome only allows its use in secure environments (https or localhost)
Instead I implement a simple form of hash that fulfills the function.