### PR TITLE
Fbw add dismiss option

### DIFF
--- a/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
+++ b/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
@@ -25,6 +25,7 @@ local fbw = {}
 
 
 fbw.WORKDIR = '/tmp/fbw/'
+fbw.IS_DISMISSED_FILE = fbw.WORKDIR .. 'is_dismissed'
 fbw.HOST_CONFIG_PREFIX = 'lime-community__host__'
 
 utils.execute('mkdir -p ' .. fbw.WORKDIR)
@@ -232,6 +233,20 @@ end
 function fbw.mark_as_configured()
     local uci_cursor = config.get_uci_cursor()
     uci_cursor:set(config.UCI_NODE_NAME, 'system', 'firstbootwizard_configured', 'true')
+end
+
+function fbw.is_dismissed()
+    local by_config = config.get_bool('system', 'firstbootwizard_dismissed', false)
+    local by_tmp_file = lutils.file_exists(fbw.IS_DISMISSED_FILE)
+    return by_config or by_tmp_file
+end
+
+function fbw.dismiss()
+    local uci_cursor = config.get_uci_cursor()
+    lutils.write_file(fbw.IS_DISMISSED_FILE, "true")
+    uci_cursor:set(config.UCI_NODE_NAME, 'system', 'firstbootwizard_dismissed', 'true')
+    uci_cursor:commit(config.UCI_NODE_NAME)
+    lutils.unsafe_shell("/usr/bin/lime-config")
 end
 
 -- Get config from lime-default file

--- a/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
+++ b/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
@@ -25,7 +25,6 @@ local fbw = {}
 
 
 fbw.WORKDIR = '/tmp/fbw/'
-fbw.IS_DISMISSED_FILE = fbw.WORKDIR .. 'is_dismissed'
 fbw.HOST_CONFIG_PREFIX = 'lime-community__host__'
 
 utils.execute('mkdir -p ' .. fbw.WORKDIR)
@@ -236,17 +235,14 @@ function fbw.mark_as_configured()
 end
 
 function fbw.is_dismissed()
-    local by_config = config.get_bool('system', 'firstbootwizard_dismissed', false)
-    local by_tmp_file = lutils.file_exists(fbw.IS_DISMISSED_FILE)
-    return by_config or by_tmp_file
+    return config.get_bool('system', 'firstbootwizard_dismissed', false)
 end
 
 function fbw.dismiss()
     local uci_cursor = config.get_uci_cursor()
-    lutils.write_file(fbw.IS_DISMISSED_FILE, "true")
     uci_cursor:set(config.UCI_NODE_NAME, 'system', 'firstbootwizard_dismissed', 'true')
     uci_cursor:commit(config.UCI_NODE_NAME)
-    lutils.unsafe_shell("/usr/bin/lime-config")
+    config.uci_autogen()
 end
 
 -- Get config from lime-default file

--- a/packages/first-boot-wizard/tests/test_firstbootwizard.lua
+++ b/packages/first-boot-wizard/tests/test_firstbootwizard.lua
@@ -49,13 +49,10 @@ describe('FirstBootWizard tests #fbw', function()
     end)
 
     it('test is_dismissed() / dismiss()', function()
-        stub(utils, "unsafe_shell", function () return nil end)
         assert.is.equal(false, fbw.is_dismissed())
         uci:set(config.UCI_NODE_NAME, 'system', 'lime')
         fbw.dismiss()
         assert.is.equal(true, fbw.is_dismissed())
-        assert.stub(utils.unsafe_shell).was.called_with('/usr/bin/lime-config')
-        config.uci_autogen()
         assert.is.equal(true, config.get_bool('system', 'firstbootwizard_dismissed', false))
     end)
 

--- a/packages/first-boot-wizard/tests/test_firstbootwizard.lua
+++ b/packages/first-boot-wizard/tests/test_firstbootwizard.lua
@@ -48,6 +48,17 @@ describe('FirstBootWizard tests #fbw', function()
 
     end)
 
+    it('test is_dismissed() / dismiss()', function()
+        stub(utils, "unsafe_shell", function () return nil end)
+        assert.is.equal(false, fbw.is_dismissed())
+        uci:set(config.UCI_NODE_NAME, 'system', 'lime')
+        fbw.dismiss()
+        assert.is.equal(true, fbw.is_dismissed())
+        assert.stub(utils.unsafe_shell).was.called_with('/usr/bin/lime-config')
+        config.uci_autogen()
+        assert.is.equal(true, config.get_bool('system', 'firstbootwizard_dismissed', false))
+    end)
+
     it('test get_networks()', function()
         fbw.get_networks() -- TODO
     end)

