### PR TITLE
Improvements to lime-sysupgrade

### DIFF
--- a/packages/lime-system/files/usr/bin/lime-sysupgrade
+++ b/packages/lime-system/files/usr/bin/lime-sysupgrade
@@ -11,7 +11,7 @@ BACKUP_EXTRA_DIR="/tmp/lime-sysupgrade/preserve/"
 
 add_file() {
   for l in `cat $1 | sed -e s/#.*$// -e /^$/d`; do
-    [ -e "$l" ] && BACKUP_FILES="$BACKUP_FILES $l"
+    [ -e "$l" ] && BACKUP_FILES="$BACKUP_FILES $l" || true
   done
 }
 

--- a/packages/lime-system/files/usr/bin/lime-sysupgrade
+++ b/packages/lime-system/files/usr/bin/lime-sysupgrade
@@ -63,6 +63,6 @@ if safe-upgrade board-supported > /dev/null 2>&1; then
     [ -e "$BACKUP_ARCHIVE" ] && OPTIONS="--preserve-archive $BACKUP_ARCHIVE" || OPTIONS="-n"
     safe-upgrade upgrade $OPTIONS $FIRMWARE
 else
-    [ -e "$BACKUP_FILES" ] && OPTIONS="-f $BACKUP_ARCHIVE" || OPTIONS="-n"
+    [ -e "$BACKUP_ARCHIVE" ] && OPTIONS="-f $BACKUP_ARCHIVE" || OPTIONS="-n"
     sysupgrade $OPTIONS $FIRMWARE &
 fi

--- a/packages/lime-system/files/usr/bin/lime-sysupgrade
+++ b/packages/lime-system/files/usr/bin/lime-sysupgrade
@@ -54,6 +54,7 @@ echo "------------------"
 echo ""
 echo "The device model is $(cat /tmp/sysinfo/model)"
 echo "The md5sum of the new firmware is $(md5sum $FIRMWARE | awk '{print $1}')"
+command -v sha256sum &> /dev/null && echo "Its sha256sum is $(sha256sum $FIRMWARE | awk '{print $1}')" || true
 echo "Ready to perform the upgrade. Press [ENTER] to continue or CTRL+C to cancel"
 [ "$FORCE" == "1" ] || read
 echo ""


### PR DESCRIPTION
Fix #769 
Here goes three changes to lime-sysupgrade script from lime-system package:

1) when one of the files from a collection was missing, for example /root/.ssh/known_hosts from dropbear collection, a misleading warning was printed, for example:

`Warning: Cannot read /lib/upgrade/keep.d/dropbear file`

even if `/lib/upgrade/keep.d/dropbear` exists.

2) the checksums since OpenWrt 19.07 are SHA256 by default, so I added the output of sha256sum. I think that sha256sum was not present in OpenWrt 18.06, so I added a check for its presence.

3) in case the router was not supported by safe-upgrade (or did not have installed it), a broken check caused the lack of preservation of the configuration.