### PR TITLE
Make ubus-lime-location optional

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -21,7 +21,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Marcos Gutierrez <gmarcos@altermundi.net>
 	URL:=http://github.com/libremesh/lime-app
 	DEPENDS:=+uhttpd +uhttpd-mod-ubus \
-		+ubus-lime-location +ubus-lime-metrics +ubus-lime-utils \
+		+ubus-lime-metrics +ubus-lime-utils \
 		+ubus-lime-openairview +ubus-lime-grondrouting
 	PKGARCH:=all
 endef


### PR DESCRIPTION
Here I removed the hard dependency of ubus-lime-location from lime-app.
In parallel, I already documented that it should be manually selected when compiling the firmware, see https://github.com/libremesh/lime-web/pull/101

Considering that ubus-lime-location causes a cascade of dependencies which includes luci-base (see #433, ubus-lime-location selects libremap-agent which selects luci-lib-libremap which selects luci-base), I thought that users trying to compile a firmware with lime-app for routers with limited flash memory could want to avoid including LuCI.

See also discussion on  #471