--- a/packages/lime-docs/files/www/docs/lime-example.txt
+++ b/packages/lime-docs/files/www/docs/lime-example.txt
@@ -23,6 +23,7 @@ config lime system
 	option root_password_secret '$1$K0.R51EI$bkjIoF5feHcpqCuEOrymB.'	# This is the password hash as stored in /etc/shadow, it is only used when root_password_policy=SET_SECRET. You can generate the secret with 'openssl passwd -1' to be compatible with most openwrt firmwares, use a strong password with at least 10 numbers and letters, the longer the better!. For improved security use "openssl passwd -6" for SHA512 (or -5 for SHA256) but be aware that not all firmwares support this.
 	option deferable_reboot_uptime_s '97200'
 	option firstbootwizard_configured false
+	option firstbootwizard_dismissed false		# When true fbw banner will be hidden.
 
 #########################################################
 ### Network general option

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -13,6 +13,7 @@ config lime system
 	option root_password_secret ''
 	option deferable_reboot_uptime_s '97200'
 	option firstbootwizard_configured false
+	option firstbootwizard_dismissed false
 
 config lime network
 	option primary_interface 'eth0'

--- a/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
+++ b/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
@@ -5,6 +5,7 @@ require "uloop"
 local fbw = require 'firstbootwizard'
 local nixio = require "nixio"
 local json = require 'luci.jsonc'
+local config = require "lime.config"
 
 uloop.init()
 
@@ -36,6 +37,12 @@ local methods = {
             function(req, msg)
                 local scan_status
                 local scan_file = fbw.check_scan_file()
+                -- reload config cursor to delete the uci cache. This is needed in daemon mode to
+                -- ensure that we have the latest configs from the config files and not some cache
+                -- stored from an older request
+                config.set_uci_cursor(nil)
+                config.get_uci_cursor()
+
                 -- if no scan file return 0
                 if scan_file == nil then scan_status = 0
                 -- if scanning return 1

--- a/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
+++ b/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
@@ -44,7 +44,7 @@ local methods = {
                 elseif scan_file == "false" then scan_status = 2
                 end
                 local status = {
-                    lock = not fbw.is_configured(),
+                    lock = not fbw.is_configured() and not fbw.is_dismissed(),
                     scan = scan_status
                 }
                 conn:reply(req, status)
@@ -68,6 +68,12 @@ local methods = {
                     conn:reply(req, { status = 'error', msg = "Network and hostname are required" })
                 end
             end, { network = ubus.STRING, hostname = ubus.STRING, password = ubus.STRING }
+        },
+        dismiss = {
+            function (req, msg)
+                conn:reply(req, {status = 'done'})
+                fbw.dismiss()
+            end, {}
         }
     }
 }

--- a/packages/ubus-lime-fbw/files/usr/share/rpcd/acl.d/lime-fbw.json
+++ b/packages/ubus-lime-fbw/files/usr/share/rpcd/acl.d/lime-fbw.json
@@ -18,6 +18,11 @@
             "ubus": {
                 "lime-fbw": ["status"]
             }
+        },
+        "write": {
+            "ubus": {
+                "lime-fbw": ["dismiss"]
+            }
         }
     }
 }

--- a/packages/ubus-lime-fbw/files/usr/share/rpcd/acl.d/lime-fbw.json
+++ b/packages/ubus-lime-fbw/files/usr/share/rpcd/acl.d/lime-fbw.json
@@ -1,5 +1,5 @@
 {
-    "lime-app": {
+    "root": {
         "description": "First Boot Wizard ubus interface",
         "read": {
             "ubus": {
@@ -9,6 +9,14 @@
         "write": {
             "ubus": {
                 "lime-fbw": ["*"]
+            }
+        }
+    },
+    "lime-app": {
+        "description": "First Boot Wizard unauthenticated ubus interface",
+        "read": {
+            "ubus": {
+                "lime-fbw": ["status"]
             }
         }
     }


### PR DESCRIPTION
This PR adds the ability to dismiss fbw from an ubus endpoint, which will be called by the LimeApp. Addressing #786 
The corresponding PR in the limeapp side is https://github.com/libremesh/lime-app/pull/278

Comments and suggestions about the implementation are welcomed. I thought it would be nice to keep track of whether the fbw has been performed firstbootwizard_configured=true or it has been dismissed firstbootwizard_dismissed=true.
Also, when dismissing, the config option is not reloaded until a reboot or restart of the rpcd service, so a temp file is used to reflect the dismiss too.

Disclaimer: This branch is rebased with the one of #791. They introduce changes in the same acl