### PR TITLE
Have dnsmasq-lease-share.sh forward it's arguments to dnsmasq-lease-share.lua

### DIFF
--- a/packages/dnsmasq-lease-share/src/dnsmasq-lease-share.sh
+++ b/packages/dnsmasq-lease-share/src/dnsmasq-lease-share.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-lua /etc/alfred/dnsmasq-lease-share.lua
+lua /etc/alfred/dnsmasq-lease-share.lua $@


### PR DESCRIPTION
In my testing, I saw dnsmasq use a very large amount of CPU, and calling dnsmasq-leash-share.sh over and over again with the same collections of arguments.

I noticed that this script wasn't calling the lua file with any arguments.

Making this change resolves the dnsmasq process using lots of CPU.

Is there anything obvious that this change will break? I'm actually a little confused how DHCP was working properly in my mesh before making this change.