### PR TITLE
Add shared-state.options.candidates list

### DIFF
--- a/packages/shared-state-persist/files/usr/bin/shared-state-persist
+++ b/packages/shared-state-persist/files/usr/bin/shared-state-persist
@@ -28,7 +28,7 @@
 local nixio = require('nixio')
 local fs = nixio.fs
 
-local sharedStateFolder = '/shared-state
+local sharedStateFolder = "/shared-state"
 local sharedStateDefaultLocation = "/var/shared-state"
 
 local NEW_DEVICE = 0

--- a/packages/shared-state/files/etc/config/shared-state
+++ b/packages/shared-state/files/etc/config/shared-state
@@ -1,2 +1,2 @@
 config shared-state 'options'
-	#list candidates '10.13.0.2'
+	#list candidates 'http://10.13.0.2/cgi-bin/shared-state/'

--- a/packages/shared-state/files/etc/config/shared-state
+++ b/packages/shared-state/files/etc/config/shared-state
@@ -1,0 +1,2 @@
+config shared-state 'options'
+	#list candidates '10.13.0.2'

--- a/packages/shared-state/files/usr/bin/shared-state
+++ b/packages/shared-state/files/usr/bin/shared-state
@@ -21,6 +21,7 @@ local http = require("luci.httpclient")
 local JSON = require("luci.jsonc")
 local nixio = require("nixio")
 require("nixio.util")
+local uci = require("uci")
 
 sharedState = {}
 
@@ -83,6 +84,15 @@ function sharedState.sync(urls)
 	urls = urls or {}
 
 	if #urls < 1 then
+
+		local uci_cursor = uci:cursor()
+		local fixed_candidates = uci_cursor:get("shared-state", "options","candidates") or {}
+		for _, line in pairs(fixed_candidates) do
+			table.insert(
+				urls,
+				"http://"..line.."/cgi-bin/shared-state/"..sharedState.dataType )
+		end
+
 		io.input(io.popen(arg[0].."-get_candidates_neigh"))
 		for line in io.lines() do
 			table.insert(

--- a/packages/shared-state/files/usr/bin/shared-state
+++ b/packages/shared-state/files/usr/bin/shared-state
@@ -90,7 +90,7 @@ function sharedState.sync(urls)
 		for _, line in pairs(fixed_candidates) do
 			table.insert(
 				urls,
-				"http://"..line.."/cgi-bin/shared-state/"..sharedState.dataType )
+				line.."/"..sharedState.dataType )
 		end
 
 		io.input(io.popen(arg[0].."-get_candidates_neigh"))


### PR DESCRIPTION
Allows you to specify additional IPs addresses using uci configurations.
Until we advance in a more fully functional scheme this option will allow us to maintain one or more masters or replicators. It is not necessary that they are routers, it is possible to program a http server for some more powerful device or destined to that end.
These ips are determined by a list in /etc/config/shared-state. 
A commented option is included in this pull request as an example.