### PR TITLE
createVlanIface fixes for vlan = 0

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -367,7 +367,11 @@ function network.createVlanIface(linuxBaseIfname, vid, openwrtNameSuffix, vlanPr
 	end
 
 	uci:set("network", owrtInterfaceName, "interface")
-	uci:set("network", owrtInterfaceName, "proto", "none")
+	local proto = "none"
+	if vid == 0 then
+		proto = "static"
+	end
+	uci:set("network", owrtInterfaceName, "proto", proto)
 	uci:set("network", owrtInterfaceName, "auto", "1")
 
 	--! In case of wifi interface not using vlan (vid == 0) avoid to set

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -343,11 +343,12 @@ function network.createVlanIface(linuxBaseIfname, vid, openwrtNameSuffix, vlanPr
 
 	local uci = config.get_uci_cursor()
 
+	owrtInterfaceName = owrtInterfaceName..openwrtNameSuffix.."_if"
+
 	if vid ~= 0 then
 		local vlanId = tostring(vid)
 		--! sanitize passed linuxBaseIfName for constructing uci section name
 		--! because only alphanumeric and underscores are allowed
-		owrtInterfaceName = owrtInterfaceName..openwrtNameSuffix.."_if"
 		owrtDeviceName = network.sanitizeIfaceName(linuxBaseIfname)..openwrtNameSuffix.."_dev"
 
 		if linuxBaseIfname:match("^wlan") then

--- a/packages/lime-system/tests/test_lime_network.lua
+++ b/packages/lime-system/tests/test_lime_network.lua
@@ -103,6 +103,53 @@ describe('LiMe Network tests', function()
         network.scandevices:revert()
     end)
 
+    it('test createVlanIface() for ethernet address #vlan', function()
+        local vid = 15
+        network.createVlanIface('eth99', vid, '_fooproto')
+
+        -- a device is created for the vlan
+        assert.is.equal('eth99_15', uci:get("network", "lm_net_eth99_fooproto_dev", "name"))
+        assert.is.equal('8021ad', uci:get("network", "lm_net_eth99_fooproto_dev", "type"))
+        assert.is.equal('eth99', uci:get("network", "lm_net_eth99_fooproto_dev", "ifname"))
+        assert.is.equal(tostring(vid), uci:get("network", "lm_net_eth99_fooproto_dev", "vid"))
+
+        -- the interface
+        assert.is.equal('eth99_15', uci:get("network", "lm_net_eth99_fooproto_if", "ifname"))
+        assert.is.equal('1', uci:get("network", "lm_net_eth99_fooproto_if", "auto"))
+        assert.is.equal('none', uci:get("network", "lm_net_eth99_fooproto_if", "proto"))
+    end)
+
+    it('test createVlanIface() for ethernet with vlan=0 #vlan', function()
+        local vid = 0
+
+        network.createVlanIface('eth99', vid, '_fooproto')
+
+        -- a device is not created for the vlan
+        assert.is_nil(uci:get("network", "lm_net_eth99_fooproto_dev", "name"))
+
+        -- the interface uses static protocol
+        assert.is.equal('eth99', uci:get("network", "lm_net_eth99_fooproto_if", "ifname"))
+        assert.is.equal('1', uci:get("network", "lm_net_eth99_fooproto_if", "auto"))
+        assert.is.equal('static', uci:get("network", "lm_net_eth99_fooproto_if", "proto"))
+    end)
+
+    it('test createVlanIface() for wireless #vlan', function()
+        local vid = 15
+
+        network.createVlanIface('wlan85', vid, '_fooproto')
+
+        -- a device is created for the vlan
+        assert.is.equal('wlan85_15', uci:get("network", "lm_net_wlan85_fooproto_dev", "name"))
+        assert.is.equal('8021ad', uci:get("network", "lm_net_wlan85_fooproto_dev", "type"))
+        assert.is.equal(tostring(vid), uci:get("network", "lm_net_wlan85_fooproto_dev", "vid"))
+        assert.is.equal('@lm_net_wlan85', uci:get("network", "lm_net_wlan85_fooproto_dev", "ifname"))
+
+        -- the interface
+        assert.is.equal('wlan85_15', uci:get("network", "lm_net_wlan85_fooproto_if", "ifname"))
+        assert.is.equal('1', uci:get("network", "lm_net_wlan85_fooproto_if", "auto"))
+        assert.is.equal('none', uci:get("network", "lm_net_wlan85_fooproto_if", "proto"))
+    end)
+
     before_each('', function()
         uci = test_utils.setup_test_uci()
     end)


### PR DESCRIPTION
Also added some tests to network.createVlanIface.

vlan=0 can be used to "disable the vlan" for a protocol. So using protocol `babel:0` disables the vlan.