### PR TITLE
lime.network: fix /etc/dnsmasq.d/*.conf not being loaded

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -138,7 +138,15 @@ function network.setup_dns()
 	)
 	uci:save("dhcp")
 
-	fs.writefile("/etc/dnsmasq.conf", "conf-dir=/etc/dnsmasq.d\n")
+	--! some dynamic scripts prefer to use confdir=/tmp/dnsmasq.d (which is the openwrt default)
+	--! so we add all the /etc/dnsmasq.d/*.conf files as individual conf-file options instead
+	--! of using uci set confdir=/etc/dnsmasq.d
+	local dnsmasq_conf_file = ""
+	for conf_file in fs.glob("/etc/dnsmasq.d/*.conf") do
+		dnsmasq_conf_file = dnsmasq_conf_file .. "conf-file=" .. conf_file .. "\n"
+	end
+
+	fs.writefile("/etc/dnsmasq.conf", dnsmasq_conf_file)
 	fs.mkdir("/etc/dnsmasq.d")
 end
 


### PR DESCRIPTION
`/etc/dnsmasq.d/*.conf` weren't loaded so for example `/etc/dnsmasq.d/lime-proto-anygw-20-ipv6.conf` was not loaded...

So this fixes ipv6 slaac dns resolution among other things. Options now aplied from `/etc/dnsmasq.d/lime-proto-anygw-20-ipv6.conf`:
```
enable-ra
ra-param=anygw,mtu:1350,120
dhcp-range=tag:anygw,2a00:1508:a85:3a00::,ra-names,24h
dhcp-option=tag:anygw,option6:domain-search,thisnode.info
```