### PR TITLE
ubus-lime-location do not depend on libremap-agent

### DIFF
--- a/packages/ubus-lime-location/Makefile
+++ b/packages/ubus-lime-location/Makefile
@@ -13,7 +13,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Marcos Gutierrez <gmarcos87@gmail.com>
   SUBMENU:=3. Applications
   TITLE:=Libremap ubus status module
-  DEPENDS:= +lua +libubox-lua +libubus-lua +libuci +libremap-agent
+  DEPENDS:= +lua +libubox-lua +libubus-lua +libuci
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
Followup from my [comment here](https://github.com/libremesh/lime-packages/issues/788#issuecomment-725038277) on #788:

>> in a cascade of dependencies (`libremap-agent` => `luci-lib-libremap` => `luci-base`) it selects `luci-base` and increases a lot the size of the image (`luci-base` is also selected in a cascade by `check-date-http` package, which is suggested as optional [in the development page](https://libremesh.org/development.html#compiling_libremesh_from_source_code)).
>> and get rid of all these issues altogether. Currently, libremap-agent is selected by ubus-lime-location which is selected by lime-app.

> I tried to understand how ubus-lime-location works and seems that it does not require libremap-agent in order to work. The selection of libremap-agent can be suggested to users willing to update the network condition on a public map server, and can be removed as a hard dependency from ubus-lime-location.
> Is this correct?
> This would have the bonus to allow the generation of images with lime-app without LuCI (less dependencies smaller image!).
