### PR TITLE
bmx6/7: unconditionally depend on ebtables

### DIFF
--- a/packages/lime-proto-bmx6/Makefile
+++ b/packages/lime-proto-bmx6/Makefile
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
   DEPENDS:=+bmx6 +bmx6-json +bmx6-sms +bmx6-table +bmx6-uci-config +!PACKAGE_firewall:iptables \
-  +lime-system +lua +libuci-lua +PACKAGE_lime-proto-batadv:kmod-ebtables-ipv6
+  +lime-system +lua +libuci-lua +kmod-ebtables-ipv6 +ebtables
   PKGARCH:=all
 endef
 

--- a/packages/lime-proto-bmx7/Makefile
+++ b/packages/lime-proto-bmx7/Makefile
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
   DEPENDS:=+bmx7 +bmx7-json +bmx7-sms +bmx7-table +bmx7-uci-config +bmx7-tun \
-  +!PACKAGE_firewall:iptables +lime-system +lua +libuci-lua
+  +lime-system +lua +libuci-lua +kmod-ebtables-ipv6 +ebtables
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
conditional dependencies are deprecated. create hard dependency instead as it seems the only good solution.