### PR TITLE
Add uhttpd-mod-lua dependency to pirania

### DIFF
--- a/packages/pirania/Makefile
+++ b/packages/pirania/Makefile
@@ -25,7 +25,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=Network
 	TITLE:=$(PKG_NAME)
 	MAINTAINER:=Marcos Gutierrez <gmarcos@altermundi.net>
-	DEPENDS:= +ip6tables-mod-nat +ipset
+	DEPENDS:= +ip6tables-mod-nat +ipset +uhttpd-mod-lua
 	PKGARCH:=all
 endef
 


### PR DESCRIPTION
Running a LibreMesh image with installed `pirania` and `pirania-app` packages, I had some errors in logread:

```
daemon.err uhttpd[2640]: Could not open plugin uhttpd_lua.so: Error loading shared library uhttpd_lua.so: No such file or directory
daemon.info procd: Instance pirania-uhttpd::instance1 s in a crash loop 6 crashes, 0 seconds since last crash
```

the file uhttpd_lua.so is part of the package uhttpd-mod-lua which I think should be included in the pirania package dependencies.