### PR TITLE
wireless: add option legacy_rates to allow disabling 11b rates

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/wireless.lua
@@ -162,6 +162,7 @@ function wireless.configure()
 			uci:set("wireless", radioName, "noscan", 1)
 			uci:set("wireless", radioName, "channel", channel)
 			if options["country"] then uci:set("wireless", radioName, "country", options["country"]) end
+			if options["legacy_rates"] and not wireless.is5Ghz(radioName) then uci:set("wireless", radioName, "legacy_rates", options["legacy_rates"]) end
 			if options["txpower"] then uci:set("wireless", radioName, "txpower", options["txpower"]) end
 			if htmode then uci:set("wireless", radioName, "htmode", htmode) end
 			uci:save("wireless")
@@ -178,6 +179,7 @@ function wireless.configure()
 					                and (not key:match("^%."))
 					                and (not key:match("channel"))
 					                and (not key:match("country"))
+					                and (not key:match("legacy_rates"))
 					                and (not key:match("txpower"))
 					                and (not key:match("htmode"))
 					                and (not (wireless.isMode(keyPrefix) and keyPrefix ~= modeName))


### PR DESCRIPTION
802.11b uses 22MHz channels with CCK modulation which causes significant noise on neighbouring 20MHz channels as they are partially overlapping.
Disabling CCK allows for better spectrum utilization as can then use 4 non-overlapping 20MHz channels (1,5,9,13) instead of just 3 (1,6,11) when located within ETSI regulatory domain.

Using `'not wireless.is5Ghz(radioName)` to designate potential 802.11b radios may not cover all cases (dual-band radios, other not yet supported non-5GHz-bands such as 60GHz)... But does the trick for all classic routers.