### PR TITLE
babeld: do not forcefully enable libremap plugin

### DIFF
--- a/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
+++ b/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
@@ -83,12 +83,6 @@ function babeld.configure(args)
 
 	uci:save("babeld")
 
-
-	uci:set("libremap", "babeld", "plugin")
-	uci:set("libremap", "babeld", "enabled", "true")
-
-	uci:save("libremap")
-
 end
 
 function babeld.setup_interface(ifname, args)


### PR DESCRIPTION
See issue description in #788.
In #788 two issues are described, the second one is addressed here.