### PR TITLE
Batman-adv enable meshing over ethernet replaces #703 #724

### DIFF
--- a/packages/lime-proto-batadv/Makefile
+++ b/packages/lime-proto-batadv/Makefile
@@ -21,7 +21,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
-  DEPENDS:=+lime-system +lua +libuci-lua +kmod-batman-adv +kmod-dummy
+  DEPENDS:=+lime-system +lua +libuci-lua +kmod-batman-adv
   PKGARCH:=all
 endef
 

--- a/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
+++ b/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
@@ -86,7 +86,7 @@ function batadv.setup_interface(ifname, args)
 	if ifname:match("^eth") then
 		--! TODO: Use DSA to check if ethernet device is capable of bigger MTU
 		--! reducing it
-		mtu = 1496
+		mtu = network.MTU_ETH_WITH_VLAN
 		
 		--! Avoid dmesg flooding caused by BLA with messages like "br-lan:
 		--! received packet on bat0 with own address as source address".

--- a/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
+++ b/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
@@ -54,20 +54,6 @@ function batadv.configure(args)
 	uci:save(cfg_file)
 	lan.setup_interface("bat0", nil)
 
-	--! Avoid dmesg flooding caused by BLA. Create a dummy0 interface with
-	--! custom MAC, as dummy0 is created very soon on boot it is added as
-	--! first and then main interface to batman so BLA messages are sent
-	--! from that MAC avoiding generating warning like:
-	--! br-lan: received packet on bat0 with own address as source address
-	local owrtInterfaceName = network.limeIfNamePrefix.."batadv_dummy_if"
-	local dummyMac = network.primary_mac(); dummyMac[1] = "aa"
-	uci:set("network", owrtInterfaceName, "interface")
-	uci:set("network", owrtInterfaceName, "ifname", "dummy0")
-	uci:set("network", owrtInterfaceName, "macaddr", table.concat(dummyMac, ":"))
-	uci:set("network", owrtInterfaceName, "proto", batadv.ifc_proto)
-	uci:set("network", owrtInterfaceName, batadv.type_option, "bat0")
-	uci:save("network")
-
 	-- enable alfred on bat0 if installed
 	if utils.is_installed("alfred") then
 		uci:set("alfred", "alfred", "batmanif", "bat0")
@@ -94,10 +80,20 @@ function batadv.setup_interface(ifname, args)
 
 	local owrtInterfaceName, _, owrtDeviceName = network.createVlanIface(ifname, vlanId, nameSuffix, vlanProto)
 
+	--! Avoid dmesg flooding caused by BLA with messages like "br-lan:
+	--! received packet on bat0 with own address as source address".
+	--! Randomize MAC address for each of the interfaces included in Batman-adv.
+	local id = utils.get_id(ifname)
+	local randomMac = network.primary_mac();
+	randomMac[1] = id[1]
+	randomMac[2] = id[2]
+	randomMac[3] = id[3]
+
 	local uci = config.get_uci_cursor()
 	uci:set("network", owrtDeviceName, "mtu", mtu)
 	uci:set("network", owrtInterfaceName, "proto", batadv.ifc_proto)
 	uci:set("network", owrtInterfaceName, batadv.type_option, "bat0")
+	uci:set("network", owrtDeviceName, "macaddr", table.concat(randomMac, ":"))
 	uci:save("network")
 end
 

--- a/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
+++ b/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
@@ -78,13 +78,13 @@ end
 function batadv.setup_interface(ifname, args)
 	if not args["specific"] then
 		if ifname:match("^wlan%d+.ap") then return end
-		if ifname:match("^eth") then return end
 	end
 
 	local vlanId = args[2] or "%N1"
 	local vlanProto = args[3] or "8021ad"
 	local nameSuffix = args[4] or "_batadv"
 	local mtu = 1532
+	if ifname:match("^eth") then mtu = 1496 end
 
 	--! Unless a specific integer is passed, parse network_id (%N1) template
 	--! and use that number to get a vlanId between 29 and 284 for batadv

--- a/packages/lime-proto-batadv/tests/test_batadv.lua
+++ b/packages/lime-proto-batadv/tests/test_batadv.lua
@@ -24,9 +24,6 @@ describe('LiMe proto Batman-adv #protobatadv', function()
         assert.is.equal('1', uci:get('network', 'bat0', 'bridge_loop_avoidance'))
         assert.is.equal('0', uci:get('network', 'bat0', 'multicast_mode'))
 
-        assert.is.equal('batadv_hardif', uci:get("network", "lm_net_batadv_dummy_if", "proto"))
-        assert.is.equal('bat0', uci:get("network", "lm_net_batadv_dummy_if", "master"))
-
         -- anygw is disabled
         assert.is_nil(uci:get('network', 'bat0', 'distributed_arp_table'))
         assert.is_nil(uci:get('network', 'bat0', 'gw_mode'))
@@ -58,9 +55,6 @@ describe('LiMe proto Batman-adv #protobatadv', function()
 
         assert.is.equal('1', uci:get('batman-adv', 'bat0', 'bridge_loop_avoidance'))
         assert.is.equal('0', uci:get('batman-adv', 'bat0', 'multicast_mode'))
-
-        assert.is.equal('batadv', uci:get("network", "lm_net_batadv_dummy_if", "proto"))
-        assert.is.equal('bat0', uci:get("network", "lm_net_batadv_dummy_if", "mesh"))
     end)
 
     before_each('', function()

--- a/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
+++ b/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
@@ -38,7 +38,6 @@ currUptime="$(get_uptime)"
 
 candidateAddresses="$(
 for iface in $(ls /sys/class/net/) ; do
-	echo ${iface} | grep -q '^dummy' && continue
 	ls /sys/class/net/${iface}/upper_bat? &> /dev/null || continue
 
 	ping6 -c 2 ff02::1%${iface} 2> /dev/null | \


### PR DESCRIPTION
This PR re-enable batman-adv meshing over ethernet, this solve bla2 loops when nodes sees each other both via ethernet and wifi, the log flooding is avoided changing the mac-address of the vlan, this trick didn't worked in the past as the unicast packets never arrived to the vlan interface as they were probably sucked in by the bridge on top of the plain ethernet interface.

I have been testing this for a few days in a real network with 9 devices distributed across 3 houses with plenty of nodes which see each other both over cable and over WiFi, no loops observed and no log flooding either. Finally!