### PR TITLE
Fix shared-state get candidates neigh

### DIFF
--- a/packages/lime-system/files/usr/bin/mac2ipv6ll
+++ b/packages/lime-system/files/usr/bin/mac2ipv6ll
@@ -1,0 +1,5 @@
+#!/usr/bin/lua
+
+local utils = require("lime.utils")
+
+io.stdout:write(utils.mac2ipv6linklocal(io.stdin:read("*all")))

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -399,5 +399,31 @@ function utils.execute_daemonized(cmd, out_file, stdin)
     return os.execute("(( " .. cmd .. " " .. stdin .. " &> " .. out_file .. " &) &)")
 end
 
+function utils.bitwise_xor(a, b)
+  local r = 0
+  for i = 0, 31 do
+    local x = a / 2 + b / 2
+    if x ~= math.floor(x) then
+      r = r + 2^i
+    end
+    a = math.floor(a / 2)
+    b = math.floor(b / 2)
+  end
+  return r
+end
+
+function utils.mac2ipv6linklocal(text)
+    function f(mac0, mac1, mac2, mac3, mac4, mac5, mac6)
+        local mac0 = string.format("%x", utils.bitwise_xor(tonumber(mac0, 16), 0x02))
+        --! going from and to string to remove leading zeroes and convert to lowercase
+        local gr1 = string.format("%x", tonumber(mac0 .. mac1, 16))
+        local gr2 = string.format("%x", tonumber(mac2 .. 'ff', 16))
+        local gr3 = string.format("%x", tonumber('fe' .. mac3, 16))
+        local gr4 = string.format("%x", tonumber(mac4 .. mac5, 16))
+        return 'fe80::' .. gr1 .. ":" .. gr2 .. ":" .. gr3 .. ":" .. gr4
+    end
+    local ret, _ = string.gsub(text, "(%x%x):(%x%x):(%x%x):(%x%x):(%x%x):(%x%x)", f)
+    return ret
+end
 
 return utils

--- a/packages/lime-system/tests/test_lime_utils.lua
+++ b/packages/lime-system/tests/test_lime_utils.lua
@@ -217,6 +217,16 @@ dnsmasq:*:18362:0:99999:7:::
         assert.are.same({'/foo', '/bar', '/baz'}, files)
     end)
 
+    it('test mac2ipv6linklocal', function()
+        assert.is.equal('foo', utils.mac2ipv6linklocal('foo'))
+        assert.is.equal('fe80::200:ff:fe00:0', utils.mac2ipv6linklocal('00:00:00:00:00:00'))
+        assert.is.equal('fe80::200:ff:fe00:fff', utils.mac2ipv6linklocal('00:00:00:00:0f:ff'))
+        assert.is.equal('fe80::ceaa:bbff:feff:11fe', utils.mac2ipv6linklocal('CC:AA:BB:FF:11:FE'))
+        assert.is.equal('fe80::aa40:41ff:fe1c:84d1', utils.mac2ipv6linklocal('a8:40:41:1c:84:d1'))
+        assert.is.equal('FOOfe80::aa40:41ff:fe1c:84d1BARfe80::aa40:41ff:fe1c:84d1',
+                         utils.mac2ipv6linklocal('FOOa8:40:41:1c:84:d1BARa8:40:41:1c:84:d1'))
+     end)
+
     before_each('', function()
         uci = test_utils.setup_test_uci()
     end)

--- a/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
+++ b/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
@@ -49,12 +49,12 @@ done | sort -u -r)"
 wifi_get_macs="
 wireless = require('lime.wireless')
 iwinfo = require('iwinfo')
-ip = require('luci.ip')
+utils = require('lime.utils')
 
 for _, ifc in ipairs(wireless.mesh_ifaces()) do
 	for mac, sta in  pairs(iwinfo.nl80211.assoclist(ifc)) do
 		if sta.inactive < 5000 then
-			print(tostring(ip.new(mac):tolinklocal()) .. '%' .. ifc)
+			print(utils.mac2ipv6linklocal(mac) .. '%' .. ifc)
 		end
 	end
 end


### PR DESCRIPTION
Use our own implementation of the conversion of mac to ipv6linklocal to workarround this bug in luci.ip.tolinklocal https://github.com/openwrt/luci/pull/4415

Also provided is the utility script `mac2ipv6ll`