### PR TITLE
Add txpower option for wireless radios

### DIFF
--- a/packages/lime-docs/files/lime-example
+++ b/packages/lime-docs/files/lime-example
@@ -107,6 +107,12 @@ config wifi radio99 # you should ensure that the chosen radio name exists, for e
 config wifi radio99 # you should ensure that the chosen radio name exists, for example with "wifi status" command, likely radio0 or radio1
 	option modes 'manual' # If you use manual protocol you must not specify other protocol, or your configuration will be broken!
 
+## decrease power output for radio99
+# decreasing the output power is rarely a good idea, do it just if you are very sure of what you are doing
+# be aware that decreasing the output power can create a "hidden node problem", see https://en.wikipedia.org/wiki/Hidden_node_problem
+config wifi radio99 # you should ensure that the chosen radio name exists, for example with "wifi status" command, likely radio0 or radio1
+	option txpower '14' # For knowing the current txpower, use the "iwinfo" command.
+
 ## set radio99 to do only adhoc and set the channel
 config wifi radio99 # you should ensure that the chosen radio name exists, for example with "wifi status" command, likely radio0 or radio1. All the other non-specified options will be taken from the general "config lime wifi" section
 	list modes 'adhoc'

--- a/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
@@ -162,6 +162,7 @@ function wireless.configure()
 			uci:set("wireless", radioName, "noscan", 1)
 			uci:set("wireless", radioName, "channel", channel)
 			if options["country"] then uci:set("wireless", radioName, "country", options["country"]) end
+			if options["txpower"] then uci:set("wireless", radioName, "txpower", options["txpower"]) end
 			if htmode then uci:set("wireless", radioName, "htmode", htmode) end
 			uci:save("wireless")
 
@@ -177,6 +178,7 @@ function wireless.configure()
 					                and (not key:match("^%."))
 					                and (not key:match("channel"))
 					                and (not key:match("country"))
+					                and (not key:match("txpower"))
 					                and (not key:match("htmode"))
 					                and (not (wireless.isMode(keyPrefix) and keyPrefix ~= modeName))
 					                and (not key:match(ignoredSuffix)) )


### PR DESCRIPTION
I some rare cases can make sense to decrease the output power of wireless radios.
This PR adds the possibility to set the txpower both globally (makes sense only for single-radio routers) or specifically for each wireless radio.