### PR TITLE
utils: adds unsafe_shell() and shell_quote() functions

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -261,4 +261,21 @@ function utils.uptime_s()
     return tonumber(string.match(uptime_line, "^%S+"))
 end
 
+--! Escape strings for safe shell usage.
+function utils.shell_quote(s)
+    --! Based on Python's shlex.quote()
+    return "'" .. string.gsub(s, "'", "'\"'\"'") .. "'"
+end
+
+--! Excutes a shell command, waits for completion and returns stdout.
+--! Warning! Use this function carefully as it could be exploted if used with
+--! untrusted input. Always use function utils.shell_quote() to escape untrusted
+--! input.
+function utils.unsafe_shell(command)
+    local handle = io.popen(command)
+    local result = handle:read("*a")
+    handle:close()
+    return result
+end
+
 return utils

--- a/packages/lime-system/tests/test_lime_utils.lua
+++ b/packages/lime-system/tests/test_lime_utils.lua
@@ -1,7 +1,7 @@
 local utils = require 'lime.utils'
 local test_utils = require 'tests.utils'
 
-describe('LiMe Utils tests', function()
+describe('LiMe Utils tests #limeutils', function()
     it('test literalize(str) with a string that has all the reserved chars', function()
         local str = 'f+o[o]?.*(,)_-%a$l^'
         assert.is.equal('f%+o%[o%]%?%.%*%(,%)_%-%%a%$l%^', utils.literalize(str))
@@ -59,5 +59,21 @@ describe('LiMe Utils tests', function()
 		utils.write_file(filename, content)
 		assert.is.equal(content, utils.read_file(filename))
     end)
+
+	it('test shell_quote', function()
+		assert.is.equal("'foo'", utils.shell_quote("foo"))
+		assert.is.equal("'ls ; cmd'", utils.shell_quote("ls ; cmd"))
+		assert.is.equal([['"']], utils.shell_quote('"'))
+		assert.is.equal([['$'"'"'b']], utils.shell_quote("$'b"))
+	end)
+
+	it('test unsafe_shell', function()
+		assert.is.equal("1\n", utils.unsafe_shell("echo 1"))
+	end)
+
+	it('test unsafe_shell returns only stdout', function()
+		assert.is.equal("", utils.unsafe_shell("ls /wrong/path 2>/dev/null"))
+		assert.is.equal("", utils.unsafe_shell("echo 1 2>/dev/null 1>&2"))
+	end)
 
 end)


### PR DESCRIPTION
We have multiple shell() functions all over the code and in some places the use is not safe. Let's face that it is a very handy practice but let's do it "safe". So I propose to add a new `utils.unsafe_shell()` function. The idea of having the unsafe word in its name is to encourage the developer of taking it carefully. 
Also adding `utils.shell_quote()` that is based on Python's shlex.quote(). Using unsafe_shell + shell_quote may be considered "safe".

After this PR is merged I will push changes to replace the actual shell calls by this new functions.