### PR TITLE
lime-app installs the redirect to /app

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -41,6 +41,7 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_BIN) ./files/95-lime-app-rpc-acl $(1)/etc/uci-defaults/
 	$(INSTALL_BIN) ./files/96-lime-app-index_page $(1)/etc/uci-defaults/
 	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d || true
+	$(INSTALL_DATA) ./files/lime_app_index.html $(1)/www/
 endef
 
 define Package/$(PKG_NAME)/postinst

--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -39,6 +39,7 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/lime-app.defaults $(1)/etc/uci-defaults/90_lime-app
 	$(INSTALL_BIN) ./files/95-lime-app-rpc-acl $(1)/etc/uci-defaults/
+	$(INSTALL_BIN) ./files/96-lime-app-index_page $(1)/etc/uci-defaults/
 	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d || true
 endef
 

--- a/packages/lime-app/files/96-lime-app-index_page
+++ b/packages/lime-app/files/96-lime-app-index_page
@@ -1,5 +1,3 @@
 #!/bin/sh
 
 uci set uhttpd.main.index_page=lime_app_index.html
-uci commit uhttpd
-/etc/init.d/uhttpd restart

--- a/packages/lime-app/files/96-lime-app-index_page
+++ b/packages/lime-app/files/96-lime-app-index_page
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+uci set uhttpd.main.index_page=lime_app_index.html
+uci commit uhttpd
+/etc/init.d/uhttpd restart

--- a/packages/lime-app/files/lime_app_index.html
+++ b/packages/lime-app/files/lime_app_index.html
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Cache-Control" content="no-cache" />
+<meta http-equiv="refresh" content="0; URL=/app" />
+</head>
+<body style="background-color: white">
+<a style="color: black; font-family: arial, helvetica, sans-serif;" href="/app">LiMe-App</a>
+</body>
+</html>


### PR DESCRIPTION
Fixes #609 
The new index file used for redirection has been copied from LibreRouter's OpenWrt repository [here](https://github.com/LibreRouterOrg/openwrt/blob/d2282e29b0888dfa272149d845f48b202ec61b6f/files/www/index.html).
