### PR TITLE
Set default country code to US

### DIFF
--- a/packages/lime-docs/files/lime-example
+++ b/packages/lime-docs/files/lime-example
@@ -59,7 +59,7 @@ config lime network
 ### WiFi general options
 
 config lime wifi
-#	option country 'ES'				# set this to your location country code, for example in Spain, setting ES allows you to use channel 13
+	option country 'US'				# set this to your location country code, for example in Spain, setting ES allows you to use channel 13
 	option channel_2ghz '11'			# May be either a list or a single option, in case of a list channel will be selected according to radio index
 #	option channel_5ghz '48'			# Check for allowed channels on https://en.wikipedia.org/wiki/List_of_WLAN_channels#regulatory_tables5.0ghz
 	list channel_5ghz '48'				# If channel is a list, each entry of the list is used for a different radio

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -45,6 +45,7 @@ config lime network
 	option use_odhcpd false
 
 config lime wifi
+	option country 'US'
 	option channel_2ghz '11'
 	list channel_5ghz '48'
 	list channel_5ghz '157'


### PR DESCRIPTION
A default country code has to be set for routers not having a factory default one, see #594.
`US` is a safe default, as most of the commercial routers have it as a factory default.

Fixes #594