### PR TITLE
create hotplug.d/lime-config directory at install time

### DIFF
--- a/packages/lime-system/Makefile
+++ b/packages/lime-system/Makefile
@@ -54,6 +54,7 @@ LIME_VERSION_SED:=$(SED)   's,%LIME_ID%,$(LIME_ID),g' \
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/
 	$(CP) ./files/* $(1)/
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/lime-config/
 	$(LIME_VERSION_SED) \
 		$(1)/etc/lime_release \
 		$(1)/etc/uci-defaults/90_lime-banner


### PR DESCRIPTION
Fixes `/usr/bin/lua: /usr/bin/lime-config:54: attempt to call a nil` value when running lime-config

Tested in a LibreRouter, after applying fix:
```
root@LiMe-8851a5:~# lime-config 
Clearing wireless config...
Clearing network config...
Disabling odhcpd
sh: /etc/init.d/odhcpd: not found
Cleaning dnsmasq
Disabling 6relayd...
lime.proto.babeld.configure(...)
Use fallback value for network.babeld_over_librenet6: false
lime.proto.babeld.setup_interface(...)	eth0.1
lime.proto.babeld.setup_interface(...)	wlan1-ap	ignored
lime.proto.babeld.setup_interface(...)	wlan0-apname	ignored
lime.proto.babeld.setup_interface(...)	wlan1-apname	ignored
lime.proto.babeld.setup_interface(...)	wlan2-mesh
lime.proto.babeld.setup_interface(...)	wlan0-mesh
lime.proto.babeld.setup_interface(...)	wlan2-ap	ignored
lime.proto.babeld.setup_interface(...)	wlan0-ap	ignored
lime.proto.babeld.setup_interface(...)	eth1.2
lime.proto.babeld.setup_interface(...)	wlan2-apname	ignored
lime.proto.babeld.setup_interface(...)	wlan1-mesh
lime.proto.babeld.setup_interface(...)	eth0
lime.proto.babeld.setup_interface(...)	eth1
Configuring system...
Let uhttpd listen on IPv4/IPv6
```

Signed-off-by: Santiago Piccinini <spiccinini@altermundi.net>