### PR TITLE
fbw: use non absolute wget path

### DIFF
--- a/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
+++ b/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
@@ -157,13 +157,13 @@ end
 function fbw.fetch_config(data)
     fbw.log('Fetch config from '.. json.stringify(data))
     local host = data.host
-    local hostname = utils.execute("/bin/wget http://["..data.host.."]/cgi-bin/hostname -qO - "):gsub("\n", "")
+    local hostname = utils.execute("wget http://["..data.host.."]/cgi-bin/hostname -qO - "):gsub("\n", "")
     fbw.log('Hostname found: '.. hostname)
     if (hostname == '') then hostname = host end
     local signal = data.signal
     local ssid = data.ssid
     local filename = fbw.WORKDIR .. fbw.HOST_CONFIG_PREFIX .. hostname
-    utils.execute("/bin/wget http://[" .. data.host .. "]/lime-community -O " .. filename)
+    utils.execute("wget http://[" .. data.host .. "]/lime-community -O " .. filename)
 
     -- Remove lime-community files that are not yet configured.
     -- For this we asume that no ap_ssid options equals not configured.


### PR DESCRIPTION
wget path changed from 18.06 to 19.07 so this is to be more compatible.
Current uses of firstbootwizard (init.d and ubus daemon) have the PATH
env variable correctly populated so this should not break anything.

Fixes #798 