### PR TITLE
Add network-profiles packages repo to OPKG feeds

### DIFF
--- a/packages/lime-system/files/etc/uci-defaults/92_add-lime-repos
+++ b/packages/lime-system/files/etc/uci-defaults/92_add-lime-repos
@@ -13,15 +13,18 @@ feeds_file="/etc/opkg/limefeeds.conf"
 }
 
 [ "$LIME_CODENAME" == "development" ] && {
-	base_url="http://feed.libremesh.org/master";
+	packages_url="http://feed.libremesh.org/master";
 } || {
-	base_url="http://feed.libremesh.org/$LIME_RELEASE"
+	packages_url="http://feed.libremesh.org/$LIME_RELEASE"
 }
+
+profiles_url="http://feed.libremesh.org/profiles"
 
 key_name="a71b3c8285abd28b"
 key_content="RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8"
 
 echo "Configuring official LibreMesh opkg feeds"
-echo "src/gz libremesh $base_url" > "$feeds_file"
+echo "src/gz libremesh $packages_url" > "$feeds_file"
+echo "src/gz profiles $profiles_url" >> "$feeds_file"
 echo "untrusted comment: signed by libremesh.org key $key_name" > "/etc/opkg/keys/$key_name"
 echo "$key_content" >> "/etc/opkg/keys/$key_name"


### PR DESCRIPTION
Sorry for not thinking this before but we can add also the packaged network-profiles repository to OPKG available packages.

Then, in order to install a network profile using OPKG it could be necessary to use the `--force-overwrite` option from `opkg` command. This is needed only for profiles providing files already existing in the router (like [this](https://github.com/libremesh/network-profiles/tree/master/libremesh/default/root/etc/config)) but will not be needed for some other network-profiles which set the options in other ways (like [this](https://github.com/libremesh/network-profiles/tree/master/libremesh/encrypt-11s/root/etc/uci-defaults)).

See also discussion on #747 