### PR TITLE
protos: force vlanId to be numeric

### DIFF
--- a/packages/lime-proto-bmx6/src/bmx6.lua
+++ b/packages/lime-proto-bmx6/src/bmx6.lua
@@ -171,7 +171,7 @@ function bmx6.setup_interface(ifname, args)
 			( ifname:match("^wlan%d+.ap") or ifname:match("^eth%d+") )
 	then return end
 
-	vlanId = args[2] or 13
+	vlanId = tonumber(args[2]) or 13
 	vlanProto = args[3] or "8021ad"
 	nameSuffix = args[4] or "_bmx6"
 

--- a/packages/lime-proto-bmx7/files/usr/lib/lua/lime/proto/bmx7.lua
+++ b/packages/lime-proto-bmx7/files/usr/lib/lua/lime/proto/bmx7.lua
@@ -190,7 +190,7 @@ function bmx7.setup_interface(ifname, args)
 		( ifname:match("^wlan%d+.ap") or ifname:match("^eth%d+") )
 	then return end
 
-	vlanId = args[2] or 18
+	vlanId = tonumber(args[2]) or 18
 	vlanProto = args[3] or "8021ad"
 	nameSuffix = args[4] or "_bmx7"
 

--- a/packages/lime-proto-olsr/src/olsr.lua
+++ b/packages/lime-proto-olsr/src/olsr.lua
@@ -41,7 +41,7 @@ function olsr.setup_interface(ifname, args)
 		if ifname:match("^wlan%d+.ap") then return end
 	end
 
-	local vlanId = args[2] or 14
+	local vlanId = tonumber(args[2]) or 14
 	local vlanProto = args[3] or "8021ad"
 	local nameSuffix = args[4] or "_olsr"
 	local ipPrefixTemplate = args[5] or "169.254.%M5.%M6/16"

--- a/packages/lime-proto-olsr2/src/olsr2.lua
+++ b/packages/lime-proto-olsr2/src/olsr2.lua
@@ -48,7 +48,7 @@ function olsr2.setup_interface(ifname, args)
 	if not args["specific"] then
 		if ifname:match("^wlan%d+.ap") then return end
 	end
-	local vlanId = args[2] or 16
+	local vlanId = tonumber(args[2]) or 16
 	local vlanProto = args[3] or "8021ad"
 	local nameSuffix = args[4] or "_olsr"
 	local owrtInterfaceName, linux802adIfName, owrtDeviceName = network.createVlanIface(ifname, vlanId, nameSuffix, vlanProto)

--- a/packages/lime-proto-olsr6/src/olsr6.lua
+++ b/packages/lime-proto-olsr6/src/olsr6.lua
@@ -41,7 +41,7 @@ function olsr.setup_interface(ifname, args)
 		if ifname:match("^wlan%d+.ap") then return end
 	end
 
-	vlanId = args[2] or 15
+	vlanId = tonumber(args[2]) or 15
 	vlanProto = args[3] or "8021ad"
 	nameSuffix = args[4] or "_olsr6"
 	local ipPrefixTemplate = args[5] or "fc00::%M1%M2:%M3%M4:%M5%M6/64"


### PR DESCRIPTION
Between the arguments which can be provided to the routing protocols, the first one is usually the VLAN ID.
Force it to be numeric, for all the protocols except Batman-adv one which can be parametrized with %N1 (and except Babeld which is being treated in #631).