### PR TITLE
fbw: missing namespace after module refactor

### DIFF
--- a/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
+++ b/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
@@ -58,7 +58,7 @@ local methods = {
                 -- apply lime config
                 conn:reply(req, { status = 'configuring' })
                 -- os.execute('sleep 2s')
-                apply_file_config(file, hostname)
+                fbw.apply_file_config(file, hostname)
                 -- remove lock?
                 -- remove_lock_file()
             end, { file = ubus.STRING, hostname = ubus.STRING }


### PR DESCRIPTION
This fixes the set_network step of firstbootwizard.
I introduced this bug in the refactor of fbw as a module. I tested all the functionality but through lua directly like 
```
fbw = require "firstbootwizard"
fbw.apply_file_config(...)
```
But I did not tested the calls through `/usr/libexec/daemon/lime-fbw`

One thing that we discovered debuging this is that If one function fails then the daemon dies. So a good idea is to use xpcall in all the calls though libexec.