### PR TITLE
bandwidth-test package for maximum available bandwidth towards the internet

### DIFF
--- a/libremesh.sdk.config
+++ b/libremesh.sdk.config
@@ -2,6 +2,7 @@
 # CONFIG_ALL_KMODS is not set
 # CONFIG_ALL is not set
 # CONFIG_SIGNED_PACKAGES is not set
+CONFIG_PACKAGE_bandwidth-test=m
 CONFIG_PACKAGE_dnsmasq=n
 CONFIG_PACKAGE_dnsmasq-dhcpv6=m
 CONFIG_PACKAGE_ALFRED_BATHOSTS=y

--- a/packages/bandwidth-test/Makefile
+++ b/packages/bandwidth-test/Makefile
@@ -16,7 +16,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/$(PKG_NAME)
   CATEGORY:=LiMe
-  TITLE:=Available internet bandwidth measurement
+  TITLE:=Internet download bandwidth measurement
   MAINTAINER:=Ilario Gelmetti <iochesonome@gmail.com>
   URL:=https://libremesh.org
   DEPENDS:=+pv
@@ -28,7 +28,8 @@ endef
 
 
 define Package/$(PKG_NAME)/description
-  	Measure the maximum available bandwidth towards the internet, downloading a list of files.
+  	Measure the maximum available bandwidth towards the internet, in the download direction.
+	Downloading a list of files via HTTP connections.
 endef
 
 define Build/Compile

