### PR TITLE
Renamed ubus-lime-utils' system_notes.sh to avoid conflicts with lime-webui

### DIFF
--- a/packages/ubus-lime-utils/files/etc/profile.d/system_notes.sh
+++ b/packages/ubus-lime-utils/files/etc/profile.d/system_notes.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-echo ""
-echo " === System Notes ====================================="
-[ -f /etc/banner.notes ] && cat /etc/banner.notes
-echo ""
-echo " == edit this note via lime-app or /etc/banner.notes =="
-echo ""

--- a/packages/ubus-lime-utils/files/etc/profile.d/ubus-lime-utils-system_notes.sh
+++ b/packages/ubus-lime-utils/files/etc/profile.d/ubus-lime-utils-system_notes.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+echo ""
+echo " === System Notes ================================================="
+[ -f /etc/banner.notes ] && cat /etc/banner.notes
+echo ""
+echo " = edit via http://thisnode.info/app/#/notes or /etc/banner.notes ="
+echo ""


### PR DESCRIPTION
With #784 I created a conflict with the (abandoned) lime-webui package.
See the report on https://lists.libremesh.org/pipermail/lime-users/2020-October/001737.html
I also changed the indication of how to modify the node from lime-app (including the full URL).