### PR TITLE
lime-proto-batadv VLAN ID start from 20 rather than from 16 and keep old default VLAN ID

### DIFF
--- a/packages/lime-docs/files/lime-example
+++ b/packages/lime-docs/files/lime-example
@@ -30,10 +30,10 @@ config lime network
 	list protocols ieee80211s			# List of protocols configured by LiMe, some of these require the relative package "lime-proto-...". Note that if you set here some protocols, you overwrite the *whole* list of protocols set in /etc/config/lime-defaults
 	list protocols lan
 	list protocols anygw
-	list protocols batadv:%N1			# Parametrizable with %Nn (which depends from ap_ssid), note that this will range between 16 and 272
+	list protocols batadv:%N1			# Parametrizable with %Nn (which depends from ap_ssid), note that this will range between 29 and 284
 #	list protocols batadv:0				# If 0 VLAN tags are disabled and the routing is done on the raw interface
 	list protocols bmx6:13				# The VLAN type can be provided as a third argument, for example bmx6:13:8021q for using VLAN 802.1q instead of the default 802.1ad
-	list protocols olsr:14
+	list protocols olsr:14				# Do not use a VLAN ID between 29 and 284 as this range is reserved for batadv:%N1 parameterization, maximum ID is 4095
 	list protocols olsr6:15
 	list protocols olsr2:16
 	list protocols babeld:17

--- a/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
+++ b/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
@@ -67,9 +67,10 @@ function batadv.setup_interface(ifname, args)
 	local mtu = 1532
 
 	--! Unless a specific integer is passed, parse network_id (%N1) template
-	--! and use that number + 16 to get a vlanId between 16 and 271 for batadv
-	--! (to avoid overlapping with other protocols)
-	if not tonumber(vlanId) then vlanId = 16 + utils.applyNetTemplate10(vlanId) end
+	--! and use that number to get a vlanId between 29 and 284 for batadv
+	--! (to avoid overlapping with other protocols,
+	--! complex definition is for keeping retrocompatibility)
+	if not tonumber(vlanId) then vlanId = 29 + (utils.applyNetTemplate10(vlanId) - 13) % 256 end
 
 	local owrtInterfaceName, _, owrtDeviceName = network.createVlanIface(ifname, vlanId, nameSuffix, vlanProto)
 

--- a/tests/test_lime_config_device.lua
+++ b/tests/test_lime_config_device.lua
@@ -52,6 +52,7 @@ describe('LiMe Config tests', function()
         assert.is.equal('17', uci:get('network', 'lm_net_wlan1_mesh_babeld_dev', 'vid'))
         assert.is_nil(uci:get('network', 'lm_net_wlan1_mesh_babeld_dev', 'mtu'))
 
+        assert.is.equal('29', uci:get('network', 'lm_net_wlan1_mesh_batadv_dev', 'vid'))
 
         assert.is_nil(uci:get('network', 'globals', 'ula_prefix'))
 		for _, radio in ipairs({'radio0', 'radio1', 'radio2'}) do


### PR DESCRIPTION
See the discussion on #676
This PR is an alternative to #676 
Retrocompatibility with the previous release is not going to happen anyway, so this keeps the retrocompatibility just for the users using development code.
At the price of a bit more weird way to calculate the VLAN ID.