### PR TITLE
Fix DNSMASQ malfunctioning in LibreMesh

### DIFF
--- a/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
+++ b/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
@@ -11,10 +11,6 @@ unique_append()
 	grep -qF "$1" "$2" || echo "$1" >> "$2"
 }
 
-# needed because init script ignore +dhcphostsfile+ if the file doesn't exists
-unique_append "dhcp-hostsfile=$dhcpHostsFile"\
-	"/etc/dnsmasq.d/shared-state-dhcp-leases.conf"
-
 unique_append \
 	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-leases &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-dnsmasq_leases/files/usr/bin/shared-state-generate_dnsmasq_leases
+++ b/packages/shared-state-dnsmasq_leases/files/usr/bin/shared-state-generate_dnsmasq_leases
@@ -28,12 +28,7 @@ for key,value in pairs(JSON.parse(io.stdin:read("*all"))) do
 		if ipaddr:find(":") then ipaddr = "[" .. ipaddr .. "]" end
 		ipaddr = ","..ipaddr
 
-		local hostname = ""
-		if string.len(value.data.hostname) > 1 then
-			hostname = ","..value.data.hostname
-		end
-
-		table.insert(outputTable, hwaddr..ipaddr..hostname)
+	table.insert(outputTable, hwaddr..ipaddr)
 	end
 end
 


### PR DESCRIPTION
# Debugging DNSMASQ malfunctioning in LibreMesh
_authors: @nicopace and @gmarcos87_

The behaviour we are trying to debug is related to dnsmasq consuming an increasing amount of resources.
We suspect that this is caused by these messages:
```bash
# logread | grep dnsmasq
Thu Jun 20 16:23:32 2019 daemon.warn dnsmasq-dhcp[6684]: duplicate IP address 2801:1e8:2::6c60:9100 (ql-gioiajesinico) in dhcp-config directive
...
Thu Jun 20 16:23:32 2019 daemon.warn dnsmasq-dhcp[6684]: duplicate IP address 10.5.0.96 (ql-gioiajesinico) in dhcp-config directive
...
Thu Jun 20 16:23:32 2019 daemon.err dnsmasq[6684]: duplicate dhcp-host IP address 10.5.5.123 at line 225 of /tmp/dhcp.hosts_remote
```

## Duplicate dhcp-host IP address

These are the configs that are being used in the node that the issue is happening, it can be found in `/tmp/etc/dnsmasq.conf.cfg*`:
```
# auto-generated config file from /etc/config/dhcp
conf-file=/etc/dnsmasq.conf
dhcp-authoritative
domain-needed
localise-queries
read-ethers
expand-hosts
bind-dynamic
local-service
domain=red.quintana.libre.org.ar
server=/red.quintana.libre.org.ar/
server=4.2.2.2
server=141.1.1.1
server=2001:470:20::2
address=/anygw/10.5.0.1
address=/anygw/2801:1e8:2::1
address=/thisnode.info/10.5.0.1
address=/thisnode.info/2801:1e8:2::1
dhcp-leasefile=/tmp/dhcp.leases
dhcp-script=/usr/lib/dnsmasq/dhcp-script.sh
resolv-file=/tmp/resolv.conf.auto
dhcp-hostsfile=/tmp/dhcp.hosts_remote
stop-dns-rebind
rebind-localhost-ok
dhcp-broadcast=tag:needs-broadcast
addn-hosts=/tmp/hosts
conf-dir=/tmp/dnsmasq.d
user=dnsmasq
group=dnsmasq
dhcp-option-force=tag:lm_net_br_lan_anygw_if,option:mtu,1350
bogus-priv
conf-file=/usr/share/dnsmasq/rfc6761.conf
no-dhcp-interface=br-lan
dhcp-range=set:lm_net_br_lan_anygw_if,10.5.0.2,10.5.7.254,255.255.248.0,1h
enable-ra
quiet-ra
```

This file points to /etc/dnsmasq.conf that says:
```
conf-dir=/etc/dnsmasq.d
```
And that dir has the following three files:

```
#   ls /etc/dnsmasq.d
lime-proto-anygw-20-ipv6.conf
local-mesh.conf
shared-state-dhcp-leases
```

The relevant info of the file `shared-state-dhcp-leases` is:
```
dhcp-hostsfile=/tmp/dhcp.hosts_remote
```

The dhcp-hostsfile variable help says that *--dhcp-hostsfile=<path> Read DHCP host specs from file.*

It looks that the dhcp-hostsfile is defined two times.

Removing one of the duplicated dhcp-hostsfile entries removes the error message from the log.

## duplicate IP address

It looks like DNSMASQ tries to assign IPs with info related to domains from two files that are clashing: /tmp/dhcp.hosts_remote and /tmp/hosts/* (this is used in order to update the hosts info without restarting dnsmasq).

This error is seen in the logs like this:
```
Thu Jun 20 16:23:32 2019 daemon.warn dnsmasq-dhcp[6684]: duplicate IP address 2801:1e8:2::6c60:9100 (ql-gioiajesinico) in dhcp-config directive
...
Thu Jun 20 16:23:32 2019 daemon.warn dnsmasq-dhcp[6684]: duplicate IP address 10.5.0.96 (ql-gioiajesinico) in dhcp-config directive
```

The files that were coliding are /tmp/hosts/* and /tmp/dhcp.hosts_remote

/tmp/hosts/* has this content that is clashing:
```
10.5.0.6 ql-nicojesigioia
2801:1e8:2::da85:1c00 ql-nicojesigioia
10.5.6.31 J7-Neo
10.5.5.52 Carmela-PC
10.5.0.169 android-ba44318e1248c10e
...
```

And this info got repeated in /tmp/dhcp.hosts_remote

So we decided to change /tmp/dhcp.hosts_remote from this:
```
a8:40:41:1c:85:db,[2801:1e8:2::da85:1c00],ql-nicojesigioia
a0:f3:c1:46:28:35,[2801:1e8:2::3528:4600],ql-cesarylucia
dc:bf:e9:03:d8:81,10.5.2.227,android-d8fc62eae17ca2e6
c0:d2:f3:32:cf:da,10.5.4.97
...
```

to this:
```
a8:40:41:1c:85:db,[2801:1e8:2::da85:1c00]
a0:f3:c1:46:28:35,[2801:1e8:2::3528:4600]
dc:bf:e9:03:d8:81,10.5.2.227
c0:d2:f3:32:cf:da,10.5.4.97
...
```

And this made the message dissapear, and still have ipv4 and ipv6 resolution.

Now we can rest in peace :)