### PR TITLE
pirania: pirania-dnsmasq should not read /etc/dnsmasq.conf

### DIFF
--- a/packages/pirania/files/etc/init.d/pirania-dnsmasq
+++ b/packages/pirania/files/etc/init.d/pirania-dnsmasq
@@ -9,6 +9,7 @@ DNSMASQ_BIN="/usr/sbin/dnsmasq"
 start_service() {
 	procd_open_instance
 	procd_set_param command $DNSMASQ_BIN \
+		--conf-file=/dev/null \
 		--keep-in-foreground \
 		--port=59053 \
 		--no-resolv \


### PR DESCRIPTION
Right now, /etc/dnsmasq.conf points to /etc/dnsmasq.d/,
which contains lime-proto-anygw-20-ipv6.conf and makes
pirania-dnsmasq do IPv6 router-advertisements on br-lan and anygw
very confusing and totally unrelated to pirania-dnsmasq function

Signed-off-by: Gui Iribarren <gui@altermundi.net>