### PR TITLE
proto.babel: fix eth MTU when using vlan

### DIFF
--- a/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
+++ b/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
@@ -110,6 +110,10 @@ function babeld.setup_interface(ifname, args)
 
 	local uci = config.get_uci_cursor()
 
+	if(vlanId ~= 0 and ifname:match("^eth")) then
+		uci:set("network", owrtDeviceName, "mtu", tostring(network.MTU_ETH_WITH_VLAN))
+	end
+
 	uci:set("network", owrtInterfaceName, "proto", "static")
 	uci:set("network", owrtInterfaceName, "ipaddr", ipv4:host():string())
 	uci:set("network", owrtInterfaceName, "netmask", "255.255.255.255")

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -12,6 +12,9 @@ network.limeIfNamePrefix="lm_net_"
 network.protoParamsSeparator=":"
 network.protoVlanSeparator="_"
 
+network.MTU_ETH = 1500
+network.MTU_ETH_WITH_VLAN = network.MTU_ETH - 4
+
 function network.get_mac(ifname)
 	local path = "/sys/class/net/"..ifname.."/address"
 	local macaddr = assert(fs.readfile(path), "network.get_mac(...) failed reading: "..path):gsub("\n","")

--- a/tests/test_lime_config_device.lua
+++ b/tests/test_lime_config_device.lua
@@ -61,6 +61,14 @@ describe('LiMe Config tests', function()
         assert.is.equal('17', uci:get('network', 'lm_net_eth0_babeld_dev', 'vid'))
         assert.is.equal('eth0_17', uci:get('network', 'lm_net_eth0_babeld_if', 'ifname'))
 
+        assert.is.equal(tostring(network.MTU_ETH_WITH_VLAN),
+                        uci:get('network', 'lm_net_eth0_babeld_dev', 'mtu'))
+
+        assert.is.equal('@lm_net_wlan1_mesh', uci:get('network', 'lm_net_wlan1_mesh_babeld_dev', 'ifname'))
+        assert.is.equal('17', uci:get('network', 'lm_net_wlan1_mesh_babeld_dev', 'vid'))
+        assert.is_nil(uci:get('network', 'lm_net_wlan1_mesh_babeld_dev', 'mtu'))
+
+
         assert.is_nil(uci:get('network', 'globals', 'ula_prefix'))
 		for _, radio in ipairs({'radio0', 'radio1', 'radio2'}) do
 			assert.is.equal('0', uci:get('wireless', radio, 'disabled'))


### PR DESCRIPTION
This fixes #580 

Some of the other protocols have mtu configurations but not all for example olsr, bgp. So this is only fixing babel I don't know if we want to create a more general patch that always use MTU = 1496 when using ETH + VLAN.

I have tested this with two LibreRouters. LR-A connected through WAN to "internet". LR-B connected to LR-A with LAN port to LAN port of LR-A. In this scenario pinging from LR-B to internet with `ping -s SIZE 192.168.1.1` only works when `SIZE <= 1470`. With this fix size could be greater than 1470 without problem.

