### PR TITLE
Specific wireless interface: if no mode is configured, use default ones

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
@@ -116,7 +116,7 @@ function wireless.configure()
 		local options = config.get_all("wifi")
 
 		if specRadio then
-			modes = specRadio["modes"]
+			modes = specRadio["modes"] or modes
 			options = utils.tableMelt(options, specRadio)
 		end
 


### PR DESCRIPTION
Currently, if a specific wireless interface configuration is used but no mode is specified, `lime-config` fails due to indexing of a nil value in `if modes[1] ~= "manual" then` introduced in https://github.com/libremesh/lime-packages/commit/d4f7a8c2bf20a373854c1f796dec9f9916642bbb.
Even if it was not failing, I think that a specific interface configuration without any mode does not make much sense. So now, if no mode is specified, the general ones are used.