### PR TITLE
safe-upgrade improvements

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -8,6 +8,7 @@ local fs = require("nixio.fs")
 
 utils.BOARD_JSON_PATH = "/etc/board.json"
 utils.SHADOW_FILENAME = "/etc/shadow"
+utils.KEEP_ON_UPGRADE_FILES_BASE_PATH = '/lib/upgrade/keep.d/'
 
 function utils.log(...)
 	if DISABLE_LOGGING ~= nil then return end
@@ -350,6 +351,27 @@ function utils.random_string(length, filter)
         end
     end
     return out
+end
+
+--! Return a list of files to keep when upgrading. Existence of the files is not guaranteed.
+function utils.keep_on_upgrade_files()
+    local file_lists = config.get("system", "keep_on_upgrade", "")
+    local files = {}
+    for _, list in pairs(utils.split(file_lists, " ")) do
+        --! convert non absolute paths to absolute
+        if not utils.stringStarts(list, "/") then
+            list =  utils.KEEP_ON_UPGRADE_FILES_BASE_PATH .. list
+        end
+        if utils.file_exists(list) then
+            for file_name in io.lines(list) do
+                --! exclude comments, blank lines, etc
+                if utils.stringStarts(file_name, "/") then
+                    table.insert(files, file_name)
+                end
+            end
+        end
+    end
+    return files
 end
 
 return utils

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -48,7 +48,8 @@ end
 --! escape the magic characters: ( ) . % + - * ? [ ] ^ $
 --! useful to use with gsub / match when finding exactly a string
 function utils.literalize(str)
-    return str:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", function(c) return "%" .. c end)
+    local ret, _ = str:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", function(c) return "%" .. c end)
+    return ret
 end
 
 function utils.isModuleAvailable(name)

