### PR TITLE
fbw: share lime-community as cgi-bin

### DIFF
--- a/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
+++ b/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
@@ -157,13 +157,19 @@ end
 function fbw.fetch_config(data)
     fbw.log('Fetch config from '.. json.stringify(data))
     local host = data.host
+
     local hostname = utils.execute("wget http://["..data.host.."]/cgi-bin/hostname -qO - "):gsub("\n", "")
     fbw.log('Hostname found: '.. hostname)
     if (hostname == '') then hostname = host end
     local signal = data.signal
     local ssid = data.ssid
     local filename = fbw.WORKDIR .. fbw.HOST_CONFIG_PREFIX .. hostname
-    utils.execute("wget http://[" .. data.host .. "]/lime-community -O " .. filename)
+
+    utils.execute("wget http://[" .. data.host .. "]/cgi-bin/lime/lime-community -O " .. filename)
+    if not utils.file_exists(filename) then
+        -- For backwards compatibility
+        utils.execute("wget http://[" .. data.host .. "]/lime-community -O " .. filename)
+    end
 
     -- Remove lime-community files that are not yet configured.
     -- For this we asume that no ap_ssid options equals not configured.

--- a/packages/first-boot-wizard/files/www/cgi-bin/lime/lime-community
+++ b/packages/first-boot-wizard/files/www/cgi-bin/lime/lime-community
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo "Content-Type: text/plain"
+echo
+
+cat /etc/config/lime-community

--- a/packages/first-boot-wizard/files/www/lime-community
+++ b/packages/first-boot-wizard/files/www/lime-community
@@ -1,1 +1,0 @@
-/etc/config/lime-community


### PR DESCRIPTION
Sharing the lime-community file as a symlink needs read permissions and uci changes these file permissions in 19.07 when uci commit is run.
Sharing the file as a cgi-bin prevents this problems and is also more hackable. 

Fixes #807 