### PR TITLE
Fix some Lime-App dependencies

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -20,7 +20,7 @@ define Package/$(PKG_NAME)
 	TITLE:=LimeApp
 	MAINTAINER:=Marcos Gutierrez <gmarcos@altermundi.net>
 	URL:=http://github.com/libremesh/lime-app
-	DEPENDS:=+rpcd +uhttpd +uhttpd-mod-ubus \
+	DEPENDS:=+rpcd +uhttpd +uhttpd-mod-ubus +uhttpd-mod-lua \
 		+ubus-lime-location +ubus-lime-metrics +ubus-lime-utils \
 		+ubus-lime-openairview +ubus-lime-grondrouting
 	PKGARCH:=all

--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -20,7 +20,7 @@ define Package/$(PKG_NAME)
 	TITLE:=LimeApp
 	MAINTAINER:=Marcos Gutierrez <gmarcos@altermundi.net>
 	URL:=http://github.com/libremesh/lime-app
-	DEPENDS:=+uhttpd +uhttpd-mod-ubus \
+	DEPENDS:=+rpcd +uhttpd +uhttpd-mod-ubus \
 		+ubus-lime-location +ubus-lime-metrics +ubus-lime-utils \
 		+ubus-lime-openairview +ubus-lime-grondrouting
 	PKGARCH:=all


### PR DESCRIPTION
Now that lime-app does not depend on libremap/luci I've spoted some missing dependencies. If we dont  select rpcd then there is a circular dependency and lime-app can't be selected:
```
tmp/.config-package.in:955:     symbol PACKAGE_rpcd is selected by PACKAGE_attendedsysupgrade-common
tmp/.config-package.in:7:       symbol PACKAGE_attendedsysupgrade-common is selected by PACKAGE_luci-app-attendedsysupgrade
tmp/.config-package.in:74090:   symbol PACKAGE_luci-app-attendedsysupgrade depends on PACKAGE_uhttpd
tmp/.config-package.in:132131:  symbol PACKAGE_uhttpd is selected by PACKAGE_lime-app
tmp/.config-package.in:73092:   symbol PACKAGE_lime-app depends on PACKAGE_rpcd
```