### PR TITLE
lime-proto-bgp depend on bird1-* packages from OpenWrt 19.07

### DIFF
--- a/packages/lime-proto-bgp/Makefile
+++ b/packages/lime-proto-bgp/Makefile
@@ -21,7 +21,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LiMe
   MAINTAINER:=Gioacchino Mazzurco <gio@diveni.re>
   URL:=http://libremesh.org
-  DEPENDS:=+bird4 +bird6 +lime-system +lua
+  DEPENDS:=+bird1-ipv4 +bird1-ipv6 +lime-system +lua
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
Fix #645

This will remove the Warning (it is not an Error!!!) from the compilation with OpenWrt 19.07 but will add the warning to the compilation with OpenWrt 18.06. I have no idea how to write a dependency valid both for OpenWrt 18.06 and 19.07 without using conditional dependencies which are evil (see #331 #673 ).

Here you can find the [Bird Makefile in 18.06](https://github.com/openwrt-routing/packages/blob/openwrt-18.06/bird/Makefile) and the [Bird1 Makefile in 19.07](https://github.com/openwrt-routing/packages/blob/openwrt-19.07/bird1/Makefile).

Plenty of users were alarmed by this warning (DrivenMadz on IRC/Element, #750, #645, on the ML [here](https://lists.libremesh.org/pipermail/lime-users/2020-August/001657.html), [here](https://lists.libremesh.org/pipermail/lime-users/2020-August/001663.html), [here](https://lists.libremesh.org/pipermail/lime-users/2020-September/001698.html)).