### PR TITLE
shared-state-nodes_and_links add dependency from ubus-lime-location

### DIFF
--- a/packages/shared-state-nodes_and_links/Makefile
+++ b/packages/shared-state-nodes_and_links/Makefile
@@ -20,7 +20,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Nicolas Pace <nico@libre.ws>
 	URL:=http://libremesh.org
 	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +lua +luci-lib-jsonc \
-		shared-state
+		shared-state +ubus-lime-location
 	PKGARCH:=all
 endef
 


### PR DESCRIPTION
shared-state-nodes_and_links [here](https://github.com/libremesh/lime-packages/blob/38ceff23454141b67981686d484e6c2b33ee20ae/packages/shared-state-nodes_and_links/files/usr/bin/shared-state-publish_nodes_and_links#L29) uses a file provided by ubus-lime-location [here](https://github.com/libremesh/lime-packages/blob/master/packages/ubus-lime-location/files/usr/libexec/rpcd/lime-location) so it looks like it has to depend on ubus-lime-location.