### PR TITLE
Add codcov env variable and badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 *~
 *.kate-swp
+luacov.stats.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 env:
     global:
     - IMAGE_NAME="openwrtorg/sdk:ar71xx-generic"
+    - CODECOV_TOKEN="a2d4efa4-ec98-4768-a9cf-7f29c19c387a"
 
 jobs:
   include:
@@ -62,4 +63,7 @@ jobs:
           on:
             all_branches: true
             condition: $TRAVIS_BRANCH != master
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![travis](https://api.travis-ci.org/libremesh/lime-packages.svg?branch=develop)](https://travis-ci.org/libremesh/lime-packages)
 [![Backers on Open Collective](https://opencollective.com/libremesh/backers/badge.svg)](#backers) 
 [![Sponsors on Open Collective](https://opencollective.com/libremesh/sponsors/badge.svg)](#sponsors) 
+[![codecov.io](http://codecov.io/github/libremesh/lime-packages/branch/master/graphs/badge.svg)](http://codecov.io/github/libremesh/lime-packages)
 
 # [LibreMesh][5] packages
 


### PR DESCRIPTION
We recently enabled unitesting in LibreMesh. This small contribution incorporates a badge with the percentage of test coverage and the link to its analysis.
It also ignores the file luacov.stats.out that is generated when the tests run locally.