### PR TITLE
FBW community shared password network creation

### DIFF
--- a/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
+++ b/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
@@ -255,22 +255,23 @@ function fbw.read_configs()
 end
 
 -- Apply configuration for a new network ( used in ubus daemon)
-function fbw.apply_user_configs(configs, hostname)
-    fbw.log('apply_file_config(ssid=' .. configs.ssid .. ', hostname=' .. hostname .. ')')
+function fbw.create_network(ssid, hostname, password)
+    fbw.log('apply_file_config(ssid=' .. ssid .. ', hostname=' .. hostname .. ')')
     local uci_cursor = config.get_uci_cursor()
-    -- Mesh network name
-    local name = configs.ssid
-    -- Format hostname
-    hostname = hostname or config.get("system", "hostname")
+
     -- Save changes in lime-community
-    uci_cursor:set("lime-community", 'wifi', 'ap_ssid', name)
-    uci_cursor:set("lime-community", 'wifi', 'apname_ssid', name..'/%H')
-    uci_cursor:set("lime-community", 'wifi', 'adhoc_ssid', 'LiMe.%H')
-    uci_cursor:set("lime-community", 'wifi', 'ieee80211s_mesh_id', 'LiMe')
+    if password ~= nil and password ~= '' then
+        lutils.set_password('root', password) -- this takes 1 second, it may be replaced with nixio.crypt(password, '$1$vv44cu1H')
+        uci_cursor:set("lime-community", 'system', 'root_password_policy', 'SET_SECRET')
+        uci_cursor:set("lime-community", 'system', 'root_password_secret', lutils.get_root_secret())
+    end
+    uci_cursor:set("lime-community", 'wifi', 'ap_ssid', ssid)
+    uci_cursor:set("lime-community", 'wifi', 'apname_ssid', ssid..'/%H')
     uci_cursor:commit("lime-community")
+
     -- Apply new configuration and setup hostname
     config.reset_node_config()
-    uci_cursor:set("lime-node", 'system', 'hostname', hostname)
+    uci_cursor:set("lime-node", 'system', 'hostname', hostname or config.get("system", "hostname"))
     fbw.end_config()
 end
 

--- a/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
+++ b/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
@@ -261,9 +261,7 @@ function fbw.create_network(ssid, hostname, password)
 
     -- Save changes in lime-community
     if password ~= nil and password ~= '' then
-        lutils.set_password('root', password) -- this takes 1 second, it may be replaced with nixio.crypt(password, '$1$vv44cu1H')
-        uci_cursor:set("lime-community", 'system', 'root_password_policy', 'SET_SECRET')
-        uci_cursor:set("lime-community", 'system', 'root_password_secret', lutils.get_root_secret())
+        lutils.set_shared_root_password(password)
     end
     uci_cursor:set("lime-community", 'wifi', 'ap_ssid', ssid)
     uci_cursor:set("lime-community", 'wifi', 'apname_ssid', ssid..'/%H')

--- a/packages/first-boot-wizard/tests/test_firstbootwizard.lua
+++ b/packages/first-boot-wizard/tests/test_firstbootwizard.lua
@@ -7,6 +7,7 @@ local fs = require("nixio.fs")
 local fbw_utils = require('firstbootwizard.utils')
 
 local uci = nil
