### PR TITLE
check-internet: use uclient-fetch instead of wget

### DIFF
--- a/packages/check-internet/Makefile
+++ b/packages/check-internet/Makefile
@@ -20,6 +20,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=Utilities
 	MAINTAINER:=Santiago Piccinini <spiccinini@altermundi.net>
 	PKGARCH:=all
+	DEPENDS:=+uclient-fetch
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/check-internet/files/usr/bin/check-internet
+++ b/packages/check-internet/files/usr/bin/check-internet
@@ -4,7 +4,7 @@ DEFAULT_TIMEOUT_S=10
 TIMEOUT_S="${1:-$DEFAULT_TIMEOUT_S}"
 DETECTION_URL="http://detectportal.firefox.com/success.txt"
 
-detection_out=$(wget -q $DETECTION_URL --timeout="$TIMEOUT_S" -O - 2> /dev/null)
+detection_out=$(uclient-fetch -q --timeout="$TIMEOUT_S" $DETECTION_URL -O - 2> /dev/null)
 
 test "$detection_out" = "success"
 


### PR DESCRIPTION
uclient-fetch is used by opkg and other core utilities.