### PR TITLE
Adds shared-state-nodes_and_links

### DIFF
--- a/packages/shared-state-nodes_and_links/Makefile
+++ b/packages/shared-state-nodes_and_links/Makefile
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2019 Gioacchino Mazzurco <gio@altermundi.net>
+#
+# This is free software, licensed under the GNU Affero General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+PKG_NAME:=shared-state-nodes_and_links
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+	TITLE:=nodes_and_links module for shared-state
+	CATEGORY:=LiMe
+	MAINTAINER:=Nicolas Pace <nico@libre.ws>
+	URL:=http://libremesh.org
+	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +lua +luci-lib-jsonc \
+		shared-state
+	PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/description
+	Syncronize nodes_and_links beween nodes.
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/shared-state-nodes_and_links/files/etc/shared-state/publishers/shared-state-publish_nodes_and_links
+++ b/packages/shared-state-nodes_and_links/files/etc/shared-state/publishers/shared-state-publish_nodes_and_links
@@ -1,0 +1,1 @@
+../../../usr/bin/shared-state-publish_nodes_and_links

--- a/packages/shared-state-nodes_and_links/files/etc/uci-defaults/shared-state-bat_nodes_and_links
+++ b/packages/shared-state-nodes_and_links/files/etc/uci-defaults/shared-state-bat_nodes_and_links
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+unique_append()
+{
+	grep -qF "$1" "$2" || echo "$1" >> "$2"
+}
+
+unique_append \
+	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync nodes_and_links &> /dev/null)&)'\
+	/etc/crontabs/root

--- a/packages/shared-state-nodes_and_links/files/usr/bin/shared-state-publish_nodes_and_links
+++ b/packages/shared-state-nodes_and_links/files/usr/bin/shared-state-publish_nodes_and_links
@@ -1,0 +1,30 @@
+#!/usr/bin/lua
+
+--! LibreMesh
+--! Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+--!
+--! This program is free software: you can redistribute it and/or modify
+--! it under the terms of the GNU Affero General Public License as
+--! published by the Free Software Foundation, either version 3 of the
+--! License, or (at your option) any later version.
+--!
+--! This program is distributed in the hope that it will be useful,
+--! but WITHOUT ANY WARRANTY; without even the implied warranty of
+--! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--! GNU Affero General Public License for more details.
+--!
+--! You should have received a copy of the GNU Affero General Public License
+--! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local fs = require("nixio.fs")
+local JSON = require("luci.jsonc")
+
+local function shell(command)
+    -- TODO(nicoechaniz): sanitize or evaluate if this is a security risk
+    local handle = io.popen(command)
+    local result = handle:read("*a")
+    handle:close()
+    return result
+end
+io.popen("shared-state insert nodes_and_links", "w"):write(shell("/usr/libexec/rpcd/lime-location call nodes_and_links </dev/null"))
+

--- a/packages/ubus-lime-location/files/usr/libexec/rpcd/lime-location
+++ b/packages/ubus-lime-location/files/usr/libexec/rpcd/lime-location
@@ -10,6 +10,14 @@ You may obtain a copy of the License at
 require "ubus"
 local json = require 'luci.json'
 
+local function shell(command)
+    -- TODO(nicoechaniz): sanitize or evaluate if this is a security risk
+    local handle = io.popen(command)
+    local result = handle:read("*a")
+    handle:close()
+    return result
+end
+
 local function printJson (obj)
     print(json.encode(obj))
 end
@@ -19,7 +27,7 @@ if not conn then
     error("Failed to connect to ubus")
 end
 
-local function get_location(msg)
+local function _get_location(msg)
     local result = {location = {}, default = false}
     local lat = conn:call("uci", "get", {config="libremap", section="location", option="latitude" }).value
     local lon = conn:call("uci", "get", {config="libremap", section="location", option="longitude" }).value
@@ -34,7 +42,11 @@ local function get_location(msg)
                                               option="community_lon" }).value
         result.default = true                                              
     end
-    printJson(result);
+    return result;
+end
+
+local function get_location(msg)
+  printJson(_get_location(msg))
 end
 
 local function set_location(msg)
@@ -43,9 +55,48 @@ local function set_location(msg)
     printJson({ lat = msg.lat, lon = msg.lon });
 end
 
+local function lines(str)
+  -- split a string into lines separated by line endings
+  local t = {}
+  local function helper(line) table.insert(t, line) return "" end
+  helper((str:gsub("(.-)\r?\n", helper)))
+  return t
+end
+
+local function nodes_and_links()
+  local hostname = io.input("/proc/sys/kernel/hostname"):read("*line")
+  local macs = lines(shell("iw dev | grep addr | cut -d \\  -f 2 | sort -u | head -c -1"))
+  local coordinates = _get_location().location
+  local iface, currneigh, _, n
+
+  local interfaces = lines(shell("iw dev | grep adhoc | cut -d \\  -f 2 | head -c -1"))
+  local links = {}
+  for _, iface in pairs(interfaces) do
+    currneigh = lines(shell("iw dev "..iface.." station dump | grep ^Station  | cut -d \\  -f2 | head -c -1"))
+    for _, n in pairs(currneigh) do
+        table.insert(links, n)
+    end
+  end
+      result = {}
+      result[hostname] = {
+      hostname=hostname,
+      macs=macs,
+      coordinates=coordinates,
+      links=links
+      }
+	printJson(result)
+
+end
+
+function all_nodes_and_links(msg)
+  print('{"result":'..shell("shared-state get nodes_and_links")..'}')
+end
+
 local methods = {
+    all_nodes_and_links = { no_params = 0},
+    nodes_and_links = { no_params = 0},
     get = { no_params = 0 },
-	set = { lat = 'value', lon = 'value' }
+    set = { lat = 'value', lon = 'value' }
 }
 
 if arg[1] == 'list' then
@@ -57,6 +108,8 @@ if arg[1] == 'call' then
 	msg = json.decode(msg)
     if       arg[2] == 'get'	        then get_location(msg)
 	elseif   arg[2] == 'set'	        then set_location(msg)
+	elseif   arg[2] == 'nodes_and_links'	        then nodes_and_links(msg)
+	elseif   arg[2] == 'all_nodes_and_links'	        then all_nodes_and_links(msg)
     else                                printJson({ error = "Method not found" })
     end
 end


### PR DESCRIPTION
This package allows to distribute via shared-state the location of the nodes, their macs and their wifi links with other macs. 
Modify ubus-lime-location to consume the information:
```
root@si-fridge:~# ubus call lime-location nodes_and_links
{
	"si-fridge": {
		"links: [
			"a0:f3:c1:6c:32:75",
			"c0:4a:00:fc:41:55"
			"14:cc:20:ad:b0:1d"
			"64:70:02:4e:cd:0b"
		],
		"coordinates: {
			"lon": "-64.39936101436615",
			"lat": "-31.799673850547368"
		},
		"macs": [
			"02:75:ba:dc:0d:51"
			"02:75:ba:dc:0d:52"
		],
		"hostname": "si-fridge"
	}
}
```

It is useful to show a map of the network in a decentralized way in lime-app