### PR TITLE
use channels 157 and 48 for 5.8GHz

### DIFF
--- a/packages/lime-system/files/etc/config/lime-defaults-factory
+++ b/packages/lime-system/files/etc/config/lime-defaults-factory
@@ -45,7 +45,8 @@ config lime network
 
 config lime wifi
 	option channel_2ghz '11'
-	option channel_5ghz '48'
+	list channel_5ghz '157'
+	list channel_5ghz '48'
 	option htmode_5ghz 'HT40'
 	option distance_2ghz '100'
 	option distance_5ghz '1000'


### PR DESCRIPTION
channel 157 is FCC approved for outdoor use

Signed-off-by: Santiago Piccinini <spiccinini@altermundi.net>

TODO: test with devices with only one radio