### PR TITLE
anygw: use dnsmasq host-record instead of address

### DIFF
--- a/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
+++ b/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
@@ -93,18 +93,10 @@ function anygw.configure(args)
 	uci:set("dhcp", owrtInterfaceName, "dhcp_option", { "option:mtu,"..anygw.SAFE_CLIENT_MTU } )
 	uci:set("dhcp", owrtInterfaceName, "force", "1")
 
-	uci:foreach("dhcp", "dnsmasq",
-		function(s)
-			uci:set("dhcp", s[".name"], "address", {
-						"/anygw/"..anygw_ipv4:host():string(),
-						"/anygw/"..anygw_ipv6:host():string(),
-						"/thisnode.info/"..anygw_ipv4:host():string(),
-						"/thisnode.info/"..anygw_ipv6:host():string(),
-						"/minodo.info/"..anygw_ipv4:host():string(),
-						"/minodo.info/"..anygw_ipv6:host():string()
-			})
-		end
-	)
+	--! useing host-record to declare own DNS entries (and not dnsmasq address as it wildcards subdomains)
+	uci:set("dhcp", "anygw_dns", "hostrecord")
+	uci:set("dhcp", "anygw_dns", "name", {"anygw", "thisnode.info", "minodo.info"})
+	uci:set("dhcp", "anygw_dns", "ip", anygw_ipv4:host():string() .. "," .. anygw_ipv6:host():string())
 
 	uci:save("dhcp")
 


### PR DESCRIPTION
This fixes dnsmasq returning the anycast address when the dns query
is for a host if dnsmasq does not know about it. For example
pepe.thisnode.info was returning the anycast address if pepe was not
known by dnsmasq (or only the ipv4 was known and the ipv6 was
requested).

This started to bite after https://github.com/libremesh/lime-packages/pull/541

This is related to openwrt's:
```
dfea3bae11dd5c207182371ce1fdca763fb5bbe0
    Author: Jo-Philipp Wich <jow@openwrt.org>
    Date:   Mon Jun 17 11:55:30 2013 +0000

        dnsmasq: use host-record instead of address

        Using "--address" for individual host A records is broken, use
	"--host-record" instead.
```

before the fix:
```
$ dig +noall +answer  A @nodo2 bonzo
bonzo.            0    IN    A    10.133.xxx.204

$ dig +noall +answer AAAA @nodo2 bonzo

$ dig +noall +answer  A @nodo2 bonzo.thisnode.info
bonzo.thisnode.info.    0    IN    A    10.133.xxx.204

$ dig +noall +answer AAAA @nodo2 bonzo.thisnode.info 
bonzo.thisnode.info.    0    IN    AAAA    2a00:1508:a85:xxxx::1
```