### PR TITLE
shared-state-dnsmasq_servers: new package

### DIFF
--- a/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
+++ b/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
@@ -100,6 +100,7 @@ function anygw.configure(args)
 	uci:foreach("dhcp", "dnsmasq",
 		function(s)
 			uci:set("dhcp", s[".name"], "add_local_fqdn", "0")
+			uci:set("dhcp", s[".name"], "add_local_hostname", "0")
 		end
 	)
 

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -153,6 +153,8 @@ function network.setup_dns()
 			uci:set("dhcp", s[".name"], "local", "/"..cloudDomain.."/")
 			uci:set("dhcp", s[".name"], "expandhosts", "1")
 			uci:set("dhcp", s[".name"], "domainneeded", "1")
+			--! allow queries from non-local ips (i.e. from other clouds)
+			uci:set("dhcp", s[".name"], "localservice", "0")
 			uci:set("dhcp", s[".name"], "server", resolvers)
 		end
 	)

--- a/packages/shared-state-dnsmasq_hosts/files/usr/bin/shared-state-generate_dnsmasq_hosts
+++ b/packages/shared-state-dnsmasq_hosts/files/usr/bin/shared-state-generate_dnsmasq_hosts
@@ -19,13 +19,10 @@
 local JSON = require("luci.jsonc")
 
 local outputTable = {}
-local localHostname = io.input("/proc/sys/kernel/hostname"):read("*line")
 
 for key,value in pairs(
 	JSON.parse(io.stdin:read("*all")) ) do
-	if value.data and value.author ~= localHostname then
 		table.insert(outputTable, key)
-	end
 end
 
 local outputFile = io.open("/var/hosts/shared-state-dnsmasq_hosts", "w")

--- a/packages/shared-state-dnsmasq_servers/Makefile
+++ b/packages/shared-state-dnsmasq_servers/Makefile
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2020 Gui iribarren <gui@altermundi.net>
+#
+# This is free software, licensed under the GNU Affero General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+PKG_NAME:=shared-state-dnsmasq_servers
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+	TITLE:=Mesh DNS module for shared-state
+	CATEGORY:=LiMe
+	MAINTAINER:=Gui iribarren <gui@altermundi.net>
+	URL:=http://libremesh.org
+	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +lua +luci-lib-jsonc \
+		shared-state
+	PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/description
+	Generates 'server' lines in dnsmasq config, so that domain zones published
+	by other nodes in the mesh can be resolved transparently.
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/shared-state-dnsmasq_servers/files/etc/shared-state/hooks/dnsmasq-servers/generate_dnsmasq_servers
+++ b/packages/shared-state-dnsmasq_servers/files/etc/shared-state/hooks/dnsmasq-servers/generate_dnsmasq_servers
@@ -1,0 +1,1 @@
+../../../../usr/bin/shared-state-generate_dnsmasq_servers

--- a/packages/shared-state-dnsmasq_servers/files/etc/shared-state/publishers/shared-state-publish_dnsmasq_servers
+++ b/packages/shared-state-dnsmasq_servers/files/etc/shared-state/publishers/shared-state-publish_dnsmasq_servers
@@ -1,0 +1,1 @@
+../../../usr/bin/shared-state-publish_dnsmasq_servers

--- a/packages/shared-state-dnsmasq_servers/files/etc/uci-defaults/shared-state-dnsmasq_servers
+++ b/packages/shared-state-dnsmasq_servers/files/etc/uci-defaults/shared-state-dnsmasq_servers
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# dnsmasq upon SIGHUP will re-read this file containing "server=/example.com/1.2.3.4" lines
+echo "servers-file=/var/shared-state/dnsmasq_servers" > "/etc/dnsmasq.d/shared-state-dnsmasq_servers.conf"
+
+unique_append()
+{
+	grep -qF "$1" "$2" || echo "$1" >> "$2"
+}
+
+unique_append \
+	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-servers &> /dev/null)&)'\
+	/etc/crontabs/root

