### PR TITLE
Fixes empty file bug.

### DIFF
--- a/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
+++ b/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
@@ -27,7 +27,7 @@ get_uptime()
 
 cacheFile="/tmp/shared-state-get_candidates_neigh.cache"
 lastRunFile="/tmp/shared-state-get_candidates_neigh.lastrun"
-lastRun=$(cat "$lastRunFile" 2>/dev/null || echo -9999)
+lastRun=$(if [ -s $lastRunFile ]; then echo $(cat $lastRunFile); else  echo -9999; fi)
 currUptime="$(get_uptime)"
 
 [ "$(($currUptime - $lastRun))" -lt "90" ] &&


### PR DESCRIPTION
Expected behaviour: when the lastrun file exists but it's empty, the program continues.
Actual behaviour: when the lastrun file exists but it's empty, the program exits.

TODO: check why the lastrun file is empty in the first place.