### PR TITLE
lime-report fix dmesg command and add info on firewalls

### DIFF
--- a/packages/lime-report/files/lime-report.sh
+++ b/packages/lime-report/files/lime-report.sh
@@ -58,9 +58,9 @@ generate_status() {
     paste_cmd iwinfo
     paste_cmd wifi status
     paste_cmd swconfig dev switch0 show
-    paste_cmd iptables -vL -t filter
-    paste_cmd iptables -vL -t nat
-    paste_cmd iptables -vL -t mangle
+    paste_cmd iptables -vnL -t filter
+    paste_cmd iptables -vnL -t nat
+    paste_cmd iptables -vnL -t mangle
     paste_cmd ebtables -t filter -L
     paste_cmd ebtables -t nat -L
     paste_cmd ebtables -t broute -L

--- a/packages/lime-report/files/lime-report.sh
+++ b/packages/lime-report/files/lime-report.sh
@@ -58,6 +58,12 @@ generate_status() {
     paste_cmd iwinfo
     paste_cmd wifi status
     paste_cmd swconfig dev switch0 show
+    paste_cmd iptables -vL -t filter
+    paste_cmd iptables -vL -t nat
+    paste_cmd iptables -vL -t mangle
+    paste_cmd ebtables -t filter -L
+    paste_cmd ebtables -t nat -L
+    paste_cmd ebtables -t broute -L
 }
 
 generate_all() {

--- a/packages/lime-report/files/lime-report.sh
+++ b/packages/lime-report/files/lime-report.sh
@@ -61,9 +61,9 @@ generate_status() {
     paste_cmd iptables -vnL -t filter
     paste_cmd iptables -vnL -t nat
     paste_cmd iptables -vnL -t mangle
-    paste_cmd ebtables -t filter -L
-    paste_cmd ebtables -t nat -L
-    paste_cmd ebtables -t broute -L
+    paste_cmd ebtables -t filter -L --Lc
+    paste_cmd ebtables -t nat -L --Lc
+    paste_cmd ebtables -t broute -L --Lc
 }
 
 generate_all() {

--- a/packages/lime-report/files/lime-report.sh
+++ b/packages/lime-report/files/lime-report.sh
@@ -37,7 +37,7 @@ generate_config() {
 }
 
 generate_status() {
-    paste_cmd dmesg | tail -c 10
+    paste_cmd "dmesg | tail -n 20"
     paste_cmd batctl if
     paste_cmd batctl o
     paste_cmd bmx6 -c show=status show=interfaces show=links show=originators show=tunnels


### PR DESCRIPTION
There were two errors in the capture of the dmesg output in lime-report utility: tail was using -c option instead of -n and the fact that the command included a pipe made necessary to enclose the command in quotes.