### PR TITLE
adding kmod-ebtables-ipv6 to anygw dependencies

### DIFF
--- a/packages/lime-proto-anygw/Makefile
+++ b/packages/lime-proto-anygw/Makefile
@@ -23,7 +23,7 @@ define Package/$(PKG_NAME)
 	URL:=http://libremesh.org
 	DEPENDS:=+dnsmasq-dhcpv6 @(!PACKAGE_dnsmasq) +ebtables +libuci-lua \
 		+lime-system +lua +kmod-ebtables +kmod-macvlan \
-		+shared-state +shared-state-dnsmasq_leases
+		+shared-state +shared-state-dnsmasq_leases +kmod-ebtables-ipv6
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
lime-proto-anygw is using ebtables functions (`--ip6-protocol`) which require a kernel module currently not included in its Makefile:

https://github.com/libremesh/lime-packages/blob/f5d680cf269f8ff109c39c639206e5283be9b52d/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua#L69-L74