+config.log = function () end
 
 local community_file = [[
 config lime 'system'
@@ -68,6 +69,19 @@ describe('FirstBootWizard tests #fbw', function()
         assert.is.equal(1, #configs)
         assert.is.equal('foo', configs[1]['config']['wifi']['ap_ssid'])
         assert.is.equal('lime-community__host__foonode', configs[1]['file'])
+    end)
+
+
+    it('test create_network() empty', function()
+        stub(utils, "set_password", function () return nil end)
+        stub(utils, "get_root_secret", function () return "mysecret" end)
+        stub(fbw, "end_config", function () end)
+        uci:set('lime-community', 'system', 'lime')
+
+        fbw.create_network("LibreMesh", "myhost", "mypassword")
+
+        assert.is.equal('SET_SECRET', uci:get("lime-community", 'system', 'root_password_policy'))
+        assert.is.equal('mysecret', uci:get("lime-community", 'system', 'root_password_secret'))
     end)
 
     before_each('', function()

--- a/packages/first-boot-wizard/tests/test_firstbootwizard.lua
+++ b/packages/first-boot-wizard/tests/test_firstbootwizard.lua
@@ -82,6 +82,7 @@ describe('FirstBootWizard tests #fbw', function()
 
         assert.is.equal('SET_SECRET', uci:get("lime-community", 'system', 'root_password_policy'))
         assert.is.equal('mysecret', uci:get("lime-community", 'system', 'root_password_secret'))
+        assert.stub(utils.set_password).was.called_with('root', "mypassword")
     end)
 
     before_each('', function()

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -326,6 +326,13 @@ function utils.set_root_secret(secret)
 	end
 end
 
+function utils.set_shared_root_password(password)
+    local uci = config.get_uci_cursor()
+    utils.set_password('root', password) -- this takes 1 second, it may be replaced with nixio.crypt(password, '$1$vv44cu1H')
+    uci:set("lime-community", 'system', 'root_password_policy', 'SET_SECRET')
+    uci:set("lime-community", 'system', 'root_password_secret', utils.get_root_secret())
+end
+
 --! returns a random string. filter is an optional function to reduce the possible characters.
 --! by default the filter allows all the alphanumeric characters
 function utils.random_string(length, filter)

--- a/packages/ubus-lime-fbw/README.md
+++ b/packages/ubus-lime-fbw/README.md
@@ -1,20 +1,18 @@
 # FirstBootWizard Libremesh ubus module
 
-| Path     | Procedure       | Signature          | Description                               |
-| -------- | --------------- | ------------------ | ----------------------------------------- |
-| lime-fbw | status          | {}                 | Get FBW status (scanning, lock, disabled) |
-| lime-fbw | create_network  | {"name": "string"} | Create network                            |
-| lime-fbw | search_networks | {"scan": true      | false}                                    | Get all networks (true force rescan) |
-| lime-fbw | set_network     | {"file": "string"} | Use one of the results                    |
-
-## Examples
+| Path     | Procedure       |  Description                              |
+| -------- | --------------- | ----------------------------------------- |
+| lime-fbw | status          | Get FBW status (scanning, lock, disabled) |
+| lime-fbw | create_network  | Create a new network                      |
+| lime-fbw | search_networks | Get all networks (true force rescan)      |
+| lime-fbw | set_network     | Use one of the results                    |
 
 ### ubus -v list lime-fbw
 
 ```
 ''lime-fbw' @4c5b89e0
 	"status":{}
-	"create_network":{"name":"String"}
+	"create_network":{"network":"String","hostname":"String", "password": "String"}
 	"search_networks":{"scan":"Boolean"}
-	"set_network":{"file":"String"}
+	"set_network":{"hostname":"String","file":"String"}
 ```

--- a/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
+++ b/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
@@ -60,16 +60,14 @@ local methods = {
         },
         create_network = {
             function(req, msg)
-                local configs = {}
-                if (msg.network ~= nil) then
-                    configs.ssid = msg.network
+                if (msg.network ~= nil and msg.hostname ~= nil) then
                     conn:reply(req, { status = 'done' })
-                    fbw.apply_user_configs(configs, msg.hostname)
+                    fbw.create_network(msg.network, msg.hostname, msg.password)
                     return
                 else
-                    conn:reply(req, { status = 'error', msg = "Network name is required"})
+                    conn:reply(req, { status = 'error', msg = "Network and hostname are required" })
                 end
-            end, { network = ubus.STRING, hostname = ubus.STRING }
+            end, { network = ubus.STRING, hostname = ubus.STRING, password = ubus.STRING }
         }
     }
 }

--- a/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
+++ b/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
@@ -62,7 +62,7 @@ local methods = {
             function(req, msg)
                 if (msg.network ~= nil and msg.hostname ~= nil) then
                     conn:reply(req, { status = 'done' })
-                    fbw.create_network(msg.network, msg.hostname, msg.password)
+                    fbw.create_network(msg.network, msg.hostname, msg.adminPassword)
                     return
                 else
                     conn:reply(req, { status = 'error', msg = "Network and hostname are required" })

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils-admin
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils-admin
@@ -20,7 +20,7 @@ local function set_root_password(msg)
     if type(msg.password) ~= "string" then
         result = {status = 'error', msg = 'Password must be a string'}
     else
-        utils.set_password('root', msg.password or '')
+        utils.set_shared_root_password(msg.password or '')
         result = {status = 'ok'}
     end
     return utils.printJson(result)

--- a/packages/ubus-lime-utils/files/usr/share/rpcd/acl.d/lime-utils-admin.json
+++ b/packages/ubus-lime-utils/files/usr/share/rpcd/acl.d/lime-utils-admin.json
@@ -1,0 +1,15 @@
+{
+	"root": {
+		"description": "root access only",
+		"read": {
+			"ubus": {
+					"lime-utils-admin": [ "*" ]
+			}
+		},
+		"write": {
+			"ubus": {
+					"lime-utils-admin": [ "*" ]
+			}
+		}
+	}
+}

--- a/packages/ubus-lime-utils/tests/test_lime_utils_admin.lua
+++ b/packages/ubus-lime-utils/tests/test_lime_utils_admin.lua
@@ -15,11 +15,15 @@ describe('ubus-lime-utils-admin tests #ubuslimeutilsadmin', function()
     end)
 
     it('test set_root_password', function()
+        uci:set('lime-community', 'system', 'lime')
         stub(utils, "set_password", function (user, pass) return pass end)
+
         local response  = rpcd_call(ubus_lime_utils, {'call', 'set_root_password'},
                                     '{"password": "foo"}')
+
         assert.is.equal("ok", response.status)
         assert.stub(utils.set_password).was.called_with('root', 'foo')
+        assert.is.equal("SET_SECRET", uci:get("lime-community", 'system', 'root_password_policy'))
     end)
 
     before_each('', function()


### PR DESCRIPTION
Allow  the creation of a network with a shared community admin password
Also `fbw.apply_user_configs(configs. hostname)` is changed by a clearer `fbw.create_network(ssid, hostname, password)`

This is to be applied on top of PR #700 , so only the last few commits are new to review.