### PR TITLE
proto-batadv: adapt to new UCI API

### DIFF
--- a/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
+++ b/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
@@ -9,43 +9,63 @@ local config = require("lime.config")
 batadv = {}
 
 batadv.configured = false
+batadv.old_cfg_api = false
+batadv.type_option = 'master'
+batadv.ifc_proto = 'batadv_hardif'
+
+function batadv.detect_old_cfg_api()
+    return not fs.lstat("/lib/netifd/proto/batadv_hardif.sh")
+end
 
 function batadv.configure(args)
 	if batadv.configured then return end
 	batadv.configured = true
 
+    --! Detect batman config API until 2019.0-2/OpenWrt 18.06.x
+    local cfg_file = 'network'
+	if batadv.detect_old_cfg_api() then
+		batadv.old_cfg_api = true
+		cfg_file = 'batman-adv'
+		batadv.ifc_proto = 'batadv'
+		batadv.type_option = 'mesh'
+    end
+
 	local uci = config.get_uci_cursor()
 
-	uci:set("network", "bat0", "interface")
-	uci:set("network", "bat0", "proto", "batadv")
-	uci:set("network", "bat0", "interface")
-	uci:set("network", "bat0", "bridge_loop_avoidance", "1")
-	uci:set("network", "bat0", "multicast_mode", "0")
+	if not batadv.old_cfg_api then
+		uci:set(cfg_file, "bat0", "interface")
+		uci:set(cfg_file, "bat0", "proto", "batadv")
+    else
+		uci:set(cfg_file, "bat0", "mesh")
+	end
+
+	uci:set(cfg_file, "bat0", "bridge_loop_avoidance", "1")
+	uci:set(cfg_file, "bat0", "multicast_mode", "0")
 
 	-- if anygw enabled disable DAT that doesn't play well with it
 	-- and set gw_mode=client everywhere. Since there's no gw_mode=server, this makes bat0 never forward requests
 	-- so a rogue DHCP server doesn't affect whole network (DHCP requests are always answered locally)
 	for _,proto in pairs(config.get("network", "protocols")) do
 		if proto == "anygw" then
-			uci:set("network", "bat0", "distributed_arp_table", "0")
-			uci:set("network", "bat0", "gw_mode", "client")
+			uci:set(cfg_file, "bat0", "distributed_arp_table", "0")
+			uci:set(cfg_file, "bat0", "gw_mode", "client")
 		end
 	end
-
+	uci:save(cfg_file)
 	lan.setup_interface("bat0", nil)
 
 	--! Avoid dmesg flooding caused by BLA. Create a dummy0 interface with
 	--! custom MAC, as dummy0 is created very soon on boot it is added as
 	--! first and then main interface to batman so BLA messages are sent
-	--! from that MAC avoiding generating warning like:  
+	--! from that MAC avoiding generating warning like:
 	--! br-lan: received packet on bat0 with own address as source address
 	local owrtInterfaceName = network.limeIfNamePrefix.."batadv_dummy_if"
 	local dummyMac = network.primary_mac(); dummyMac[1] = "aa"
 	uci:set("network", owrtInterfaceName, "interface")
 	uci:set("network", owrtInterfaceName, "ifname", "dummy0")
 	uci:set("network", owrtInterfaceName, "macaddr", table.concat(dummyMac, ":"))
-	uci:set("network", owrtInterfaceName, "proto", "batadv_hardif")
-	uci:set("network", owrtInterfaceName, "master", "bat0")
+	uci:set("network", owrtInterfaceName, "proto", batadv.ifc_proto)
+	uci:set("network", owrtInterfaceName, batadv.type_option, "bat0")
 	uci:save("network")
 
 	-- enable alfred on bat0 if installed
@@ -76,8 +96,8 @@ function batadv.setup_interface(ifname, args)
 
 	local uci = config.get_uci_cursor()
 	uci:set("network", owrtDeviceName, "mtu", mtu)