--- a/packages/lime-system/tests/test_lime_utils.lua
+++ b/packages/lime-system/tests/test_lime_utils.lua
@@ -84,6 +84,7 @@ describe('LiMe Utils tests #limeutils', function()
 		stub(os, "execute", function (cmd) return cmd end)
 		assert.is.equal("(echo 'mypassword'; sleep 1; echo 'mypassword') | passwd 'root' >/dev/null 2>&1",
 						utils.set_password("root", "mypassword"))
+        os.execute:revert()
 	end)
 
 	it('test get_root_secret', function()

--- a/packages/lime-system/tests/test_lime_utils.lua
+++ b/packages/lime-system/tests/test_lime_utils.lua
@@ -11,6 +11,8 @@ describe('LiMe Utils tests #limeutils', function()
         -- check that when replacing the original string with the literalized string
         -- the result is that all the string is replaced
         assert.is.equal('bar', string.gsub(str, utils.literalize(str), 'bar'))
+        -- return only the new string
+        assert.is.equal(1, #table.pack(utils.literalize(str)))
     end)
 
     it('test isModuleAvailable existing modules', function()

--- a/packages/lime-system/tests/test_lime_utils.lua
+++ b/packages/lime-system/tests/test_lime_utils.lua
@@ -186,12 +186,27 @@ dnsmasq:*:18362:0:99999:7:::
 		assert.is.equal("number", type(tonumber(utils.random_string(5, function (c) return c:match('%d') ~= nil end))))
 	end)
 
+    it('test keep_on_upgrade_files()', function()
+        local test_dir = test_utils.setup_test_dir()
+        local absolute_keep_file_path = test_dir .. 'absolute_keep_file'
+        config.set('system', 'lime')
+        config.set('system', 'keep_on_upgrade', 'relative_keep_file inexistent_keep_file  ' .. absolute_keep_file_path)
+
+        utils.KEEP_ON_UPGRADE_FILES_BASE_PATH = test_dir
+        utils.write_file(test_dir .. 'relative_keep_file', "# comment \n\n/foo\n/bar")
+        utils.write_file(absolute_keep_file_path, "/baz")
+
+        local files = utils.keep_on_upgrade_files()
+        assert.are.same({'/foo', '/bar', '/baz'}, files)
+    end)
+
     before_each('', function()
         uci = test_utils.setup_test_uci()
     end)
 
     after_each('', function()
         test_utils.teardown_test_uci(uci)
+        test_utils.teardown_test_dir()
     end)
 
 end)

--- a/packages/safe-upgrade/Makefile
+++ b/packages/safe-upgrade/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=Utilities
   TITLE:=$(PKG_NAME) provides safe firmware upgrades using two partitions.
   MAINTAINER:=Santiago Piccinini <spiccinini@altermundi.net>
-  DEPENDS:=+lua-argparse
+  DEPENDS:=+lua-argparse +luci-lib-jsonc +lime-system
   PKGARCH:=all
 endef
 

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -28,12 +28,13 @@ local firmware_size_bytes = 7936*1024
 local fw1_addr = 0x9f050000
 local fw2_addr = 0x9f050000 + firmware_size_bytes
 su._supported_devices = {'librerouter-v1'}
+su._mtd_partitions_desc = '/proc/mtd'
 
 -- safe upgrade script, generated with bootscript.py, DO NOT edit here!
 local bootcmd = 'run preboot; boot_part=${stable_part}; if test ${testing_part} -ne 0; then echo Testing part ${testing_part}; boot_part=${testing_part}; set testing_part 0; saveenv; fi; if test ${boot_part} -eq 2; then fw_addr=${fw2_addr}; run boot_2; else fw_addr=${fw1_addr}; run boot_1; fi; run boot_1; bootm ${fw1_addr};'
 
-local STABLE_PARTITION_NAME = 'stable_part'
-local TESTING_PARTITION_NAME = 'testing_part'
+su.STABLE_PARTITION_NAME = 'stable_part'
+su.TESTING_PARTITION_NAME = 'testing_part'
 
 local safe_upgrade_auto_reboot_script = [[#!/bin/sh /etc/rc.common
 
@@ -73,10 +74,8 @@ stop() {
 }
 ]]
 
-local function get_uboot_env(key)
-    local handle = io.popen("fw_printenv -n " .. key .. " 2>&1")
-    local value = handle:read("*a")
-    handle:close()
+function su.get_uboot_env(key)
+    local value = utils.unsafe_shell("fw_printenv -n " .. key .. " 2>&1")
 
     if value:find('## Error:') == nil then
         -- remove EOL
@@ -90,19 +89,11 @@ end
 local function set_uboot_env(key, value)
     print("DEBUG: seting key:" .. key)
     print("DEBUG: value:" .. value)
-    local handle = io.popen("fw_setenv " .. key .. " '" .. value .. "'")
-    local value = handle:read("*a")
-    handle:close()
-end
-
-local function file_exists(filename)
-    local f = io.open(filename, "rb")
-    if f then f:close() end
-    return f ~= nil
+    local value = utils.unsafe_shell("fw_setenv " .. key .. " '" .. value .. "'")
 end
 
 local function fw_env_configured()
-    return file_exists('/etc/fw_env.config')
+    return utils.file_exists('/etc/fw_env.config')
 end
 
 local function assert_fw_env_configured()
@@ -113,16 +104,11 @@ local function assert_fw_env_configured()
 end
 
 local function get_current_cmdline()
-    local handle = io.open('/proc/cmdline', 'r')
-    local data = handle:read()
-    handle:close()
-    return data
+    return utils.read_file('/proc/cmdline')
 end
 
-local function get_current_partition()
-    local handle = io.open('/proc/mtd', 'r')
-    local data = handle:read("*all")
-    handle:close()
+function su.get_current_partition()
+    local data = utils.read_file(su._mtd_partitions_desc)
     if data:find("fw2") == nil then
         return 2
     else
@@ -130,22 +116,22 @@ local function get_current_partition()
     end
 end
 
-local function get_partitions()
+function su.get_partitions()
     local p = {}
-    p.current = get_current_partition()
+    p.current = su.get_current_partition()
     if p.current == 1 then
         p.other = 2
     else
         p.other = 1
     end
-    p.stable = tonumber(get_uboot_env(STABLE_PARTITION_NAME))
-    p.testing = tonumber(get_uboot_env(TESTING_PARTITION_NAME))
+    p.stable = tonumber(su.get_uboot_env(su.STABLE_PARTITION_NAME))
+    p.testing = tonumber(su.get_uboot_env(su.TESTING_PARTITION_NAME))
 
     return p
 end
 
 local function get_su_version()
-    return get_uboot_env('su_version')
+    return su.get_uboot_env('su_version')
 end
 
 local function is_su_installed()
@@ -160,11 +146,11 @@ local function fw_env_config()
 end
 
 local function set_testing_partition(partition)
-    set_uboot_env(TESTING_PARTITION_NAME, tostring(partition))
+    set_uboot_env(su.TESTING_PARTITION_NAME, tostring(partition))
 end
 
 local function set_stable_partition(partition)
-    set_uboot_env(STABLE_PARTITION_NAME, tostring(partition))
+    set_uboot_env(su.STABLE_PARTITION_NAME, tostring(partition))
 end
 
 local function assert_su_installed()
@@ -252,7 +238,7 @@ local function bootstrap(args)
     end
 
 
-    if get_current_partition() ~= 1 then
+    if su.get_current_partition() ~= 1 then
         print("installing safe-upgrade from partition 2 is not supported yet")
         os.exit(120)
     end
@@ -281,23 +267,23 @@ end
 
 local function verify(args)
     if _verify(args.firmware) then
-        exit(0)
+        os.exit(0)
     else
         print("Invalid firmware!")
-        exit(111)
+        os.exit(111)
     end
 end
 
 local function upgrade(args)
     assert_su_installed()
-    local partitions = get_partitions()
+    local partitions = su.get_partitions()
 
     if not _verify(args.firmware) then
         print("Invalid firmware!")
         if args.force then
-            print("Forcing upgrade to continue as requested")
+            print("Forcing upgrade to continue as requested.")
         else
-            exit(111)
+            os.exit(111)
         end
     end
 
@@ -339,7 +325,7 @@ end
 
 local function confirm(args)
     assert_su_installed()
-    local partitions = get_partitions()
+    local partitions = su.get_partitions()
     if partitions.current == partitions.stable then
         print(string.format('the current partition: %d is already the stable partition, aborting', partitions.current))
         os.exit(113)
@@ -355,7 +341,7 @@ end
 
 local function test_other_partition(args)
     assert_su_installed()
-    local partitions = get_partitions()
+    local partitions = su.get_partitions()
     set_testing_partition(partitions.other)
     print(string.format('Next boot will run partition: %d. You may confirm it if you like after reboot.', partitions.other))
 end
@@ -363,7 +349,7 @@ end
 
 local function parse_args()
     local function validate_file_exists(filename)
-        if file_exists(filename) then
+        if utils.file_exists(filename) then
             return filename
         else
             return nil, string.format("file %q does not exists", filename)
@@ -442,13 +428,13 @@ else
             os.exit(198)
         end
     elseif args.show then
-        local su_installed_version = get_uboot_env('su_version')
+        local su_installed_version = su.get_uboot_env('su_version')
         if su_installed_version == nil then
             print('safe-upgrade is not installed, aborting.')
             os.exit(199)
         end
         print('safe-upgrade version: ' .. su_installed_version)
-        local partitions = get_partitions()
+        local partitions = su.get_partitions()
         --TODO show labels of partitions (maybe store them when flashing from a metadata file)
         print(string.format('current partition: %d', partitions.current))
         print(string.format('stable partition: %d', partitions.stable))

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -88,7 +88,7 @@ end
 local function set_uboot_env(key, value)
     print("DEBUG: seting key:" .. key)
     print("DEBUG: value:" .. value)
-    local value = utils.unsafe_shell("fw_setenv " .. key .. " '" .. value .. "'")
+    utils.unsafe_shell("fw_setenv " .. key .. " '" .. value .. "'")
 end
 
 local function fw_env_configured()
@@ -135,13 +135,6 @@ end
 
 local function is_su_installed()
     return get_su_version() ~= nil
-end
-
-local function fw_env_config()
-    if not fw_env_configured() then
-        print('fw_env.config not found, installing /etc/fw_env.config')
-        fw_env_configure()
-    end
 end
 
 local function set_testing_partition(partition)
@@ -333,7 +326,7 @@ local function upgrade(args)
                              args.firmware, partitions.other))
 
     -- TODO: load bootargs from acompaning image, here is hardcoded!!
-
+    local fw_mtd_str = ''
     if partitions.other == 2 then
         fw_mtd_str = '7936k(fw1),7936k(firmware)'
     else

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -291,24 +291,17 @@ function test_other_partition(args)
 end
 
 
-function parse_args()
-    local parser = argparse('safe-upgrade', 'Safe upgrade mechanism for dual-boot systems')
-    parser:command_target('command')
-    local show = parser:command('show', 'Show the status of the system partitions.')
 
-    local upgrade = parser:command('upgrade', 'Upgrade firmware in a non permanent way.')
-    function validate_file_exists(filename)
+function parse_args()
+    local function validate_file_exists(filename)
         if file_exists(filename) then
             return filename
         else
             return nil, string.format("file %q does not exists", filename)
         end
     end
-    upgrade:argument("firmware", "firmware image (xxx-sysupgrade.bin)"):convert(validate_file_exists)
-    upgrade:flag("-n --do-not-preserve-config", "Do not save configuration to the new partition")
-    upgrade:flag("--disable-reboot-safety", "Disable the automatic reboot safety mechanism")
 
-    function validate_safety_timeout(value)
+    local function validate_safety_timeout(value)
         local timeout = tonumber(value)
         if timeout == nil then
             return nil, string.format("invalid --reboot-safety-timeout value: %q", value)
