### PR TITLE
Support Babeld without VLAN on ethernet interfaces inside br-lan

### DIFF
--- a/packages/lime-docs/files/lime-example
+++ b/packages/lime-docs/files/lime-example
@@ -51,6 +51,7 @@ config lime network
 	option bmx7_over_batman false
 	option bmx7_pref_gw none			# Force bmx7 to use a specific gateway to Internet (hostname must be used as identifier)
 	option bmx7_wifi_rate_max 'auto'
+	option babeld_over_batman false			# When Babeld is run without VLAN (babeld:0), it runs on the bridge which includes Batman-adv's bat0, keeping this false avoids to have Babeld metrics distorted by Batman-adv
 	option anygw_mac 'aa:aa:aa:%N1:%N2:aa'		# Parametrizable with %Nn. Keep in mind that the ebtables rule will use a mask of ff:ff:ff:00:00:00 so br-lan will not forward anything coming in that matches the first 3 bytes of it's own anygw_mac (aa:aa:aa: by default)
 #	option autoap_enabled 0				# Requires lime-ap-watchping installed. If enabled AP SSID is changed to ERROR when network issues
 #	option autoap_hosts "8.8.8.8 141.1.1.1"		# Requires lime-ap-watchping installed. Hosts used to check if the network is working fine

--- a/packages/lime-proto-anygw/Makefile
+++ b/packages/lime-proto-anygw/Makefile
@@ -23,7 +23,7 @@ define Package/$(PKG_NAME)
 	URL:=http://libremesh.org
 	DEPENDS:=+dnsmasq-dhcpv6 @(!PACKAGE_dnsmasq) +ebtables +libuci-lua \
 		+lime-system +lua +kmod-ebtables +kmod-macvlan \
-		+shared-state +shared-state-dnsmasq_leases
+		+shared-state +shared-state-dnsmasq_leases +kmod-ebtables-ipv6
   PKGARCH:=all
 endef
 

--- a/packages/lime-proto-babeld/Makefile
+++ b/packages/lime-proto-babeld/Makefile
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=https://libremesh.org
-  DEPENDS:=+babeld +lime-system
+  DEPENDS:=+babeld +lime-system +PACKAGE_lime-proto-batadv:kmod-ebtables-ipv6
   PKGARCH:=all
 endef
 

--- a/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
+++ b/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
@@ -129,6 +129,7 @@ function babeld.setup_interface(ifname, args)
 	end
 
 	if tonumber(vlanId) == 0 and isIntoLAN then
+		utils.log("Rather than "..ifname..", adding br-lan into Babeld interfaces")
 		ifname = "br-lan"
 		addIPtoIf = false
 	end

--- a/packages/lime-system/files/etc/config/lime-defaults-factory
+++ b/packages/lime-system/files/etc/config/lime-defaults-factory
@@ -39,6 +39,7 @@ config lime network
 	option bmx7_over_batman false
 	option bmx7_pref_gw none
 	option bmx7_wifi_rate_max 'auto'
+	option babeld_over_batman false
 	option anygw_mac "aa:aa:aa:%N1:%N2:aa"
 	option use_odhcpd false
 

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -276,6 +276,8 @@ function network.configure()
 			flags["specific"] = true
 			flags["_specific_section"] = owrtIf
 		end
+		
+		flags["deviceProtos"] = deviceProtos
 
 		for _,protoParams in pairs(deviceProtos) do
 			local args = utils.split(protoParams, network.protoParamsSeparator)


### PR DESCRIPTION
Fix #596 
Part of the code has been copied and pasted [from BMX6](https://github.com/libremesh/lime-packages/blob/master/packages/lime-proto-bmx6/src/bmx6.lua#L117-L138) (which run on br-lan by default).

We want to support running Babeld without VLAN (`list protocols babeld:0`) because:

* it is not actually needed
* seems that [switch on some Mediatek routers does not like it](https://forum.openwrt.org/t/mediatek-and-vlan-802-1ad-on-ethernet/42346)

But Babeld cannot run directly on an interface (e.g. `eth0` or `eth0.1`) which is included into a bridge (e.g. `br-lan`) because it cannot have an IPv6 Link-Local.
What have that is the bridge itself, so Babeld has to run on the bridge.
But the bridge includes `bat0` (Batman-adv stuff) which assures that all the packets get through, distorting the way that Babeld has for determining the metric of a route (sending UDP packets and checking how many get lost).

Maybe the configurable option `babeld_over_batman` is not useful and we can consider that it is always false?

I am still testing this PR, please review but wait for merging :)