### PR TITLE
Fix main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,11 @@ Clone OpenWrt stable repository, nowadays is version 18.06.1.
     git clone https://www.github.com/openwrt/openwrt -b openwrt-18.06
     cd openwrt
 
-Add lime-packages, libremap and lime-ui-ng feeds to the default ones.
+Add lime-packages and libremap feeds to the default ones.
 
     cp feeds.conf.default feeds.conf
     echo "src-git libremesh https://github.com/libremesh/lime-packages.git" >> feeds.conf
     echo "src-git libremap https://github.com/libremap/libremap-agent-openwrt.git" >> feeds.conf
-    echo "src-git limeui https://github.com/libremesh/lime-ui-ng.git" >> feeds.conf
 
 If you want to use a specific branch of lime-packages specify it adding
 ;nameofthebranch at the end of the relative line. For example:


### PR DESCRIPTION
In the main Readme it is indicated that the repo lime-ng-ui must be added to the feeds list. This information is incorrect at the current stage of development. The required packages are already integrated into lime-packages.