### PR TITLE
lime-proto-batadv VLAN ID start from 50 rather than from 16

### DIFF
--- a/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
+++ b/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
@@ -67,9 +67,9 @@ function batadv.setup_interface(ifname, args)
 	local mtu = 1532
 
 	--! Unless a specific integer is passed, parse network_id (%N1) template
-	--! and use that number + 16 to get a vlanId between 16 and 271 for batadv
+	--! and use that number + 50 to get a vlanId between 50 and 305 for batadv
 	--! (to avoid overlapping with other protocols)
-	if not tonumber(vlanId) then vlanId = 16 + utils.applyNetTemplate10(vlanId) end
+	if not tonumber(vlanId) then vlanId = 50 + utils.applyNetTemplate10(vlanId) end
 
 	local owrtInterfaceName, _, owrtDeviceName = network.createVlanIface(ifname, vlanId, nameSuffix, vlanProto)
 


### PR DESCRIPTION
Read bug report on #670 
Currently, the default Babeld VLAN ID is 17 but Batman-adv VLAN ID is randomized between 16 and 271. This means that when changing the ap_name option (which gets used for generating Batman-adv VLAN ID) there's a probability of 1 over 256 that the configuration will be really broken.
Both this solution and the alternative one (change Babeld VLAN ID) will break retrocompatiblity with routers flashed with recent development code.

Fix #670