### PR TITLE
lime-ap-watchping add dependency from lime-system

### DIFF
--- a/packages/lime-ap-watchping/Makefile
+++ b/packages/lime-ap-watchping/Makefile
@@ -20,7 +20,7 @@ define Package/$(PKG_NAME)
   TITLE:= Watchping hooks to manage AP SSID if network problems
   MAINTAINER:=Pau Escrich <p4u@dabax.et>
   URL:=http://libremesh.org
-  DEPENDS:= +watchping
+  DEPENDS:= +watchping +lime-system
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
lime-ap-watchping edits `lime-autogen` [here](https://github.com/libremesh/lime-packages/blob/38ceff23454141b67981686d484e6c2b33ee20ae/packages/lime-ap-watchping/files/etc/uci-defaults/91_autoAP#L2-L3) and get configs from `lime` [here](https://github.com/libremesh/lime-packages/blob/3e7573c4936bb0851f045af06513aba6489ddcb0/packages/lime-ap-watchping/files/etc/init.d/auto-ap#L10) (which I suppose will fail as it does not exist anymore?) so it is evident that has to depend on `lime-system`.