-	uci:set("network", owrtInterfaceName, "proto", "batadv_hardif")
-	uci:set("network", owrtInterfaceName, "master", "bat0")
+	uci:set("network", owrtInterfaceName, "proto", batadv.ifc_proto)
+	uci:set("network", owrtInterfaceName, batadv.type_option, "bat0")
 	uci:save("network")
 end
 

--- a/packages/lime-proto-batadv/tests/test_batadv.lua
+++ b/packages/lime-proto-batadv/tests/test_batadv.lua
@@ -1,0 +1,73 @@
+local config = require 'lime.config'
+local network = require 'lime.network'
+local wireless = require 'lime.wireless'
+local utils = require 'lime.utils'
+local test_utils = require 'tests.utils'
+local proto = require 'lime.proto.batadv'
+
+-- disable logging in config module
+config.log = function() end
+
+local uci
+
+describe('LiMe proto Batman-adv #protobatadv', function()
+    it('test config', function()
+        config.set('network', 'lime')
+        config.set('network', 'protocols', {'lan'})
+        stub(proto, "detect_old_cfg_api", function () return false end)
+        stub(network, "primary_mac", function () return  {'00', '00', '00', '00', '00', '00'} end)
+
+        batadv.configured = false
+        proto.configure()
+
+        assert.is.equal('batadv', uci:get('network', 'bat0', 'proto'))
+        assert.is.equal('1', uci:get('network', 'bat0', 'bridge_loop_avoidance'))
+        assert.is.equal('0', uci:get('network', 'bat0', 'multicast_mode'))
+
+        assert.is.equal('batadv_hardif', uci:get("network", "lm_net_batadv_dummy_if", "proto"))
+        assert.is.equal('bat0', uci:get("network", "lm_net_batadv_dummy_if", "master"))
+
+        -- anygw is disabled
+        assert.is_nil(uci:get('network', 'bat0', 'distributed_arp_table'))
+        assert.is_nil(uci:get('network', 'bat0', 'gw_mode'))
+    end)
+
+    it('test config 2', function()
+        config.set('network', 'lime')
+        config.set('network', 'protocols', {'lan', 'anygw'})
+        stub(proto, "detect_old_cfg_api", function () return false end)
+        stub(network, "primary_mac", function () return  {'00', '00', '00', '00', '00', '00'} end)
+
+        batadv.configured = false
+        proto.configure()
+
+        -- anygw is enabled
+        assert.is.equal('0', uci:get('network', 'bat0', 'distributed_arp_table'))
+        assert.is.equal('client', uci:get('network', 'bat0', 'gw_mode'))
+    end)
+
+    it('test config pre 2019.0-2 config api', function()
+
+        config.set('network', 'lime')
+        config.set('network', 'protocols', {'lan'})
+        stub(proto, "detect_old_cfg_api", function () return true end)
+        stub(network, "primary_mac", function () return  {'00', '00', '00', '00', '00', '00'} end)
+
+        batadv.configured = false
+        proto.configure()
+
+        assert.is.equal('1', uci:get('batman-adv', 'bat0', 'bridge_loop_avoidance'))
+        assert.is.equal('0', uci:get('batman-adv', 'bat0', 'multicast_mode'))
+
+        assert.is.equal('batadv', uci:get("network", "lm_net_batadv_dummy_if", "proto"))
+        assert.is.equal('bat0', uci:get("network", "lm_net_batadv_dummy_if", "mesh"))
+    end)
+
+    before_each('', function()
+        uci = test_utils.setup_test_uci()
+    end)
+
+    after_each('', function()
+        test_utils.teardown_test_uci(uci)
+    end)
+end)


### PR DESCRIPTION
commit openwrt-routing/packages@54af5a209e0a
("batman-adv: Split batadv proto in meshif and hardif part") changed the
way batman-adv is configured in OpenWrt. Change the lime proto accordingly.
This is needed for lime-proto-batadv to work with OpenWrt 19.07 or newer.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>