### PR TITLE
github-ci: replace deprecated set-env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           echo "DEST_DIR=$TAG" >> $GITHUB_ENV
 
       - name: Upload packages to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3.7.0-8
+        uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: libremesh/lime-feed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           export TAG=$(echo "${{ github.ref }}" | cut -d '/' -f 3-)
           echo "$TAG"
-          echo "::set-env name=DEST_DIR::$TAG"
+          echo "DEST_DIR=$TAG" >> $GITHUB_ENV
 
       - name: Upload packages to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3.7.0-8


### PR DESCRIPTION
Hopefuly fIxes github action.
I am not exactly sure but as per the following documentation  https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files this should do the work.