--- a/packages/shared-state-dnsmasq_servers/files/usr/bin/shared-state-generate_dnsmasq_servers
+++ b/packages/shared-state-dnsmasq_servers/files/usr/bin/shared-state-generate_dnsmasq_servers
@@ -1,0 +1,46 @@
+#!/usr/bin/lua
+
+--! LibreMesh
+--! Copyright (C) 2020 Gui iribarren <gui@altermundi.net>
+--!
+--! This program is free software: you can redistribute it and/or modify
+--! it under the terms of the GNU Affero General Public License as
+--! published by the Free Software Foundation, either version 3 of the
+--! License, or (at your option) any later version.
+--!
+--! This program is distributed in the hope that it will be useful,
+--! but WITHOUT ANY WARRANTY; without even the implied warranty of
+--! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--! GNU Affero General Public License for more details.
+--!
+--! You should have received a copy of the GNU Affero General Public License
+--! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local JSON = require("luci.jsonc")
+
+local uci = require("uci"):cursor()
+
+uci:foreach("dhcp", "dnsmasq",
+  function(s)
+    localDomain = uci:get("dhcp", s[".name"], "local"):gsub("/","")
+  end
+)
+
+local localHostname = io.input("/proc/sys/kernel/hostname"):read("*line")
+
+local content = {}
+
+--! example key="cloud1.mesh", example value.data="fd0d:fe46:8ce8::ab:cd00"
+for key,value in pairs(
+ JSON.parse(io.stdin:read("*all")) ) do
+ if value.data and value.author ~= localHostname and key ~= localDomain then
+   table.insert(content, "server=/" .. key .. "/" .. value.data)
+ end
+end
+
+local outputFile = io.open("/var/shared-state/dnsmasq_servers", "w")
+if outputFile then
+	outputFile:write(table.concat(content,"\n").."\n")
+	outputFile:close()
+	os.execute("killall -HUP dnsmasq 2>/dev/null")
+end

--- a/packages/shared-state-dnsmasq_servers/files/usr/bin/shared-state-publish_dnsmasq_servers
+++ b/packages/shared-state-dnsmasq_servers/files/usr/bin/shared-state-publish_dnsmasq_servers
@@ -1,0 +1,36 @@
+#!/usr/bin/lua
+
+--! LibreMesh
+--! Copyright (C) 2020 Gui iribarren <gui@altermundi.net>
+--!
+--! This program is free software: you can redistribute it and/or modify
+--! it under the terms of the GNU Affero General Public License as
+--! published by the Free Software Foundation, either version 3 of the
+--! License, or (at your option) any later version.
+--!
+--! This program is distributed in the hope that it will be useful,
+--! but WITHOUT ANY WARRANTY; without even the implied warranty of
+--! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--! GNU Affero General Public License for more details.
+--!
+--! You should have received a copy of the GNU Affero General Public License
+--! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local JSON = require("luci.jsonc")
+
+local uci = require("uci"):cursor()
+
+uci:foreach("dhcp", "dnsmasq",
+  function(s)
+    localDomain = uci:get("dhcp", s[".name"], "local"):gsub("/","")
+  end
+)
+
+local anygwIPv6 = uci:get("network", "lm_net_br_lan_anygw_if", "ip6addr")
+if anygwIPv6 then anygwIPv6 = anygwIPv6:gsub("/.*$", "") end
+
+local domains = {}
+domains[localDomain] = anygwIPv6
+
+--! JSON.stringify(domains) will output for example {"cloud1.mesh":"fd0d:fe46:8ce8::ab:cd00"}
+io.popen("shared-state insert dnsmasq-servers", "w"):write(JSON.stringify(domains))


### PR DESCRIPTION
Signed-off-by: Gui Iribarren <gui@altermundi.net>

* a uci-defaults script points dnsmasq to use `/var/shared-state/dnsmasq_servers` as `servers-file`
* each node then publishes through shared-state their own dhcp.dnsmasq.domain and anygw ipv6
* each node populates the local `/var/shared-state/dnsmasq_servers` with all the domains and ipv6s from the other clouds.