@@ -318,6 +311,18 @@ function parse_args()
         end
         return timeout
     end
+
+
+    local parser = argparse('safe-upgrade', 'Safe upgrade mechanism for dual-boot systems')
+    parser:command_target('command')
+
+    local show = parser:command('show', 'Show the status of the system partitions.')
+
+    local upgrade = parser:command('upgrade', 'Upgrade firmware in a non permanent way.')
+    upgrade:argument("firmware", "firmware image (xxx-sysupgrade.bin)"):convert(validate_file_exists)
+    upgrade:flag("-n --do-not-preserve-config", "Do not save configuration to the new partition")
+    upgrade:flag("--disable-reboot-safety", "Disable the automatic reboot safety mechanism")
+    upgrade:flag("-f --force", "Upgrade even if firmware is not valid")
     upgrade:option("--reboot-safety-timeout",
                    "Set the timeout (in seconds) of the automatic reboot safety mechanism")
                    :default('600'):convert(validate_safety_timeout)

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -336,6 +336,11 @@ local function upgrade(args)
     local boot_script = string.format(boot_script_tpl, fw_mtd_str, partitions.other)
     set_uboot_env(string.format('boot_%d', partitions.other), boot_script)
     set_testing_partition(partitions.other)
+
+    if not args.no_reboot then
+        print("Rebooting into the new firmware. Do the confirm step if everything is ok.")
+        os.execute("reboot")
+    end
 end
 
 local function confirm(args)
@@ -396,7 +401,8 @@ local function parse_args()
     upgrade:flag("-n --do-not-preserve-config", "Do not save configuration to the new partition")
     upgrade:flag("--disable-reboot-safety", "Disable the automatic reboot safety mechanism")
     upgrade:flag("--force", "Upgrade even if firmware is not valid")
