### PR TITLE
Logging intead of print

### DIFF
--- a/packages/lime-hwd-openwrt-wan/files/usr/lib/lua/lime/hwd/openwrt_wan.lua
+++ b/packages/lime-hwd-openwrt-wan/files/usr/lib/lua/lime/hwd/openwrt_wan.lua
@@ -48,7 +48,7 @@ function openwrt_wan.detect_hardware()
 			config.set(openwrt_wan.sectionName, "linux_name", ifname)
 			config.end_batch()
 		else
-			print("No wan interface detected")
+			utils.log("No wan interface detected")
 		end
 	end
 end

--- a/packages/lime-hwd-openwrt-wan/tests/test_lime_hwd_openwrt_wan.lua
+++ b/packages/lime-hwd-openwrt-wan/tests/test_lime_hwd_openwrt_wan.lua
@@ -5,6 +5,8 @@ local test_utils = require 'tests.utils'
 
 local uci
 
+utils.disable_logging()
+
 local COMPLETE_BOARD = {
     ["network"] = {
         ["lan"] = {

--- a/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
+++ b/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
@@ -28,7 +28,7 @@ function babeld.configure(args)
 	if babeld.configured then return end
 	babeld.configured = true
 
-	print("lime.proto.babeld.configure(...)")
+	utils.log("lime.proto.babeld.configure(...)")
 
 	fs.writefile("/etc/config/babeld", "")
 
@@ -93,11 +93,11 @@ end
 
 function babeld.setup_interface(ifname, args)
 	if not args["specific"] and ifname:match("^wlan%d+.ap") then
-		print("lime.proto.babeld.setup_interface(...)", ifname, "ignored")
+		utils.log("lime.proto.babeld.setup_interface(...)", ifname, "ignored")
 		return
 	end
 
-	print("lime.proto.babeld.setup_interface(...)", ifname)
+	utils.log("lime.proto.babeld.setup_interface(...)", ifname)
 
 	local vlanId = args[2] or 17
 	local vlanProto = args[3] or "8021ad"

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -95,7 +95,7 @@ function network.primary_address(offset)
 	if invalid then
 		ipv4_template = mc:maxhost()
 		ipv4_template:prefix(tonumber(ipv4_maskbits))
-		print("INVALID main_ipv4_address " ..tostring(mc).. " IDENTICAL TO RESERVED "
+		utils.log("INVALID main_ipv4_address " ..tostring(mc).. " IDENTICAL TO RESERVED "
 			..invalid.. " ADDRESS. USING " ..tostring(ipv4_template))
 	end
 
@@ -143,7 +143,7 @@ function network.setup_dns()
 end
 
 function network.clean()
-	print("Clearing network config...")
+	utils.log("Clearing network config...")
 
 	local uci = config.get_uci_cursor()
 
@@ -167,20 +167,20 @@ function network.clean()
 	uci:save("network")
 
 	if config.get_bool("network", "use_odhcpd", false) then
-		print("Use odhcpd as dhcp server")
+		utils.log("Use odhcpd as dhcp server")
 		uci:set("dhcp", "odchpd", "maindhcp", 1)
 		os.execute("/etc/init.d/odhcpd enable")
 	else
-		print("Disabling odhcpd")
+		utils.log("Disabling odhcpd")
 		uci:set("dhcp", "odchpd", "maindhcp", 0)
 		os.execute("/etc/init.d/odhcpd disable")
 	end
 
-	print("Cleaning dnsmasq")
+	utils.log("Cleaning dnsmasq")
 	uci:foreach("dhcp", "dnsmasq", function(s) uci:delete("dhcp", s[".name"], "server") end)
 	uci:save("dhcp")
 
-	print("Disabling 6relayd...")
+	utils.log("Disabling 6relayd...")
 	fs.writefile("/etc/config/6relayd", "")
 end
 

--- a/packages/lime-system/files/usr/lib/lua/lime/system.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/system.lua
@@ -26,10 +26,10 @@ function system.clean()
 end
 
 function system.configure()
-    print("Configuring system...")
+    utils.log("Configuring system...")
     system.set_hostname()
 
-    print("Let uhttpd listen on IPv4/IPv6")
+    utils.log("Let uhttpd listen on IPv4/IPv6")
     local uci = config.get_uci_cursor()
     uci:set("uhttpd", "main", "listen_http", "80")
     uci:set("uhttpd", "main", "listen_https", "443")

--- a/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
@@ -18,7 +18,7 @@ function wireless.get_phy_mac(phy)
 end
 
 function wireless.clean()
-	print("Clearing wireless config...")
+	utils.log("Clearing wireless config...")
 	local uci = config.get_uci_cursor()
 	uci:foreach("wireless", "wifi-iface", function(s) uci:delete("wireless", s[".name"]) end)
 	uci:save("wireless")

--- a/tests/test_lime_config_device.lua
+++ b/tests/test_lime_config_device.lua
@@ -7,6 +7,7 @@ local test_utils = require 'tests.utils'
 
 -- disable logging in config module
 config.log = function() end
+utils.disable_logging()
 
 local uci
 


### PR DESCRIPTION
utils.log is prefered because we can control its output for example
disabling writing to stdout when testing.

I removed all the prints that polluted the testing output, so I am confident that this is not breaking anything.
