### PR TITLE
Option to ignore devices in shared-state-presist

### DIFF
--- a/packages/shared-state-persist/files/usr/bin/shared-state-persist
+++ b/packages/shared-state-persist/files/usr/bin/shared-state-persist
@@ -74,7 +74,7 @@ local function getDevices()
 end
 
 local function isWritable(devicePath)
-	return fs.stat(devicePath..'/.read-only') == nil
+	return fs.stat(devicePath..'/.shared_state_persist_ignore_device') == nil
 end
 
 local function runPersist()

--- a/packages/shared-state-persist/files/usr/bin/shared-state-persist
+++ b/packages/shared-state-persist/files/usr/bin/shared-state-persist
@@ -74,7 +74,7 @@ local function getDevices()
 end
 
 local function isWritable(devicePath)
-	return fs.stat(devicePath..'/.shared_state_persist_ignore_device') == nil
+	return fs.stat(devicePath..'/shared_state_persist_ignore_device') == nil
 end
 
 local function runPersist()

--- a/packages/shared-state-persist/files/usr/bin/shared-state-persist
+++ b/packages/shared-state-persist/files/usr/bin/shared-state-persist
@@ -73,13 +73,17 @@ local function getDevices()
 	return shell("block info | grep -oE \"(\/mnt\/+[a-z]*[0-9])\""):gmatch("[^'\n']+")
 end
 
+local function isWritable(devicePath)
+	return fs.stat(devicePath..'/.read-only') == nil
+end
+
 local function runPersist()
 	local selectedPath = nil
 	local selectedOption = NON_DEVICE
 
 	for mntPath in getDevices() do
 		-- Setup first device as valid
-		if selectedPath == nil and selectedOption == NON_DEVICE then
+		if selectedPath == nil and selectedOption == NON_DEVICE and isWritable(mntPath) then
 			selectedOption = NEW_DEVICE
 			selectedPath = mntPath
 		end

--- a/packages/shared-state-persist/files/usr/bin/shared-state-persist
+++ b/packages/shared-state-persist/files/usr/bin/shared-state-persist
@@ -79,7 +79,7 @@ local function runPersist()
 
 	for mntPath in getDevices() do
 		-- Setup first device as valid
-		if selectedPath == nil and selectedOption == 2 then
+		if selectedPath == nil and selectedOption == NON_DEVICE then
 			selectedOption = NEW_DEVICE
 			selectedPath = mntPath
 		end


### PR DESCRIPTION
We are currently thinking about other automatic behaviors with storage devices in routers. With this pull-request the behavior of shared-state-persist is changed so that it ignores the device if it has a file with the name .shared_state_persist_ignore_device in the root.