### PR TITLE
lime-report filter keys also in commands

### DIFF
--- a/packages/lime-report/files/lime-report.sh
+++ b/packages/lime-report/files/lime-report.sh
@@ -10,11 +10,11 @@ paste_file() {
 
 paste_cmd() {
     echo -e "\n### CMD $@\n"
-    eval $@ 2>&1
+    eval $@ 2>&1 | grep -v key | grep -v pass
 }
 
 header() {
-    paste_cmd echo $HOSTNAME
+    paste_cmd echo hostname $HOSTNAME
     paste_cmd date \'+%Y-%m-%d %H:%M:%S\'
     paste_cmd uptime
 }


### PR DESCRIPTION
The AP passwords are shown also by the `wifi status` command, so the filter for not disclosing passwords have to be applied also to the commands output.