### PR TITLE
firstbootwizard: now needs root privilege to run

### DIFF
--- a/packages/ubus-lime-fbw/files/usr/share/rpcd/acl.d/lime-fbw.json
+++ b/packages/ubus-lime-fbw/files/usr/share/rpcd/acl.d/lime-fbw.json
@@ -1,5 +1,5 @@
 {
-    "lime-app": {
+    "root": {
         "description": "First Boot Wizard ubus interface",
         "read": {
             "ubus": {
@@ -9,6 +9,14 @@
         "write": {
             "ubus": {
                 "lime-fbw": ["*"]
+            }
+        }
+    },
+    "lime-app": {
+        "description": "First Boot Wizard unauthenticated ubus interface",
+        "read": {
+            "ubus": {
+                "lime-fbw": ["status"]
             }
         }
     }


### PR DESCRIPTION
This PR changes acl for firstbootwizard, in order to fix the current privilege escalation reported at: https://github.com/libremesh/lime-packages/issues/763#issuecomment-696670006
It should be merged along with https://github.com/libremesh/lime-app/pull/277 at the LimeApp