### PR TITLE
Fix device tests

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -18,19 +18,21 @@ function network.get_mac(ifname)
 	return utils.split(macaddr, ":")
 end
 
+function network.assert_interface_exists(ifname)
+	assert( ifname ~= nil and ifname ~= "",
+	        "network.primary_interface() could not determine ifname!" )
+
+	assert( fs.lstat("/sys/class/net/"..ifname),
+	        "network.primary_interface() "..ifname.." doesn't exists!" )
+end
+
 function network.primary_interface()
 	local ifname = config.get("network", "primary_interface", "eth0")
 	if ifname == "auto" then
 		local board = utils.getBoardAsTable()
 		ifname = board['network']['lan']['ifname']
 	end
-
-	assert( ifname ~= nil and ifname ~= "",
-	        "network.primary_interface() could not determine ifname!" )
-
-	assert( fs.lstat("/sys/class/net/"..ifname),
-	        "network.primary_interface() "..ifname.." doesn't exists!" )
-
+	network.assert_interface_exists(ifname)
 	return ifname
 end
 

--- a/packages/lime-system/tests/test_lime_network.lua
+++ b/packages/lime-system/tests/test_lime_network.lua
@@ -30,16 +30,13 @@ describe('LiMe Network tests', function()
     end)
 
     it('test primary_interface configured interface', function()
-        -- disable assertions beacause there is a check to validate
-        -- that the interface really exists in the system
-        test_utils.disable_asserts()
         config.set('network', 'lime')
         config.set('network', 'primary_interface', 'test0')
         uci:commit('lime')
         stub(utils, "getBoardAsTable", function () return BOARD end)
+        stub(network, "assert_interface_exists", function () return true end)
 
         assert.is.equal('test0', network.primary_interface())
-        test_utils.enable_asserts()
     end)
 
     it('test primary_interface auto config', function()
@@ -60,9 +57,10 @@ describe('LiMe Network tests', function()
         uci:commit('lime')
 
         stub(network, "get_mac", function () return  {'00', '00', '00', '00', '00', '00'} end)
-        test_utils.disable_asserts()
+        stub(network, "assert_interface_exists", function () return true end)
+
         local ipv4, ipv6 = network.primary_address()
-        test_utils.enable_asserts()
+
         assert.is.equal('10.13.0.0', ipv4:network():string())
         assert.is.equal(16, ipv4:prefix())
         -- as 'lo' interface MAC address is 00:00:00:00:00 then
@@ -94,10 +92,9 @@ describe('LiMe Network tests', function()
         stub(network, "get_mac", function () return  {'00', '00', '00', '00', '00', '00'} end)
         stub(network, "scandevices", function () return  {eth99={}} end)
         stub(utils, "getBoardAsTable", function () return BOARD end)
+        stub(network, "assert_interface_exists", function () return true end)
 
-        test_utils.disable_asserts()
         network.configure()
-        test_utils.enable_asserts()
 
         assert.is.equal("1500", uci:get("network", "lan", "mtu"))
         assert.is.equal("static", uci:get("network", "lan", "proto"))

--- a/tests/test_lime_config_device.lua
+++ b/tests/test_lime_config_device.lua
@@ -1,4 +1,5 @@
 local config = require 'lime.config'
+local network = require 'lime.network'
 local utils = require 'lime.utils'
 local hw_detection = require 'lime.hardware_detection'
 local test_utils = require 'tests.utils'
@@ -31,6 +32,9 @@ describe('LiMe Config tests', function()
 		config.set('wifi', 'distance_5ghz', '1234')
 		config.set('wifi', 'htmode_5ghz', 'HT40')
         uci:commit('lime')
+
+        stub(network, "get_mac", utils.get_id)
+        stub(network, "assert_interface_exists", function () return true end)
 
         -- copy openwrt first boot generated configs
 		for _, config_name in ipairs({'network', 'wireless'}) do


### PR DESCRIPTION
Allow disabling or customizing the validation of the existance of the interfaces from the tests. Now mocking this in the tests instead of disabling the assertions globaly.

Tests are failing if run in a machine without `eth0` (not the case of travis nor my computer...)