-    upgrade:option("--preserve-archive", [[Specify additional files to preserve as a tar.gz (Like the sysupgrade -f).
+    upgrade:flag("--no-reboot", "Do not reboot automatically after flashing")
+    upgrade:option("--preserve-archive", [[Specify the files to be preserved as a tar.gz (Like the sysupgrade -f).
     To preserve a full config you may use sysupgrade --create-backup and use this .tar.gz.]])
                    :convert(validate_file_exists)
     upgrade:option("--reboot-safety-timeout",

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -1,6 +1,6 @@
 #!/usr/bin/lua
 --[[
-    Copyright (C) 2019 Santiago Piccinini <spiccinini@altermundi.net>
+    Copyright (C) 2019-2020 Santiago Piccinini <spiccinini@altermundi.net>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,7 +19,9 @@
 local io = require "io"
 local argparse = require 'argparse'
 
-local version = '1.0'
+local su = {}
+
+su.version = '1.0'
 local firmware_size_bytes = 7936*1024
 local fw1_addr = 0x9f050000
 local fw2_addr = 0x9f050000 + firmware_size_bytes
@@ -216,7 +218,7 @@ function bootstrap(args)
     -- us to know here the correct cmdline bootargs of the running kernel
     local boot_1 = 'set bootargs ' .. get_current_cmdline() .. '; echo booting part 1; bootm ${fw_addr};'
     set_uboot_env('boot_1', boot_1)
-    set_uboot_env('su_version', version)
+    set_uboot_env('su_version', su.version)
 
     -- installing the script. Everything must be installed before this!
     set_uboot_env('bootcmd', bootcmd)
@@ -337,6 +339,7 @@ end
 -- detect if this module is run as a library or as a script
 if pcall(debug.getlocal, 4, 1) then
     -- Library mode
+    return su
 else
     -- Main script mode
 

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -216,6 +216,9 @@ function su.preserve_files_to_new_partition(args)
 
     if args.do_not_preserve_config then
         utils.log('Not preserving config.')
+    elseif args.preserve_archive then
+        utils.log('Preserving from archive')
+        os.execute("tar xfz " .. args.preserve_archive .. " -C /tmp/_to_sysupgradetgz/")
     else
         utils.log('Preserving libremesh minimal config.')
         local files = ""
@@ -229,10 +232,6 @@ function su.preserve_files_to_new_partition(args)
             os.execute("tar cf /tmp/_safe_upgrade_intermadiate.tar " .. files .. " 2> /dev/null")
             os.execute("tar xf /tmp/_safe_upgrade_intermadiate.tar -C /tmp/_to_sysupgradetgz/")
         end
-    end
-
-    if args.preserve_archive then
-        os.execute("tar xfz " .. args.preserve_archive .. " -C /tmp/_to_sysupgradetgz/")
     end
 
     os.execute('find /tmp/_to_sysupgradetgz/ -type f -o -type l | sed "s|^\/tmp\/_to_sysupgradetgz\/||" | sort -u > /tmp/_to_persist')

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -440,9 +440,8 @@ if pcall(debug.getlocal, 4, 1) then
 else
     -- Main script mode
 
-    assert_fw_env_configured()
-
     local args = parse_args()
+    assert_fw_env_configured()
     if args.bootstrap then
         bootstrap(args)
     elseif args.upgrade then

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -242,7 +242,9 @@ function su.preserve_files_to_new_partition(args)
         os.execute("tar xfz " .. args.preserve_archive .. " -C /tmp/_to_sysupgradetgz/")
     end
 
-    os.execute("tar cfz /tmp/sysupgrade.tgz -C /tmp/_to_sysupgradetgz/ `ls /tmp/_to_sysupgradetgz/`")
+    os.execute('find /tmp/_to_sysupgradetgz/ -type f -o -type l | sed "s|^\/tmp\/_to_sysupgradetgz\/||" | sort -u > /tmp/_to_persist')
+    os.execute("tar cfz /tmp/sysupgrade.tgz -C /tmp/_to_sysupgradetgz/ -T /tmp/_to_persist 2>/dev/null")
+
     utils.log('List of files that are being preserved:')
     local file_list = {}
     local out = io.popen("tar tfz /tmp/sysupgrade.tgz")

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -273,13 +273,26 @@ local function bootstrap(args)
     print('succesfully bootstraped safe-upgrade')
 end
 
+local function _verify(firmware)
+    local fw_metadata = read_fw_metadata(firmware)
+    local fw_valid = fw_metadata ~= nil and su.is_firmware_valid(fw_metadata)
+    return fw_valid
+end
+
+local function verify(args)
+    if _verify(args.firmware) then
+        exit(0)
+    else
+        print("Invalid firmware!")
+        exit(111)
+    end
+end
+
 local function upgrade(args)
     assert_su_installed()
     local partitions = get_partitions()
 
-    local fw_metadata = read_fw_metadata(args.firmware)
-    fw_valid = fw_metadata ~= nil and su.is_firmware_valid(fw_metadata)
-    if not fw_valid then
+    if not _verify(args.firmware) then
         print("Invalid firmware!")
         if args.force then
             print("Forcing upgrade to continue as requested")
@@ -368,11 +381,13 @@ local function parse_args()
         return timeout
     end
 
-
     local parser = argparse('safe-upgrade', 'Safe upgrade mechanism for dual-boot systems')
     parser:command_target('command')
 
     local show = parser:command('show', 'Show the status of the system partitions.')
+
+    local verify = parser:command('verify', 'Verify that the firmware is valid and can be installed.')
+    verify:argument("firmware", "firmware image (xxx-sysupgrade.bin)"):convert(validate_file_exists)
 
     local upgrade = parser:command('upgrade', 'Upgrade firmware in a non permanent way.')
     upgrade:argument("firmware", "firmware image (xxx-sysupgrade.bin)"):convert(validate_file_exists)
@@ -415,6 +430,8 @@ else
         upgrade(args)
     elseif args.confirm then
         confirm(args)
+    elseif args.verify then
+        verify(args)
     elseif args['test-other-partition'] then
         test_other_partition(args)
     elseif args['board-supported'] then

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -205,7 +205,8 @@ function su.is_firmware_valid(metadata)
     return false
 end
 
-local function preserve_files_to_new_partition(args)
+function su.preserve_files_to_new_partition(args)
+    os.execute("rm -rf /tmp/_to_sysupgradetgz/")
     os.execute("mkdir -p /tmp/_to_sysupgradetgz/etc/init.d/")
     os.execute("mkdir -p /tmp/_to_sysupgradetgz/etc/rc.d/")
     local f = io.open("/tmp/_to_sysupgradetgz/etc/init.d/safe_upgrade_auto_reboot", "w")
@@ -215,18 +216,46 @@ local function preserve_files_to_new_partition(args)
     os.execute("chmod +x /tmp/_to_sysupgradetgz/etc/init.d/safe_upgrade_auto_reboot")
     os.execute("ln -s ../init.d/safe_upgrade_auto_reboot /tmp/_to_sysupgradetgz/etc/rc.d/S11safe_upgrade_auto_reboot")
 
-
     if not args.disable_reboot_safety then
         local f = io.open("/tmp/_to_sysupgradetgz/etc/safe_upgrade_auto_reboot_confirm_timeout_s", "w")
         f:write(args.reboot_safety_timeout)
         f:close()
     end
 
-    -- append files from existing /tmp/sysupgrade.tgz
-    if file_exists("/tmp/sysupgrade.tgz") then
-        os.execute("tar xfz /tmp/sysupgrade.tgz -C /tmp/_to_sysupgradetgz/")
+    if args.do_not_preserve_config then
+        utils.log('Not preserving config.')
+    else
+        utils.log('Preserving libremesh minimal config.')
+        local files = ""
+        for _, file_name in pairs(utils.keep_on_upgrade_files()) do
+            if utils.file_exists(file_name) then
+                files = files .. " " .. file_name
+            end
+        end
+        if files ~= '' then
+            --! using an intermediate tar file for simplicity
+            os.execute("tar cf /tmp/_safe_upgrade_intermadiate.tar " .. files .. " 2> /dev/null")
+            os.execute("tar xf /tmp/_safe_upgrade_intermadiate.tar -C /tmp/_to_sysupgradetgz/")
+        end
     end
+
+    if args.preserve_archive then
+        os.execute("tar xfz " .. args.preserve_archive .. " -C /tmp/_to_sysupgradetgz/")
+    end
+
     os.execute("tar cfz /tmp/sysupgrade.tgz -C /tmp/_to_sysupgradetgz/ `ls /tmp/_to_sysupgradetgz/`")
+    utils.log('List of files that are being preserved:')
+    local file_list = {}
+    local out = io.popen("tar tfz /tmp/sysupgrade.tgz")
+    for line in out:lines() do
+        --! skip directories
+        if not utils.stringEnds(line, '/') then
+            table.insert(file_list, line)
+            utils.log('\t' .. line)
+        end
+    end
+    out:close()
+    return file_list
 end
 
 local function bootstrap(args)
@@ -287,15 +316,7 @@ local function upgrade(args)
         end
     end
 
-    if not args.do_not_preserve_config then
-        print('Preserving full config')
-        os.execute("sysupgrade  --create-backup /tmp/sysupgrade.tgz")
-        --[[ TODO: implement preserve config lime for first boot wizard,
-             the final file must be /tmp/sysupgrade.tgz
-        ]]--
-    end
-
-    preserve_files_to_new_partition(args)
+    su.preserve_files_to_new_partition(args)
 
     -- postpone 10m defarable-reboot
     os.execute("awk '{print $1 + 600}' /proc/uptime > /tmp/deferable-reboot.defer")
@@ -380,6 +401,9 @@ local function parse_args()
     upgrade:flag("-n --do-not-preserve-config", "Do not save configuration to the new partition")
     upgrade:flag("--disable-reboot-safety", "Disable the automatic reboot safety mechanism")
     upgrade:flag("--force", "Upgrade even if firmware is not valid")
+    upgrade:option("--preserve-archive", [[Specify additional files to preserve as a tar.gz (Like the sysupgrade -f).
+    To preserve a full config you may use sysupgrade --create-backup and use this .tar.gz.]])
+                   :convert(validate_file_exists)
     upgrade:option("--reboot-safety-timeout",
                    "Set the timeout (in seconds) of the automatic reboot safety mechanism")
                    :default('600'):convert(validate_safety_timeout)

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -393,7 +393,7 @@ local function parse_args()
     upgrade:argument("firmware", "firmware image (xxx-sysupgrade.bin)"):convert(validate_file_exists)
     upgrade:flag("-n --do-not-preserve-config", "Do not save configuration to the new partition")
     upgrade:flag("--disable-reboot-safety", "Disable the automatic reboot safety mechanism")
-    upgrade:flag("-f --force", "Upgrade even if firmware is not valid")
+    upgrade:flag("--force", "Upgrade even if firmware is not valid")
     upgrade:option("--reboot-safety-timeout",
                    "Set the timeout (in seconds) of the automatic reboot safety mechanism")
                    :default('600'):convert(validate_safety_timeout)

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -17,7 +17,6 @@
 ]]--
 
 local io = require "io"
-local argparse = require 'argparse'
 local json = require "luci.jsonc"
 local utils = require "lime.utils"
 
@@ -388,6 +387,7 @@ local function parse_args()
         return timeout
     end
 
+    local argparse = require 'argparse'
     local parser = argparse('safe-upgrade', 'Safe upgrade mechanism for dual-boot systems')
     parser:command_target('command')
 

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -18,6 +18,8 @@
 
 local io = require "io"
 local argparse = require 'argparse'
+local json = require "luci.jsonc"
+local utils = require "lime.utils"
 
 local su = {}
 
@@ -25,6 +27,7 @@ su.version = '1.0'
 local firmware_size_bytes = 7936*1024
 local fw1_addr = 0x9f050000
 local fw2_addr = 0x9f050000 + firmware_size_bytes
+su._supported_devices = {'librerouter-v1'}
 
 -- safe upgrade script, generated with bootscript.py, DO NOT edit here!
 local bootcmd = 'run preboot; boot_part=${stable_part}; if test ${testing_part} -ne 0; then echo Testing part ${testing_part}; boot_part=${testing_part}; set testing_part 0; saveenv; fi; if test ${boot_part} -eq 2; then fw_addr=${fw2_addr}; run boot_2; else fw_addr=${fw1_addr}; run boot_1; fi; run boot_1; bootm ${fw1_addr};'
@@ -169,6 +172,24 @@ function assert_su_installed()
         print('safe-upgrade is not installed, aborting')
         os.exit(114)
     end
+end
+
+function su.get_current_device()
+    return utils.read_file("/tmp/sysinfo/board_name")
+end
+
+function su.get_supported_devices()
+    return su._supported_devices
+end
+
+function su.is_current_board_supported()
+    local current_device = su.get_current_device()
+    for _, supported_device in pairs(su.get_supported_devices()) do
+        if string.find(current_device, utils.literalize(supported_device)) then
+            return true
+        end
+    end
+    return false
 end
 
 function preserve_files_to_new_partition(args)
@@ -334,6 +355,8 @@ function parse_args()
 
     local test_other_parition = parser:command('test-other-partition',
         'Mark the other partition as testing partition.')
+
+    local board_supported = parser:command('board-supported', 'Exits with 0 if board is supported')
     --local swap_stable = parser:command('swap', 'Change the stable partition to the other partition.')
     local args = parser:parse()
 
@@ -359,6 +382,13 @@ else
         confirm(args)
     elseif args['test-other-partition'] then
         test_other_partition(args)
+    elseif args['board-supported'] then
+        if su.is_current_board_supported() then
+            os.exit(0)
+        else
+            print("This board is not supported")
+            os.exit(198)
+        end
     elseif args.show then
         local su_installed_version = get_uboot_env('su_version')
         if su_installed_version == nil then

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -35,6 +35,15 @@ local bootcmd = 'run preboot; boot_part=${stable_part}; if test ${testing_part} 
 su.STABLE_PARTITION_NAME = 'stable_part'
 su.TESTING_PARTITION_NAME = 'testing_part'
 
+su.EXIT_ERROR_OK = 0
+su.EXIT_STATUS_INVALID_FIRMWARE = 111
+su.EXIT_STATUS_ALREADY_CONFIRMED = 113
+su.EXIT_STATUS_FW_ENV_NOT_FOUND = 115
+su.EXIT_STATUS_BOARD_NOT_SUPPORTED = 198
+su.EXIT_STATUS_NOT_INSTALLED = 199
+su.EXIT_STATUS_INSTALL_FROM_PART2 = 120
+su.EXIT_STATUS_ALREADY_INSTALLED = 121
+
 local safe_upgrade_auto_reboot_script = [[#!/bin/sh /etc/rc.common
 
 REBOOT_FILE_CONFIG_TIMEOUT_S="/etc/safe_upgrade_auto_reboot_confirm_timeout_s"
@@ -98,7 +107,7 @@ end
 local function assert_fw_env_configured()
     if not fw_env_configured() then
         print('/etc/fw_env.confg does not exist, aborting')
-        os.exit(115)
+        os.exit(su.EXIT_STATUS_FW_ENV_NOT_FOUND)
     end
 end
 
@@ -148,7 +157,7 @@ end
 local function assert_su_installed()
     if not is_su_installed() then
         print('safe-upgrade is not installed, aborting')
-        os.exit(114)
+        os.exit(su.EXIT_STATUS_NOT_INSTALLED)
     end
 end
 
@@ -256,13 +265,13 @@ local function bootstrap(args)
     if is_su_installed() then
         print(string.format("safe-upgrade version '%s' is already installed, aborting",
                             get_su_version()))
-        os.exit(121)
+        os.exit(su.EXIT_STATUS_ALREADY_INSTALLED)
     end
 
 
     if su.get_current_partition() ~= 1 then
         print("installing safe-upgrade from partition 2 is not supported yet")
-        os.exit(120)
+        os.exit(su.EXIT_STATUS_INSTALL_FROM_PART2)
     end
 
     set_stable_partition(1)
@@ -289,10 +298,10 @@ end
 
 local function verify(args)
     if _verify(args.firmware) then
-        os.exit(0)
+        os.exit(su.EXIT_STATUS_OK)
     else
         print("Invalid firmware!")
-        os.exit(111)
+        os.exit(su.EXIT_STATUS_INVALID_FIRMWARE)
     end
 end
 
@@ -305,7 +314,7 @@ local function upgrade(args)
         if args.force then
             print("Forcing upgrade to continue as requested.")
         else
-            os.exit(111)
+            os.exit(su.EXIT_STATUS_INVALID_FIRMWARE)
         end
     end
 
@@ -347,7 +356,7 @@ local function confirm(args)
     local partitions = su.get_partitions()
     if partitions.current == partitions.stable then
         print(string.format('the current partition: %d is already the stable partition, aborting', partitions.current))
-        os.exit(113)
+        os.exit(su.EXIT_STATUS_ALREADY_CONFIRMED)
     end
 
     print("Canceling and disabling automatic reboot")
@@ -446,18 +455,14 @@ else
         test_other_partition(args)
     elseif args['board-supported'] then
         if su.is_current_board_supported() then
-            os.exit(0)
+            os.exit(su.EXIT_STATUS_OK)
         else
             print("This board is not supported")
-            os.exit(198)
+            os.exit(su.EXIT_STATUS_BOARD_NOT_SUPPORTED)
         end
     elseif args.show then
-        local su_installed_version = su.get_uboot_env('su_version')
-        if su_installed_version == nil then
-            print('safe-upgrade is not installed, aborting.')
-            os.exit(199)
-        end
-        print('safe-upgrade version: ' .. su_installed_version)
+        assert_su_installed()
+        print('safe-upgrade version: ' .. get_su_version())
         local partitions = su.get_partitions()
         --TODO show labels of partitions (maybe store them when flashing from a metadata file)
         print(string.format('current partition: %d', partitions.current))

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -321,7 +321,7 @@ local function upgrade(args)
     -- with the file /tmp/sysupgrade.tgz because there are hooks in place
     -- to unpack this tar and install the files at boot
     print(string.format("writing partition %d", partitions.other))
-    os.execute(string.format("mtd -j /tmp/sysupgrade.tgz write %s fw%d",
+    os.execute(string.format("mtd -j /tmp/sysupgrade.tgz write '%s' fw%d",
                              args.firmware, partitions.other))
 
     -- TODO: load bootargs from acompaning image, here is hardcoded!!

--- a/packages/safe-upgrade/files/usr/sbin/safe-upgrade
+++ b/packages/safe-upgrade/files/usr/sbin/safe-upgrade
@@ -32,10 +32,10 @@ su._supported_devices = {'librerouter-v1'}
 -- safe upgrade script, generated with bootscript.py, DO NOT edit here!
 local bootcmd = 'run preboot; boot_part=${stable_part}; if test ${testing_part} -ne 0; then echo Testing part ${testing_part}; boot_part=${testing_part}; set testing_part 0; saveenv; fi; if test ${boot_part} -eq 2; then fw_addr=${fw2_addr}; run boot_2; else fw_addr=${fw1_addr}; run boot_1; fi; run boot_1; bootm ${fw1_addr};'
 
-STABLE_PARTITION_NAME = 'stable_part'
-TESTING_PARTITION_NAME = 'testing_part'
+local STABLE_PARTITION_NAME = 'stable_part'
+local TESTING_PARTITION_NAME = 'testing_part'
 
-safe_upgrade_auto_reboot_script = [[#!/bin/sh /etc/rc.common
+local safe_upgrade_auto_reboot_script = [[#!/bin/sh /etc/rc.common
 
 REBOOT_FILE_CONFIG_TIMEOUT_S="/etc/safe_upgrade_auto_reboot_confirm_timeout_s"
 MINIMUM_REBOOT_TIMEOUT_S=60
@@ -73,7 +73,7 @@ stop() {
 }
 ]]
 
-function get_uboot_env(key)
+local function get_uboot_env(key)
     local handle = io.popen("fw_printenv -n " .. key .. " 2>&1")
     local value = handle:read("*a")
     handle:close()
@@ -87,7 +87,7 @@ function get_uboot_env(key)
     end
 end
 
-function set_uboot_env(key, value)
+local function set_uboot_env(key, value)
     print("DEBUG: seting key:" .. key)
     print("DEBUG: value:" .. value)
     local handle = io.popen("fw_setenv " .. key .. " '" .. value .. "'")
@@ -95,31 +95,31 @@ function set_uboot_env(key, value)
     handle:close()
 end
 
-function file_exists(filename)
+local function file_exists(filename)
     local f = io.open(filename, "rb")
     if f then f:close() end
     return f ~= nil
 end
 
-function fw_env_configured()
+local function fw_env_configured()
     return file_exists('/etc/fw_env.config')
 end
 
-function assert_fw_env_configured()
+local function assert_fw_env_configured()
     if not fw_env_configured() then
         print('/etc/fw_env.confg does not exist, aborting')
         os.exit(115)
     end
 end
 
-function get_current_cmdline()
+local function get_current_cmdline()
     local handle = io.open('/proc/cmdline', 'r')
     local data = handle:read()
     handle:close()
     return data
 end
 
-function get_current_partition()
+local function get_current_partition()
     local handle = io.open('/proc/mtd', 'r')
     local data = handle:read("*all")
     handle:close()
@@ -130,7 +130,7 @@ function get_current_partition()
     end
 end
 
-function get_partitions()
+local function get_partitions()
     local p = {}
     p.current = get_current_partition()
     if p.current == 1 then
@@ -144,34 +144,41 @@ function get_partitions()
     return p
 end
 
-function get_su_version()
+local function get_su_version()
     return get_uboot_env('su_version')
 end
 
-function is_su_installed()
+local function is_su_installed()
     return get_su_version() ~= nil
 end
 
-function fw_env_config()
+local function fw_env_config()
     if not fw_env_configured() then
         print('fw_env.config not found, installing /etc/fw_env.config')
         fw_env_configure()
     end
 end
 
-function set_testing_partition(partition)
+local function set_testing_partition(partition)
     set_uboot_env(TESTING_PARTITION_NAME, tostring(partition))
 end
 
-function set_stable_partition(partition)
+local function set_stable_partition(partition)
     set_uboot_env(STABLE_PARTITION_NAME, tostring(partition))
 end
 
-function assert_su_installed()
+local function assert_su_installed()
     if not is_su_installed() then
         print('safe-upgrade is not installed, aborting')
         os.exit(114)
     end
+end
+
+local function read_fw_metadata(path)
+    local handle = io.popen("fwtool -i - " .. path)
+    local metadata = json.parse(handle:read("*a"))
+    handle:close()
+    return metadata
 end
 
 function su.get_current_device()
@@ -192,7 +199,27 @@ function su.is_current_board_supported()
     return false
 end
 
-function preserve_files_to_new_partition(args)
+function su.is_firmware_valid(metadata)
+    local current_device = su.get_current_device()
+    if metadata ~= nil then
+        local fw_devices = metadata['supported_devices']
+        if fw_devices ~= nil then
+            for _, fw_device in pairs(fw_devices) do
+                for _, supported_device in pairs(su.get_supported_devices()) do
+                    --! Check that the firmware is supported by safe upgrade
+                    --! and that the current board is among the firmware devices
+                    if string.find(fw_device, utils.literalize(supported_device)) and
+                       string.find(fw_device, utils.literalize(current_device)) then
+                        return true
+                    end
+                end
+            end
+        end
+    end
+    return false
+end
+
+local function preserve_files_to_new_partition(args)
     os.execute("mkdir -p /tmp/_to_sysupgradetgz/etc/init.d/")
     os.execute("mkdir -p /tmp/_to_sysupgradetgz/etc/rc.d/")
     local f = io.open("/tmp/_to_sysupgradetgz/etc/init.d/safe_upgrade_auto_reboot", "w")
@@ -216,7 +243,7 @@ function preserve_files_to_new_partition(args)
     os.execute("tar cfz /tmp/sysupgrade.tgz -C /tmp/_to_sysupgradetgz/ `ls /tmp/_to_sysupgradetgz/`")
 end
 
-function bootstrap(args)
+local function bootstrap(args)
     --TODO: add --force option to upgrade SU
     if is_su_installed() then
         print(string.format("safe-upgrade version '%s' is already installed, aborting",
@@ -246,11 +273,20 @@ function bootstrap(args)
     print('succesfully bootstraped safe-upgrade')
 end
 
-function upgrade(args)
+local function upgrade(args)
     assert_su_installed()
     local partitions = get_partitions()
 
-    -- TODO: validate that the firmware is valid for this board using metadata
+    local fw_metadata = read_fw_metadata(args.firmware)
+    fw_valid = fw_metadata ~= nil and su.is_firmware_valid(fw_metadata)
+    if not fw_valid then
+        print("Invalid firmware!")
+        if args.force then
+            print("Forcing upgrade to continue as requested")
+        else
+            exit(111)
+        end
+    end
 
     if not args.do_not_preserve_config then
         print('Preserving full config')
@@ -288,7 +324,7 @@ function upgrade(args)
     set_testing_partition(partitions.other)
 end
 
-function confirm(args)
+local function confirm(args)
     assert_su_installed()
     local partitions = get_partitions()
     if partitions.current == partitions.stable then
@@ -304,7 +340,7 @@ function confirm(args)
     print(string.format('Confirmed partition %d as stable partition', partitions.current))
 end
 
-function test_other_partition(args)
+local function test_other_partition(args)
     assert_su_installed()
     local partitions = get_partitions()
     set_testing_partition(partitions.other)
@@ -312,8 +348,7 @@ function test_other_partition(args)
 end
 
 
-
-function parse_args()
+local function parse_args()
     local function validate_file_exists(filename)
         if file_exists(filename) then
             return filename

--- a/packages/safe-upgrade/tests/test_safe-upgade.lua
+++ b/packages/safe-upgrade/tests/test_safe-upgade.lua
@@ -1,0 +1,22 @@
+local su = require 'safe-upgrade'
+local utils = require 'lime.utils'
+local test_utils = require 'tests.utils'
+
+
+describe('safe-upgrade tests #safeupgrade', function()
+
+    it('test is_current_board_supported()', function()
+        stub(su, 'get_supported_devices', function () return {'librerouter-v1', 'librerouter-v2'} end)
+        stub(su, 'get_current_device', function () return 'librerouter-v1' end)
+        assert.is_true(su.is_current_board_supported())
+        stub(su, 'get_current_device', function () return 'librerouter-v2' end)
+        assert.is_true(su.is_current_board_supported())
+        stub(su, 'get_current_device', function () return '' end)
+        assert.is_false(su.is_current_board_supported())
+        stub(su, 'get_current_device', function () return 'qemu-standard-pc' end)
+        assert.is_false(su.is_current_board_supported())
+        su.get_current_device:revert()
+        su.get_supported_devices:revert()
+    end)
+
+end)

--- a/packages/safe-upgrade/tests/test_safe-upgade.lua
+++ b/packages/safe-upgrade/tests/test_safe-upgade.lua
@@ -1,7 +1,7 @@
 local su = require 'safe-upgrade'
 local utils = require 'lime.utils'
 local test_utils = require 'tests.utils'
-
+local json = require 'luci.jsonc'
 
 describe('safe-upgrade tests #safeupgrade', function()
 
@@ -17,6 +17,29 @@ describe('safe-upgrade tests #safeupgrade', function()
         assert.is_false(su.is_current_board_supported())
         su.get_current_device:revert()
         su.get_supported_devices:revert()
+    end)
+
+    it('test is_firmware_valid()', function()
+        local meta_lros = '{  "supported_devices":["librerouter-v1"] }'
+        local meta_master = '{  "supported_devices":["librerouter,librerouter-v1"]}'
+        local meta_v2 = '{  "supported_devices":["other,librerouter-v2"]}'
+        local meta_other = '{  "supported_devices":["other"]}'
+        stub(su, 'get_current_device', function () return 'librerouter-v1' end)
+        assert.is_true(su.is_firmware_valid(json.parse(meta_lros)))
+        assert.is_true(su.is_firmware_valid(json.parse(meta_master)))
+        assert.is_false(su.is_firmware_valid(json.parse(meta_v2)))
+        assert.is_false(su.is_firmware_valid(json.parse(meta_other)))
+        assert.is_false(su.is_firmware_valid(nil))
+        assert.is_false(su.is_firmware_valid({}))
+
+        stub(su, 'get_current_device', function () return 'librerouter-v2' end)
+        assert.is_false(su.is_firmware_valid(json.parse(meta_lros)))
+        assert.is_false(su.is_firmware_valid(json.parse(meta_master)))
+        assert.is_false(su.is_firmware_valid(json.parse(meta_v2)))
+        assert.is_false(su.is_firmware_valid(json.parse(meta_other)))
+        assert.is_false(su.is_firmware_valid(nil))
+        assert.is_false(su.is_firmware_valid({}))
+        su.get_current_device:revert()
     end)
 
 end)

--- a/packages/safe-upgrade/tests/test_safe-upgade.lua
+++ b/packages/safe-upgrade/tests/test_safe-upgade.lua
@@ -139,6 +139,11 @@ mtd8: 00010000 00010000 "ART"
         assert.are.same(expected, files_preserved)
     end)
 
+    it('test cmdline help', function()
+        local out = utils.unsafe_shell('lua ./packages/safe-upgrade/files/usr/sbin/safe-upgrade --help')
+        assert.not_nil(string.match(out, "Safe upgrade mechanism"))
+    end)
+
     before_each('', function()
         test_dir = test_utils.setup_test_dir()
     end)

--- a/packages/safe-upgrade/tests/test_safe-upgade.lua
+++ b/packages/safe-upgrade/tests/test_safe-upgade.lua
@@ -3,7 +3,58 @@ local utils = require 'lime.utils'
 local test_utils = require 'tests.utils'
 local json = require 'luci.jsonc'
 
+local test_dir = nil
+
 describe('safe-upgrade tests #safeupgrade', function()
+    it('test get_partitions()', function()
+        stub(su, 'get_uboot_env',
+            function(part_name)
+                if part_name == su.STABLE_PARTITION_NAME then
+                    return 1
+                elseif part_name == su.TESTING_PARTITION_NAME then
+                    return 0
+                else
+                    assert.is_true(false)
+                end
+            end)
+        local mtd_file = test_dir .. 'mtd'
+        local mtd = [[dev:    size   erasesize  name
+mtd0: 00040000 00010000 "u-boot"
+mtd1: 00010000 00010000 "u-boot-env"
+mtd2: 007d0000 00010000 "firmware"
+mtd3: 00160000 00010000 "kernel"
+mtd4: 00670000 00010000 "rootfs"
+mtd5: 00480000 00010000 "rootfs_data"
+mtd6: 007d0000 00010000 "fw2"
+mtd7: 00010000 00010000 "ART"
+]]
+        utils.write_file(mtd_file, mtd)
+        su._mtd_partitions_desc = mtd_file
+        local partitions = su.get_partitions()
+        assert.are.equal(1, partitions.current)
+        assert.are.equal(2, partitions.other)
+        assert.are.equal(1, partitions.stable)
+        assert.are.equal(0, partitions.testing)
+
+        local mtd = [[dev:    size   erasesize  name
+mtd0: 00040000 00010000 "u-boot"
+mtd1: 00010000 00010000 "u-boot-env"
+mtd2: 007c0000 00010000 "fw1"
+mtd3: 007c0000 00010000 "firmware"
+mtd4: 00160000 00010000 "kernel"
+mtd5: 00660000 00010000 "rootfs"
+mtd6: 00310000 00010000 "rootfs_data"
+mtd7: 00020000 00010000 "res"
+mtd8: 00010000 00010000 "ART"
+]]
+        utils.write_file(mtd_file, mtd)
+        su._mtd_partitions_desc = mtd_file
+        local partitions = su.get_partitions()
+        assert.are.equal(2, partitions.current)
+        assert.are.equal(1, partitions.other)
+        assert.are.equal(1, partitions.stable)
+        assert.are.equal(0, partitions.testing)
+    end)
 
     it('test is_current_board_supported()', function()
         stub(su, 'get_supported_devices', function () return {'librerouter-v1', 'librerouter-v2'} end)

--- a/packages/safe-upgrade/tests/test_safe-upgade.lua
+++ b/packages/safe-upgrade/tests/test_safe-upgade.lua
@@ -101,9 +101,9 @@ mtd8: 00010000 00010000 "ART"
         local args = {reboot_safety_timeout=600}
         local files_preserved = su.preserve_files_to_new_partition(args)
         local expected = {
-            'etc/safe_upgrade_auto_reboot_confirm_timeout_s',
-            'etc/rc.d/S11safe_upgrade_auto_reboot',
             'etc/init.d/safe_upgrade_auto_reboot',
+            'etc/rc.d/S11safe_upgrade_auto_reboot',
+            'etc/safe_upgrade_auto_reboot_confirm_timeout_s',
              string.sub(preserve_file, 2)
         }
         assert.are.same(expected, files_preserved)
@@ -117,9 +117,9 @@ mtd8: 00010000 00010000 "ART"
         local args = {reboot_safety_timeout=600, do_not_preserve_config=true}
         local files_preserved = su.preserve_files_to_new_partition(args)
         local expected = {
-            'etc/safe_upgrade_auto_reboot_confirm_timeout_s',
-            'etc/rc.d/S11safe_upgrade_auto_reboot',
             'etc/init.d/safe_upgrade_auto_reboot',
+            'etc/rc.d/S11safe_upgrade_auto_reboot',
+            'etc/safe_upgrade_auto_reboot_confirm_timeout_s',
         }
         assert.are.same(expected, files_preserved)
     end)
@@ -131,9 +131,9 @@ mtd8: 00010000 00010000 "ART"
         local args = {reboot_safety_timeout=600, preserve_archive=preserve_archive}
         local files_preserved = su.preserve_files_to_new_partition(args)
         local expected = {
-            'etc/safe_upgrade_auto_reboot_confirm_timeout_s',
-            'etc/rc.d/S11safe_upgrade_auto_reboot',
             'etc/init.d/safe_upgrade_auto_reboot',
+            'etc/rc.d/S11safe_upgrade_auto_reboot',
+            'etc/safe_upgrade_auto_reboot_confirm_timeout_s',
             'proc/version',
         }
         assert.are.same(expected, files_preserved)

--- a/run_tests
+++ b/run_tests
@@ -14,6 +14,8 @@ for pkg in packages/*/files/usr/lib/lua/; do
 done
 # append default paths
 LIB_PATHS="$LIB_PATHS;;"
+LUA_PATH=$LIB_PATHS
+export LUA_PATH
 
 # create a temporaty script file to be able to run multiple commands inside docker
 temp_file=$(mktemp /tmp/lime_test.XXXX)
@@ -28,7 +30,7 @@ fi
 
 cat > ${temp_file}<< SCRIPT
 #!/bin/bash
-${LOGGING} busted -v --coverage ${TESTS_PATHS} --lpath='${LIB_PATHS}' ${1} && luacov
+${LOGGING} LUA_PATH='$LUA_PATH' busted -v --coverage ${TESTS_PATHS} --lpath='${LIB_PATHS}' ${1} && luacov
 SCRIPT
 
 ./tools/dockertestshell "${temp_file}"

--- a/tests/test_test_utils.lua
+++ b/tests/test_test_utils.lua
@@ -1,5 +1,6 @@
 local fs = require 'nixio.fs'
 local config = require 'lime.config'
+local utils = require 'lime.utils'
 local test_utils = require "tests.utils"
 
 local uci = nil
@@ -49,6 +50,15 @@ describe("Test utils tests #testutils", function()
         test_utils.write_uci_file(uci, 'foo', content)
         assert.is.equal('dhcp', uci:get_all('foo', 'wan', 'proto'))
         assert.is.equal(content, test_utils.read_uci_file(uci, 'foo'))
+    end)
+
+    it("test setup and teardown _test_dir", function()
+        local dir = test_utils.setup_test_dir()
+        assert.is_true(utils.file_exists(dir))
+        assert.is_true(utils.stringStarts(dir, "/tmp/"))
+        assert.is_true(utils.stringEnds(dir, "/"))
+        test_utils.teardown_test_dir()
+        assert.is_false(utils.file_exists(dir))
     end)
 
     before_each('', function()

--- a/tests/utils.lua
+++ b/tests/utils.lua
@@ -71,6 +71,22 @@ function utils.teardown_test_uci(uci)
 	uci:close()
 end
 
+-- Create a temporal empty directory and return its path with a trailin '/'
+-- eg: '/tmp/tmp.occigb/'
+-- utils.teardown_test_dir() must be called for cleanup
+function utils.setup_test_dir()
+	utils._tmpdir = io.popen("mktemp -d"):read('*l') .. "/"
+	return utils._tmpdir
+end
+
+function utils.teardown_test_dir()
+	if(utils._tmpdir ~= nil and string.find(utils._tmpdir, '^/tmp') ~= nil) then
+		local out = io.popen("rm -rf " .. utils._tmpdir)
+		out:read('*all') -- this allows waiting for popen completion
+		out:close()
+	end
+end
+
 function utils.get_board(name)
 	local board_path = 'tests/devices/' .. name .. '/board.json'
 	return limeutils.getBoardAsTable(board_path)


### PR DESCRIPTION
Many improvements in safe-upgrade! This changes allows to expose better a firmware upgrade mechanism through ubus.

* upgrade now reboots  after upgrade (add `--no-reboot`), just like sysupgrade.  Rebooting right away after upgrading is almost always what the user want to do.
* improved upgrade backup functionality adding `--preserve-archive` option to the upgrade (like `sysupgrade -f`). By default uses config 'lime.keep_on_upgrade' to provide the list of files to preserve.
* remove short option `-f` (as this means something else in sysupgrade it may lead to confusion)
* add `verify` cmd to veryfy of a firmware (like `sysupgrade --test`)
* add `board_supported` subcommand (to be able to ask the firmware if safe-uppgrade can be performed or a fallback to sysupgrade has to be used)
* testing, cleanups and refactoring to be able to add unittesting

Also other improvements:
*  tests: add `setup_test_dir()` and `teardown_test_dir()` helpers. Use this to get a working directory to create files for tests. The teardown will remove the directory.
* utils: refactor literalize to return only one argument. The idea of literalize was always to only return the new string
but by mistake it returned two arguments. So tests passed and also some (all?) current usages were working as expected.