### PR TITLE
In bat-host take iface name as unique key

### DIFF
--- a/packages/shared-state-bat_hosts/files/usr/bin/shared-state-generate_bat_hosts
+++ b/packages/shared-state-bat_hosts/files/usr/bin/shared-state-generate_bat_hosts
@@ -19,10 +19,20 @@
 local JSON = require("luci.jsonc")
 
 local outputTable = {}
+local filtredValues = {}
 
-for key,value in pairs(
-	JSON.parse(io.stdin:read("*all")) ) do
-	table.insert(outputTable, key.." "..value.data)
+for key,value in pairs(JSON.parse(io.stdin:read("*all")) ) do
+	if filtredValues[value.data] == nil or filtredValues[value.data].bleachTTL < value.bleachTTL then
+		filtredValues[value.data] = {
+			data = value.data,
+			key = key,
+			bleachTTL = value.bleachTTL
+		}
+	end
+end
+
+for _,value in pairs(filtredValues) do
+	table.insert(outputTable, value.key.." "..value.data)
 end
 
 io.output("/etc/bat-hosts"):write(table.concat(outputTable,"\n").."\n")


### PR DESCRIPTION
Shared-state is using the mac address as the unique key when publishing interfaces in shared-state-bat-hosts. 
This is not bad, except that the bat0 interface gets a random mac address at every startup. This generates duplicate entries in bat-hosts (different macs for the same interface) and warning messages in batctl like this one:

> root@ql-oncelotes:~# batctl o
Warning - name already known (changing mac from 'F6:D5:91:7F:CA:D2' to '2e:37:8e:5d:32:e8'): si_monica_bat0
Warning - name already known (changing mac from '06:4B:C4:D4:89:50' to '46:f0:c8:89:16:00'): si_radio_bat0
Warning - name already known (changing mac from '76:0C:12:EB:D4:7E' to '46:d6:3b:16:e0:c2'): si_nestor_bat0
Warning - name already known (changing mac from '2E:37:8E:5D:32:E8' to '12:c1:ba:2b:9d:47'): si_monica_bat0
Warning - name already known (changing mac from '46:F0:C8:89:16:00' to '5a:c3:4c:97:02:af'): si_radio_bat0
Warning - name already known (changing mac from '46:D6:3B:16:E0:C2' to '6a:bb:c6:2c:32:8b'): si_nestor_bat0

While it may be useful to identify nodes that are constantly restarting it is not the idea of this module. :)

Another improvement that we can make is to use the iface name as a key, but that breaks the compatibility with the already deployed nodes. Perhaps filtering the json of /shared-state/data/bat-hosts.json to avoid continuing to replicate useless information would be a good idea