### PR TITLE
testshell: use docker explicit '1.0' tag instead defaulting to 'latest'

### DIFF
--- a/tools/dockertestshell
+++ b/tools/dockertestshell
@@ -3,7 +3,7 @@
 PWD=$(printf "%q\n" "${PWD}")
 APP=${@:-/bin/bash}
 
-DOCKER_IMAGE="${DOCKER_IMAGE:-libremesh/luatest}"
+DOCKER_IMAGE="${DOCKER_IMAGE:-libremesh/luatest:1.0}"
 
 DOCKER_BASHRC=/tmp/.docker_${USER}_bashrc
 


### PR DESCRIPTION
Without this change executing `./tools/dockertestshell` gives an error beacause `latest` tag does not exists as docker uses `latest` by default instead of using _any_ tag available (1.0 is available)