### PR TITLE
Support Babeld without VLAN on ethernet interfaces inside br-lan, replaces #600

### DIFF
--- a/packages/lime-proto-babeld/Makefile
+++ b/packages/lime-proto-babeld/Makefile
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=https://libremesh.org
-  DEPENDS:=+babeld +lime-system
+  DEPENDS:=+babeld +lime-system +kmod-ebtables-ipv6
   PKGARCH:=all
 endef
 

--- a/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
+++ b/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
@@ -89,6 +89,17 @@ function babeld.configure(args)
 
 	uci:save("libremap")
 
+	--! If Babeld's Hello packets run over Batman-adv (whose bat0 is also
+	--! included in br-lan), all the Babeld nodes would appear as being direct
+	--! neighbors, so these Hello packets on bat0 have to be filtered
+	if utils.is_installed("kmod-batman-adv") then
+		fs.mkdir("/etc/firewall.lime.d")
+		fs.writefile("/etc/firewall.lime.d/21-babeld-not-over-bat0-ebtables",
+		  "ebtables -t nat -A POSTROUTING -o bat0 -p ipv6"..
+		  " --ip6-proto udp --ip6-sport 6696 --ip6-dport 6696 -j DROP\n")
+	else
+		fs.remove("/etc/firewall.lime.d/21-babeld-not-over-bat0-ebtables")
+	end
 end
 
 function babeld.setup_interface(ifname, args)
@@ -103,21 +114,70 @@ function babeld.setup_interface(ifname, args)
 	local vlanProto = args[3] or "8021ad"
 	local nameSuffix = args[4] or "_babeld"
 
+
+	--! If Babeld is without VLAN (vlanId is 0) it should run directly on plain
+	--! ethernet interfaces, but the ones which are inside of the LAN bridge
+	--! (e.g. eth0 or eth0.1) cannot have an IPv6 Link-Local and Babeld needs it.
+	--! So Babeld has to run on the bridge interface br-lan
+	local isIntoLAN = false
+	local addIPtoIf = true
+	for _,v in pairs(args["deviceProtos"]) do
+		if v == "lan" then
+			isIntoLAN = true
+		--! would be weird to add a static IP to the WAN interface
+		elseif v == "wan" then
+			addIPtoIf = false
+		end
+	end
+
+	if ifname:match("^wlan") then
+		--! currently (2019-10-12) mode-ap and mode-apname have an hardcoded
+		--! "option network lan" so they are always in the br-lan bridge
+		if ifname:match("^wlan.*ap$") or ifname:match("^wlan.*apname$") then
+			isIntoLAN = true
+
+		--! all the WLAN interfaces are ignored by proto-lan
+		--! so they are not in the bridge even if proto-lan is present
+		--! (except mode-ap and mode-apname as mentioned above)
+		else
+			isIntoLAN = false
+		end
+	end
+
+	if tonumber(vlanId) == 0 and isIntoLAN then
+		utils.log("Rather than "..ifname..
+		  ", adding br-lan into Babeld interfaces")
+		ifname = "br-lan"
+		--! br-lan has already an IPv4, no need to add it
+		addIPtoIf = false
+	end
+
 	local owrtInterfaceName, linuxVlanIfName, owrtDeviceName =
 	  network.createVlanIface(ifname, vlanId, nameSuffix, vlanProto)
 
-	local ipv4, _ = network.primary_address()
-
 	local uci = config.get_uci_cursor()
 
-	if(vlanId ~= 0 and ifname:match("^eth")) then
+	if tonumber(vlanId) ~= 0 and ifname:match("^eth") then
 		uci:set("network", owrtDeviceName, "mtu", tostring(network.MTU_ETH_WITH_VLAN))
 	end
 
-	uci:set("network", owrtInterfaceName, "proto", "static")
-	uci:set("network", owrtInterfaceName, "ipaddr", ipv4:host():string())
-	uci:set("network", owrtInterfaceName, "netmask", "255.255.255.255")
-	uci:save("network")
+	if addIPtoIf then
+		local ipv4, _ = network.primary_address()
+		--! the "else" way should always work but it fails in a weird way
+		--! with some wireless interfaces without VLAN
+		--! (e.g. works with wlan0-mesh and fails with wlan1-mesh)
+		--! so for these cases, the first way is used
+		--! (which indeed fails for most of the other cases)
+		if ifname:match("^wlan") and tonumber(vlanId) == 0 then
+			uci:set("network", owrtInterfaceName, "ifname", "@"..owrtDeviceName)
+		else
+			uci:set("network", owrtInterfaceName, "ifname", linuxVlanIfName)
+		end
+		uci:set("network", owrtInterfaceName, "proto", "static")
+		uci:set("network", owrtInterfaceName, "ipaddr", ipv4:host():string())
+		uci:set("network", owrtInterfaceName, "netmask", "255.255.255.255")
+		uci:save("network")
+	end
 
 	uci:set("babeld", owrtInterfaceName, "interface")
 	uci:set("babeld", owrtInterfaceName, "ifname", linuxVlanIfName)

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -280,6 +280,8 @@ function network.configure()
 			flags["_specific_section"] = owrtIf
 		end
 
+		flags["deviceProtos"] = deviceProtos
+
 		for _,protoParams in pairs(deviceProtos) do
 			local args = utils.split(protoParams, network.protoParamsSeparator)
 			if args[1] == "manual" then break end -- If manual is specified do not configure interface


### PR DESCRIPTION
This is #600 with very few modifications, like the elimination of the `babeld_over_batman` option and removed the conditional dependency.
Will fix #596 and is a step towards #581.
I tested on various routers (YouHua WR1200JS, TP-Link WDR3600, Ubiquiti NanoStation LoCo M2, Comtrend AR-5387un, Comtrend AR-5315u) with or without VLAN.
This PR allows to use YouHua WR1200JS also with ethernet connections (there's a [drivers bug to be confirmed which maybe affects all the Mediatek routers](https://forum.openwrt.org/t/mediatek-and-vlan-802-1ad-on-ethernet/42346)) when setting VLAN 0 (no VLAN).