### PR TITLE
Fix unittests broken and use docker pull instead of local build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfiles/*
+!tools/*

--- a/Dockerfiles/Dockerfile.unittests
+++ b/Dockerfiles/Dockerfile.unittests
@@ -1,6 +1,6 @@
 FROM abaez/luarocks:lua5.1
 
-ARG OPENWRT_REPO=https://downloads.openwrt.org/releases/18.06.4/packages/x86_64
+ARG OPENWRT_REPO=https://downloads.openwrt.org/releases/18.06.8/packages/x86_64
 
 WORKDIR /root
 

--- a/Dockerfiles/Dockerfile.unittests
+++ b/Dockerfiles/Dockerfile.unittests
@@ -22,4 +22,4 @@ RUN /root/tools/dlpkg $OPENWRT_REPO/base/ liblua /root && \
     /root/tools/dlpkg $OPENWRT_REPO/luci/ luci-lib-jsonc /root
 
 RUN for packet in /root/*.ipk; do tar xf $packet; tar xvf /root/data.tar.gz -C /; rm /root/data.tar.gz; done
-RUN mv /usr/lib/lua/* /usr/local/lib/lua/5.1/
+RUN mv /usr/lib/lua/* /usr/local/lib/lua/5.1/; ln -s /usr/local/bin/lua /usr/bin/lua

--- a/Dockerfiles/Dockerfile.unittests
+++ b/Dockerfiles/Dockerfile.unittests
@@ -19,7 +19,9 @@ RUN /root/tools/dlpkg $OPENWRT_REPO/base/ liblua /root && \
     /root/tools/dlpkg $OPENWRT_REPO/base/ libnl-tiny /root && \
     /root/tools/dlpkg $OPENWRT_REPO/luci/ luci-lib-nixio /root && \
     /root/tools/dlpkg $OPENWRT_REPO/luci/ luci-lib-ip /root && \
-    /root/tools/dlpkg $OPENWRT_REPO/luci/ luci-lib-jsonc /root
+    /root/tools/dlpkg $OPENWRT_REPO/luci/ luci-lib-jsonc /root && \
+    /root/tools/dlpkg $OPENWRT_REPO/luci/ liblucihttp /root && \
+    /root/tools/dlpkg $OPENWRT_REPO/luci/ liblucihttp-lua /root
 
 RUN for packet in /root/*.ipk; do tar xf $packet; tar xvf /root/data.tar.gz -C /; rm /root/data.tar.gz; done
 RUN mv /usr/lib/lua/* /usr/local/lib/lua/5.1/; ln -s /usr/local/bin/lua /usr/bin/lua

--- a/packages/safe-upgrade/tests/test_safe-upgade.lua
+++ b/packages/safe-upgrade/tests/test_safe-upgade.lua
@@ -139,11 +139,6 @@ mtd8: 00010000 00010000 "ART"
         assert.are.same(expected, files_preserved)
     end)
 
-    it('test cmdline help', function()
-        local out = utils.unsafe_shell('lua ./packages/safe-upgrade/files/usr/sbin/safe-upgrade --help')
-        assert.not_nil(string.match(out, "Safe upgrade mechanism"))
-    end)
-
     before_each('', function()
         test_dir = test_utils.setup_test_dir()
     end)

--- a/run_tests
+++ b/run_tests
@@ -1,7 +1,9 @@
 #!/bin/bash
 DOCKER_IMAGE="libremesh/luatest:1.1"
 if ! docker inspect --type=image $DOCKER_IMAGE > /dev/null 2>&1; then
-    docker build -f Dockerfiles/Dockerfile.unittests -t "$DOCKER_IMAGE" .
+    echo "Pulling docker image '$DOCKER_IMAGE'."
+    echo "If you want to build it locally run 'docker build -f Dockerfiles/Dockerfile.unittests -t $DOCKER_IMAGE .'"
+    docker pull "$DOCKER_IMAGE"
 fi
 export DOCKER_IMAGE
 

--- a/run_tests
+++ b/run_tests
@@ -1,7 +1,7 @@
 #!/bin/bash
-DOCKER_IMAGE="libremesh/luatest:1.0"
+DOCKER_IMAGE="libremesh/luatest:1.1"
 if ! docker inspect --type=image $DOCKER_IMAGE > /dev/null 2>&1; then
-    docker build -f Dockerfiles/Dockerfile.unittests . -t "$DOCKER_IMAGE"
+    docker build -f Dockerfiles/Dockerfile.unittests -t "$DOCKER_IMAGE" .
 fi
 export DOCKER_IMAGE
 

--- a/tools/dockertestshell
+++ b/tools/dockertestshell
@@ -3,7 +3,7 @@
 PWD=$(printf "%q\n" "${PWD}")
 APP=${@:-/bin/bash}
 
-DOCKER_IMAGE="${DOCKER_IMAGE:-libremesh/luatest:1.0}"
+DOCKER_IMAGE="${DOCKER_IMAGE:-libremesh/luatest:1.1}"
 
 DOCKER_BASHRC=/tmp/.docker_${USER}_bashrc
 


### PR DESCRIPTION
Unittests are broken from #737 . I don't know how github allowed merging without a green status after the last push, or maybe travis did not run at each push.
This fixes this.
Also changes the behaviour of ./run_tests to use docker pull instead of docker build. This speed things up in  the first use.
