### PR TITLE
Fix typos in lime-utils and safe-upgrade

### DIFF
--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -272,7 +272,7 @@ function confirm(args)
         os.exit(113)
     end
 
-    print("Canceling and disabling automatic rebool")
+    print("Canceling and disabling automatic reboot")
     os.execute("/etc/init.d/safe_upgrade_auto_reboot stop")
     os.execute("/etc/init.d/safe_upgrade_auto_reboot disable")
 
@@ -321,7 +321,7 @@ function parse_args()
                    "Set the timeout (in seconds) of the automatic reboot safety mechanism")
                    :default('600'):convert(validate_safety_timeout)
 
-    local confirm = parser:command('confirm', ('Confirm the current partition. Use when after an upgrade' ..
+    local confirm = parser:command('confirm', ('Confirm the current partition. Use when after an upgrade ' ..
                                               'or after running "test-other-partition".'))
 
     local bootstrap = parser:command('bootstrap', 'Install the safe-upgrade mechanism')

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
@@ -195,7 +195,7 @@ local function change_config (msg)
             country = country
         }})
         shell("lime-config && reboot")
-        printJson({ status = 'ok'})|
+        printJson({ status = 'ok'})
     else
         printJson({ status = 'error', msg = 'You must enter a hostname' })
     end


### PR DESCRIPTION
Solve a couple of typing errors in safe-upgrade and an extra character in lime-utills