### PR TITLE
FirstBootWizard use uci instead of /etc/first_run

### DIFF
--- a/packages/first-boot-wizard/files/bin/firstbootwizard
+++ b/packages/first-boot-wizard/files/bin/firstbootwizard
@@ -2,5 +2,7 @@
 
 local fbw = require('firstbootwizard')
 
-print("[FBW] Scanning...")
-fbw.get_all_networks()
+if not fbw.is_configured() then
+    print("[FBW] Scanning...")
+    fbw.get_all_networks()
+end

--- a/packages/first-boot-wizard/tests/test_firstbootwizard.lua
+++ b/packages/first-boot-wizard/tests/test_firstbootwizard.lua
@@ -71,13 +71,13 @@ describe('FirstBootWizard tests #fbw', function()
     end)
 
     before_each('', function()
+        fbw_utils.execute('rm -f /tmp/fbw/*')
+        fbw_utils.execute('rm -f /tmp/scanning')
         uci = test_utils.setup_test_uci()
     end)
 
     after_each('', function()
         test_utils.teardown_test_uci(uci)
-        fbw_utils.execute('rm -f /tmp/fbw/*')
-        fbw_utils.execute('rm -f /tmp/scanning')
     end)
 
 end)

--- a/packages/first-boot-wizard/tests/test_firstbootwizard.lua
+++ b/packages/first-boot-wizard/tests/test_firstbootwizard.lua
@@ -22,13 +22,30 @@ config lime 'wifi'
 
 describe('FirstBootWizard tests #fbw', function()
 
-    it('test start/end_scan()', function()
+    it('test start/end_scan() and check_scan_file()', function()
+        assert.is_nil(fbw.check_scan_file())
+
         fbw.start_scan_file()
         assert.are.same('true', io.open("/tmp/scanning"):read("*a"))
+        assert.is.equal('true', fbw.check_scan_file())
+
         fbw.end_scan()
         assert.are.same('false', io.open("/tmp/scanning"):read("*a"))
+        assert.is.equal('false', fbw.check_scan_file())
     end)
 
+    it('test is_configured() / mark_as_configured() ', function()
+
+        assert.is.equal(false, fbw.is_configured())
+
+        uci:set(config.UCI_NODE_NAME, 'system', 'lime')
+        fbw.mark_as_configured()
+        assert.is.equal('true', uci:get(config.UCI_NODE_NAME, 'system', 'firstbootwizard_configured'))
+
+        config.uci_autogen()
+        assert.is.equal(true, fbw.is_configured())
+
+    end)
 
     it('test get_networks()', function()
         fbw.get_networks() -- TODO
@@ -42,7 +59,9 @@ describe('FirstBootWizard tests #fbw', function()
     it('test get_networks() empty', function()
         local configs = fbw.read_configs()
         assert.is.equal(0, #configs)
+    end)
 
+    it('test get_networks() empty', function()
         utils.write_file('/tmp/fbw/lime-community__host__foonode', community_file)
 
         local configs = fbw.read_configs()
@@ -58,6 +77,7 @@ describe('FirstBootWizard tests #fbw', function()
     after_each('', function()
         test_utils.teardown_test_uci(uci)
         fbw_utils.execute('rm -f /tmp/fbw/*')
+        fbw_utils.execute('rm -f /tmp/scanning')
     end)
 
 end)

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -10,6 +10,7 @@ config lime system
 	option domain 'thisnode.info'
 	option keep_on_upgrade 'libremesh base-files-essential /etc/sysupgrade.conf'
 	option deferable_reboot_uptime_s '97200'
+	option firstbootwizard_configured false
 
 config lime network
 	option primary_interface 'eth0'

--- a/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
+++ b/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
@@ -43,9 +43,8 @@ local methods = {
                 -- if done scanning return 2
                 elseif scan_file == "false" then scan_status = 2
                 end
-                local lock_file = fbw.check_lock_file()
                 local status = {
-                    lock = lock_file,
+                    lock = not fbw.is_configured(),
                     scan = scan_status
                 }
                 conn:reply(req, status)


### PR DESCRIPTION
Fixes #569 

Also prevents FBW from running the scanning/network gathering at boot time if it is already configured.