--- a/packages/bandwidth-test/Makefile
+++ b/packages/bandwidth-test/Makefile
@@ -1,0 +1,44 @@
+# 
+# Copyright (C) 2019 Ilario Gelmetti
+#
+# This is free software, licensed under the GNU General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+PKG_NAME:=bandwidth-test
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  CATEGORY:=LiMe
+  TITLE:=Available internet bandwidth measurement
+  MAINTAINER:=Ilario Gelmetti <iochesonome@gmail.com>
+  URL:=https://libremesh.org
+  DEPENDS:=+pv
+  PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/config
+endef
+
+
+define Package/$(PKG_NAME)/description
+  	Measure the maximum available bandwidth towards the internet, downloading a list of files.
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/bin/
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_BIN) ./files/bin/bandwidth-test.lua $(1)/bin/bandwidth-test
+	$(INSTALL_CONF) ./files/etc/config/bandwidth-test $(1)/etc/config/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/bandwidth-test/files/bin/bandwidth-test.lua
+++ b/packages/bandwidth-test/files/bin/bandwidth-test.lua
@@ -1,0 +1,151 @@
+#!/usr/bin/lua
+
+local libuci_loaded, libuci = pcall(require, "uci")
+
+local function config_uci_get(option)
+	local result
+	if libuci_loaded then
+		result = libuci:cursor():get("bandwidth-test","bandwidth_test",option)
+	else
+		result = nil
+	end
+	return result
+end
+
+local PIDfile = "/tmp/bandwidth-test-wget-pid"
+
+local singleTestDuration = tonumber(arg[1]) or tonumber(config_uci_get("single_test_duration")) or 20
+
+local nonzeroTests = tonumber(arg[2]) or tonumber(config_uci_get("nonzero_tests")) or 5
+
+local defaultServersList = {
+	"http://speedtest-lon1.digitalocean.com/10mb.test",
+	"http://www.ovh.net/files/10Mio.dat",
+	"http://cloudharmony.com/probe/test10mb.jpg",
+	"http://frf1-speed-02.host.twtelecom.net.prod.hosts.ooklaserver.net:8080/download?size=12000000",
+	"http://cdn.google.cloudharmony.net/probe/test10mb.jpg",
+	"http://deb.debian.org/debian/ls-lR.gz",
+	"http://speedtest.catnix.cat.prod.hosts.ooklaserver.net:8080/download?size=12000000",
+	"http://ubuntu.inode.at/ubuntu/dists/bionic/main/installer-amd64/current/images/hd-media/initrd.gz",
+	"http://cdn.kernel.org/pub/linux/kernel/v4.x/patch-4.9.gz",
+	"http://ftp.belnet.be/ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/hd-media/initrd.gz"
+}
+
+local serversList
+if arg[3] then
+	serversList = {}
+	for i = 3,#arg,1
+	do
+		serversList[#serversList + 1] = tostring(arg[i])
+	end
+else
+	local temp = config_uci_get("server")
+	serversList = type(temp) == "table" and temp or defaultServersList
+end
+
+if not singleTestDuration or not nonzeroTests or not serversList[1]:find("http") then
+	local help = {"Usage: "..arg[0].." [SINGLE_TEST_DURATION] [NONZERO_TESTS] [SERVERS_LIST]",
+		"Measures the maximum available bandwidth downloading a list of files.",
+		"The measurement will take approximately SINGLE_TEST_DURATION*NONZERO_TESTS seconds.",
+		"The download of each URL is attempted at most one time: multiple URLs should be provided.",
+		"The speed in B/s is printed to STDOUT.",
+		"",
+		"  SINGLE_TEST_DURATION  fixed duration of each download process,",
+		"                          if missing reads from UCI status-report (default 20)",
+		"  NONZERO_TESTS         minimum number of successful downloads,",
+		"                          if missing reads from UCI status-report (default 5)",
+		"  SERVERS_LIST          a space-separated list of files' URLs to download,",
+		"                          preferably large files.",
+		"                          When running with Busybox wget, has to include http://",
+		"                          and will likely fail with https://",
+		"                          if missing reads from UCI status-report",
+		"                          (defaults to a list of 10 MB files on various domains)"}
+	for i = 1,#help,1 do
+		io.stderr:write(help[i],"\n")
+	end
+	os.exit(1)
+end
+
+local function do_split(str,pat)
+	local tbl = {}
+	str:gsub(pat, function(x) tbl[#tbl+1]=x end)
+	return tbl
+end
+
+local function do_test(server)
+	io.stderr:write("Attempting connection to "..server.."\n")
+	local timeout = singleTestDuration * 0.75
+	local pvCommand = "(wget -T"..timeout.." -q "..server..
+		" -O- & echo $! >&3) 3> "..PIDfile..
+		" | pv -n -b -t 2>&1 >/dev/null"
+	local handlePv = io.popen(pvCommand, 'r')
+	local handleKill = io.popen("sleep "..singleTestDuration.."; kill $(cat "..PIDfile.." 2>/dev/null) 2>/dev/null")
+	local pvRaw = handlePv:read("*a")
+	handleKill:close()
+	handlePv:close()
+	local pvArray = do_split(pvRaw,"[.%d]+")
+	return pvArray
+end
+
+local function get_speed(pvArray)
+	local t1 = tonumber(pvArray[#pvArray-3]) or 0
+	local d1 = tonumber(pvArray[#pvArray-2]) or 0
+	local t2 = tonumber(pvArray[#pvArray-1])
+	local d2 = tonumber(pvArray[#pvArray])
+	local speed = 0
+	if t2 and d2 then
+		speed = (d2 - d1) / (t2 - t1)
+	end
+	return speed
+end
+
+local function remove_zeros(array)
+    local tbl = {}
+    for i = 1, #array do
+	if(array[i] ~= 0) then
+            table.insert(tbl, array[i])
+        end
+    end
+    return tbl
+end
+
+local function do_median(array)
+	local temp = array
+	local median = 0
+	if #temp ~= 0 then
+		table.sort(temp)
+		median = temp[math.floor(#array/2)+1]
+	end
+	return median
+end
+
+local function do_tests_serie()
+	local results = {}
+	local i = 1
+	while #results < nonzeroTests and serversList[i] do
+		local test = do_test(serversList[i])
+		local testResult = get_speed(test)
+		io.stderr:write(math.floor(testResult).." B/s\n")
+		results[#results + 1] = testResult
+		results = remove_zeros(results)
+		i = i + 1
+	end
+	local median = do_median(results)
+	local attempted = i - 1
+	return median, attempted, #results
+end
+
+local result, attempted, successful = do_tests_serie()
+
+print(result)
+
+local message = "Maximum available bandwidth "..math.floor(result)..
+	" B/s, attempted connection to "..attempted..
+	" servers, successful connection to "..successful..
+	" servers."
+
+io.stderr:write(message.."\n")
+
+local handle = io.popen("logger -t bandwidth-test "..message)
+handle:close()
+

--- a/packages/bandwidth-test/files/bin/bandwidth-test.lua
+++ b/packages/bandwidth-test/files/bin/bandwidth-test.lua
@@ -45,10 +45,10 @@ end
 
 if not singleTestDuration or not nonzeroTests or not serversList[1]:find("http") then
 	local help = {"Usage: "..arg[0].." [SINGLE_TEST_DURATION] [NONZERO_TESTS] [SERVERS_LIST]",
-		"Measures the maximum available bandwidth downloading a list of files.",
+		"Measures maximum available download bandwidth downloading a list of files from the internet.",
 		"The measurement will take approximately SINGLE_TEST_DURATION*NONZERO_TESTS seconds.",
-		"The download of each URL is attempted at most one time: multiple URLs should be provided.",
-		"The speed in B/s is printed to STDOUT.",
+		"Download of each URL is attempted at most one time: multiple URLs should be provided.",
+		"Speed in B/s is printed to STDOUT.",
 		"",
 		"  SINGLE_TEST_DURATION  fixed duration of each download process,",
 		"                          if missing reads from UCI status-report (default 20)",

--- a/packages/bandwidth-test/files/etc/config/bandwidth-test
+++ b/packages/bandwidth-test/files/etc/config/bandwidth-test
@@ -1,0 +1,13 @@
+config bandwidth_test 'bandwidth_test'
+	option single_test_duration 20
+	option nonzero_tests 5
+	list server 'http://speedtest-lon1.digitalocean.com/10mb.test'
+	list server 'http://www.ovh.net/files/10Mio.dat'
+	list server 'http://cloudharmony.com/probe/test10mb.jpg'
+	list server 'http://frf1-speed-02.host.twtelecom.net.prod.hosts.ooklaserver.net:8080/download?size=12000000'
+	list server 'http://cdn.google.cloudharmony.net/probe/test10mb.jpg'
+	list server 'http://deb.debian.org/debian/ls-lR.gz'
+	list server 'http://speedtest.catnix.cat.prod.hosts.ooklaserver.net:8080/download?size=12000000'
+	list server 'http://ubuntu.inode.at/ubuntu/dists/bionic/main/installer-amd64/current/images/hd-media/initrd.gz'
+	list server 'http://cdn.kernel.org/pub/linux/kernel/v4.x/patch-4.9.gz'
+	list server 'http://ftp.belnet.be/ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/hd-media/initrd.gz'

--- a/packages/lime-debug/Makefile
+++ b/packages/lime-debug/Makefile
@@ -21,7 +21,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LiMe
 	MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
 	URL:=http://libremesh.org
-	DEPENDS:=+PACKAGE_lime-proto-batadv:batctl \
+	DEPENDS:=+PACKAGE_lime-proto-batadv:batctl +bandwidth-test \
 		+busybox +ethtool +iwinfo +iw +mtr +ip +iputils-ping6 +iputils-ping \
 		+sprunge +safe-reboot +netperf +pv +tcpdump-mini +bwm-ng
 	PKGARCH:=all


### PR DESCRIPTION
This Lua script downloads a list of files from the internet (it could also be used for measuring the local network speed, but for this case using netperf like in [lime-metrics](https://github.com/libremesh/lime-packages/blob/ce7a73038afb5de5b7709e9bbfc353c97c86913e/packages/ubus-lime-metrics/files/usr/libexec/rpcd/lime-metrics#L77) would be more proper).

In order to not take too long on slow networks, the downloads are interrupted after a specific time (the SINGLE_TEST_DURATION option). This has the drawback that on fast connections, the SINGLE_TEST_DURATION time has to be waited even if the file download has already finished.
In my opinion this is not a problem, but if you want I can try to change this.

The final speed output is taken as the median of a few measurements on different servers (by default 5, this is the NONZERO_TESTS option). The measurements that give zero speed are discarded. This happens quite often as Busybox wget cannot manage any kind of redirection.
It can also happen if a too short SINGLE_TEST_DURATION is employed (wget timeout is set to SINGLE_TEST_DURATION*0.75).

The list of files to download has been adapted from @p4u's [bmx7-auto-gw-bw-mode](https://github.com/libremesh/lime-packages/blob/master/packages/bmx7-auto-gw-bw-mode/files/usr/sbin/bmx7-auto-bw-test) package.

The parameters are documented in the package's help:

```
Usage: bandwidth-test [SINGLE_TEST_DURATION] [NONZERO_TESTS] [SERVERS_LIST]
Measures the maximum available bandwidth downloading a list of files.
The measurement will take approximately SINGLE_TEST_DURATION*NONZERO_TESTS seconds.
The download of each URL is attempted at most one time: multiple URLs should be provided.
The speed in B/s is printed to STDOUT.

SINGLE_TEST_DURATION  fixed duration of each download process,
                      if missing reads from UCI status-report (default 20)
NONZERO_TESTS         minimum number of successful downloads,
                      if missing reads from UCI status-report (default 5)
SERVERS_LIST          a space-separated list of files' URLs to download,
                      preferably large files.
                      When running with Busybox wget, has to include http://
                      and will likely fail with https://
                      if missing reads from UCI status-report
                      (defaults to a list of 10 MB files on various domains)
```

The arguments are optional but their ordering is fixed (the first argument is SINGLE_TEST_DURATION, the second is NONZERO_TESTS and from the third on they are the SERVERS_LIST).

The parameters can be provided as options from the command line.
If UCI is present in the system (e.g. when using this script in OpenWrt), it is used for accessing the parameters in `/etc/config/bandwidth-test`.
If no arguments are provided and UCI is missing or the configuration is empty, use the default hardcoded parameters.