### PR TITLE
Removes event-based sync as it creates a loop that drains router resources

### DIFF
--- a/packages/shared-state-dnsmasq_leases/files/usr/bin/dnsmasq-lease-share.sh
+++ b/packages/shared-state-dnsmasq_leases/files/usr/bin/dnsmasq-lease-share.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-((shared-state-publish_dnsmasq_leases $@; shared-state sync dnsmasq-leases; shared-state sync dnsmasq-hosts) &>/dev/null &)
+((shared-state-publish_dnsmasq_leases $@) &>/dev/null &)


### PR DESCRIPTION
@gmarcos87 and I have seen that when the sync is triggered in each update, the router can't cope with it and stalls processes enough to drain the resources of the device.

While this gets fixed, it is safer if only cron-based updates are run.