### PR TITLE
Add netperf dependency to ubus-lime-metrics Makefile

### DIFF
--- a/packages/ubus-lime-metrics/Makefile
+++ b/packages/ubus-lime-metrics/Makefile
@@ -14,7 +14,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Marcos Gutierrez <gmarcos87@gmail.com>
   SUBMENU:=3. Applications
   TITLE:=Metrics ubus module
-  DEPENDS:= +lua +libubox-lua +libubus-lua +luci-lib-json
+  DEPENDS:= +lua +libubox-lua +libubus-lua +luci-lib-json +netperf
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
ubus-lime-metrics package [employs netperf](https://github.com/libremesh/lime-packages/blob/master/packages/ubus-lime-metrics/files/usr/libexec/rpcd/lime-metrics#L77-L80) for measuring the bandwidth but netperf was not included between the dependencies. 
