### PR TITLE
ubus-lime-metrics: use http instead of icmp to detect internet

### DIFF
--- a/packages/ubus-lime-metrics/files/usr/sbin/last_internet
+++ b/packages/ubus-lime-metrics/files/usr/sbin/last_internet
@@ -8,7 +8,7 @@
 
 result=''
 # if 8.8.8.8 is accessible, print internet path
-if ping -q -c5 -w10 8.8.8.8 &>/dev/null; then
+if wget http://detectportal.firefox.com/success.txt -q -O - &>/dev/null; then
     #BMX6 Path to INternet
     if [[ -f '/usr/lib/opkg/info/lime-proto-bmx6.control' ]]; then 
         default_dev=`ip r | grep "default dev" | cut -d' ' -f3`;


### PR DESCRIPTION
Some ISP drop some ICMP packets (like ping), so using http is better to detect internet (and also http/tcp is more reliable than icmp).