### PR TITLE
Enable ubus cors in uhttpd

### DIFF
--- a/packages/lime-app/files/lime-app.defaults
+++ b/packages/lime-app/files/lime-app.defaults
@@ -5,4 +5,6 @@ uci set rpcd.@login[1].password='$1$$ta3C2yX4TvVObdaJyQ9Md1'
 uci add_list rpcd.@login[1].read='lime-app'
 uci add_list rpcd.@login[1].write='lime-app'
 uci commit rpcd
+uci set uhttpd.main.ubus_cors='1'
+uci commit uhttpd
 exit 0


### PR DESCRIPTION
This allows you to consume the ubus api from another domain. This way LimeApp can consume the api of the different nodes without having to recharge all the assets.