### PR TITLE
lime-proto-batadv change MAC also of wlan interfaces

### DIFF
--- a/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
+++ b/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
@@ -87,19 +87,19 @@ function batadv.setup_interface(ifname, args)
 		--! TODO: Use DSA to check if ethernet device is capable of bigger MTU
 		--! reducing it
 		mtu = network.MTU_ETH_WITH_VLAN
-		
-		--! Avoid dmesg flooding caused by BLA with messages like "br-lan:
-		--! received packet on bat0 with own address as source address".
-		--! Tweak MAC address for each of the interfaces used by Batman-adv
-		--! 00 + Locally administered unicast .. 2 bytes from interface name
-		--! .. 3 bytes from main interface
-		local id = utils.get_id(ifname)
-		local vMacaddr = network.primary_mac();
-		vMacaddr[1] = "02"
-		vMacaddr[2] = id[2]
-		vMacaddr[3] = id[3]
-		uci:set("network", owrtDeviceName, "macaddr", table.concat(vMacaddr, ":"))
 	end
+
+	--! Avoid dmesg flooding caused by BLA with messages like "br-lan:
+	--! received packet on bat0 with own address as source address".
+	--! Tweak MAC address for each of the interfaces used by Batman-adv
+	--! 00 + Locally administered unicast .. 2 bytes from interface name
+	--! .. 3 bytes from main interface
+	local id = utils.get_id(ifname)
+	local vMacaddr = network.primary_mac();
+	vMacaddr[1] = "02"
+	vMacaddr[2] = id[2]
+	vMacaddr[3] = id[3]
+	uci:set("network", owrtDeviceName, "macaddr", table.concat(vMacaddr, ":"))
 
 	uci:set("network", owrtDeviceName, "mtu", mtu)
 	uci:save("network")


### PR DESCRIPTION
In order to avoid the "received packet on bat0 with own address as source address" annoying (but harmless) message we are customizing the MAC address of the ethernet VLAN interface, see #726 (and #703 and #724).
But in some cases (see [here](https://lists.libremesh.org/pipermail/lime-users/2020-December/001855.html)) for some reason the wireless VLAN interface can be taken as MainIF by batman-adv and therefore needs to have a customized mac address also.

This PR simply moves the MAC customization code out of the `if` block, with no further edit.