### PR TITLE
bmx7: allow setting trustedNodesDir

### DIFF
--- a/packages/lime-docs/files/lime-example
+++ b/packages/lime-docs/files/lime-example
@@ -55,6 +55,7 @@ config lime network
 	option bmx7_over_batman false
 	option bmx7_pref_gw none			# Force bmx7 to use a specific gateway to Internet (hostname must be used as identifier)
 	option bmx7_wifi_rate_max 'auto'
+	option bmx7_enable_pki false			# Trust only nodes in /etc/bmx7/trustedNodes when set (default is to trust all nodes)
 	option anygw_mac 'aa:aa:aa:%N1:%N2:aa'		# Parametrizable with %Nn. Keep in mind that the ebtables rule will use a mask of ff:ff:ff:00:00:00 so br-lan will not forward anything coming in that matches the first 3 bytes of it's own anygw_mac (aa:aa:aa: by default)
 #	option autoap_enabled 0				# Requires lime-ap-watchping installed. If enabled AP SSID is changed to ERROR when network issues
 #	option autoap_hosts "8.8.8.8 141.1.1.1"		# Requires lime-ap-watchping installed. Hosts used to check if the network is working fine

--- a/packages/lime-proto-bmx7/files/usr/lib/lua/lime/proto/bmx7.lua
+++ b/packages/lime-proto-bmx7/files/usr/lib/lua/lime/proto/bmx7.lua
@@ -142,6 +142,11 @@ function bmx7.configure(args)
 		uci:set("bmx7", "librenet6", "dev", "librenet6")
 	end
 
+	local enablePKI = config.get_bool("network", "bmx7_enable_pki")
+	if (enablePKI) then
+		uci:set(bmx7.f, "general", "trustedNodesDir", "/etc/bmx7/trustedNodes")
+	end
+
 	if(hasLan) then
 		uci:set("bmx7", "lm_net_br_lan", "dev")
 		uci:set("bmx7", "lm_net_br_lan", "dev", "br-lan")

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -43,6 +43,7 @@ config lime network
 	option bmx7_over_batman false
 	option bmx7_pref_gw none
 	option bmx7_wifi_rate_max 'auto'
+	option bmx7_enable_pki false
 	option anygw_mac "aa:aa:aa:%N1:%N2:aa"
 	option use_odhcpd false
 


### PR DESCRIPTION
To make use of bmx7 signature checking one has to set
`bmx7.general.trustedNodesDir='/etc/bmx7/trustedNodes'`
Allow communities to do that by reading the value from lime's
`network.bmx7_trustedNodesDir` option.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>