### PR TITLE
Remove unused line from wireless.lua

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
@@ -119,7 +119,6 @@ function wireless.configure()
 				channel = options["channel"..freqSuffix] or options["channel"]
 				if type(channel) == "table" then
 					local chanIndex = 1 + radioName:match("%d+$") % #channel
-					chanIndex = chanIndex > 0 and chanIndex or 1
 					channel = channel[chanIndex]
 				end
 			else


### PR DESCRIPTION
In `wireless.lua` from `lime-system` package the [third line here](https://github.com/libremesh/lime-packages/blob/81168c1af02b76f079228d8d9d629d0369a4aad5/packages/lime-system/files/usr/lib/lua/lime/wireless.lua#L120-L124) can be safely removed:

```
if type(channel) == "table" then
	local chanIndex = 1 + radioName:match("%d+$") % #channel
	chanIndex = chanIndex > 0 and chanIndex or 1
	channel = channel[chanIndex]
end
```

In Lua the `%` operator (in the second line) has always zero or positive output and [has the precedence](https://www.lua.org/manual/5.3/manual.html#3.4.8) over the `+` operator.
So `chanIndex` calculated in the second line will always be at least 1 and there is no need for the third line.

I cannot test as I don't own any router with more than one radio on the same band...