### PR TITLE
shared-state: multiple fixes

### DIFF
--- a/packages/lime-debug/Makefile
+++ b/packages/lime-debug/Makefile
@@ -16,13 +16,16 @@ PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
 
 include $(INCLUDE_DIR)/package.mk
 
+include ../../ping6retrocompat.mk
+
 define Package/$(PKG_NAME)
 	TITLE:=libremesh debug utils
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
 	URL:=http://libremesh.org
 	DEPENDS:=+bandwidth-test \
-		+busybox +ethtool +iwinfo +iw +mtr +ip +iputils-ping6 +iputils-ping \
+		+busybox +ethtool +iwinfo +iw +mtr +ip \
+		+$(PING6_PACKAGE) +iputils-ping \
 		+sprunge +safe-reboot +netperf +pv +tcpdump-mini +bwm-ng \
 		+lime-report
 	PKGARCH:=all

--- a/packages/shared-state/Makefile
+++ b/packages/shared-state/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 Gioacchino Mazzurco <gio@altermundi.net>
+# Copyright (C) 2019-2020 Gioacchino Mazzurco <gio@altermundi.net>
 #
 # This is free software, licensed under the GNU Affero General Public License v3.
 #
@@ -14,17 +14,24 @@ PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
 
 include $(INCLUDE_DIR)/package.mk
 
+include ../../ping6retrocompat.mk
+
 define Package/$(PKG_NAME)
 	TITLE:=Very minimal state sharing betwen nodes
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+libuci-lua +lua +luci-lib-jsonc +luci-lib-nixio +uclient-fetch +lime-system
+	DEPENDS:=+libuci-lua +lime-system +lua +luci-lib-jsonc +luci-lib-nixio \
+		+$(PING6_PACKAGE) +uclient-fetch
 	PKGARCH:=all
 endef
 
+define Package/$(PKG_NAME)/config
+	select $(PING6_SYMLINK)
+endef
+
 define Package/$(PKG_NAME)/description
-	LiMe utilities to avoid alfred pitfalls
+	LiMe style minimal unsecured CRDT to share light state between nodes
 endef
 
 define Build/Compile

--- a/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
+++ b/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
@@ -3,7 +3,7 @@
 << COPYRIGHT
 
  LibreMesh
- Copyright (C) 2019  Gioacchino Mazzurco <gio@altermundi.net>
+ Copyright (C) 2019-2020  Gioacchino Mazzurco <gio@altermundi.net>
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU Affero General Public License as
@@ -42,6 +42,7 @@ for iface in $(ls /sys/class/net/) ; do
 
 	echo "${iface}" | grep -E "mesh|adhoc" &> /dev/null && continue
 
+#[Doc] ping6 from busybox doesn't support float intervals iputils-ping does
 	ping6 -i 0.1 -c 2 ff02::1%${iface} 2> /dev/null | \
 		awk '{if ($3 == "from") print substr($4, 1, length($4)-1)'"\"%${iface}\""'}'
 done | sort -u -r)"
@@ -71,12 +72,14 @@ for ownAddr in $(ip -6 address show | awk '{if ($1 == "inet6") print $2}' | awk 
 	candidateAddresses="$(echo "$candidateAddresses" | grep -v "^$ownAddr%.*$")"
 done
 
-# Deduplicate addresses visible from muliple interfaces
+#[Doc] Deduplicate addresses visible from muliple interfaces
 for cAddr in $(echo "$candidateAddresses"); do
 	cIp="$(echo "$cAddr" | awk -F% '{print $1}')"
 	cIface="$(echo "$cAddr" | awk -F% '{print $2}')"
 
-	candidateAddresses="$cAddr
+#[Doc] Use ${cIp}%${cIface} instead of $cAddr to avoid duplicate interface with
+#[Doc] newer iputils-ping
+	candidateAddresses="${cIp}%${cIface}
 $(echo "$candidateAddresses" | grep -v "$cIp")"
 
 done

--- a/ping6retrocompat.mk
+++ b/ping6retrocompat.mk
@@ -1,0 +1,20 @@
+# Provide ping6 compatibility between Openwrt master and future releases based
+# on it with OpenWrt 19.07.X and 18.06.X
+# Other attempts using LINUX_X_Y variable proven to not work reliably and where
+# even uglier.
+# Include this file in your makefile and the use the PING6_PACKAGE
+# and PING6_SYMLINK as you need.
+# See shared-state and lime-debug for usage examples.
+
+# Just in case the the OpenWrt source code is a shallow clone
+$(shell git -C $(TOPDIR) fetch --unshallow || true)
+
+# In case the iputils-ping6 removal commit
+# 98b3526bf23e8d1b48939c937c9b12e4f2160415 is ancestor of current commit
+# ping6 is provided by iputils-ping + PING_LEGACY_SYMLINKS.
+PING6_PACKAGE=iputils-ping6
+PING6_SYMLINK=PACKAGE_iputils-ping6
+ifeq ($(shell git -C $(TOPDIR) merge-base --is-ancestor 98b3526bf23e8d1b48939c937c9b12e4f2160415 HEAD ; echo $$?),0)
+PING6_PACKAGE=iputils-ping
+PING6_SYMLINK=PING_LEGACY_SYMLINKS
+endif


### PR DESCRIPTION
As busybox ping6 doesn't support float intervals, ping6 from iputils is needed, in recent versions of OpenWrt the package iputils-ipv6 has been removed and meld into iputils-ping, the output of the command also changed son a few tricks to keep compatibility with all this different versions were needed.
As a bonus also lime-debug get its dependencies fixed for OpenWrt master in a retro-compatible way.