### PR TITLE
luci-app-lime-location fix typo

### DIFF
--- a/packages/luci-app-lime-location/files/usr/lib/lua/luci/controller/location.lua
+++ b/packages/luci-app-lime-location/files/usr/lib/lua/luci/controller/location.lua
@@ -29,7 +29,7 @@ end
 function set_location(lat, lon)
    local uci = require "uci"                         
    local uci = uci.cursor() 
-   uci:tset('libremap', 'location', {latitude=lat, longitude=lon})
+   uci:set('libremap', 'location', {latitude=lat, longitude=lon})
    uci:save('libremap')
    uci:commit('libremap')
 end


### PR DESCRIPTION
I casually found a typo in luci-app-lime-location package