### PR TITLE
Lime proto babeld fixes

### DIFF
--- a/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
+++ b/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
@@ -82,9 +82,9 @@ function babeld.configure(args)
 	uci:set("babeld", "localdeny", "action", "deny")
 
 	-- Avoid redistributing enything else
-	uci:set("babeld", "deny", "filter")
-	uci:set("babeld", "deny", "type", "redistribute")
-	uci:set("babeld", "deny", "action", "deny")
+	uci:set("babeld", "denyany", "filter")
+	uci:set("babeld", "denyany", "type", "redistribute")
+	uci:set("babeld", "denyany", "action", "deny")
 
 	uci:save("babeld")
 

--- a/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
+++ b/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
@@ -82,9 +82,9 @@ function babeld.configure(args)
 	uci:set("babeld", "localdeny", "action", "deny")
 
 	-- Avoid redistributing enything else
-	uci:set("babeld", "dany", "filter")
-	uci:set("babeld", "dany", "type", "redistribute")
-	uci:set("babeld", "dany", "action", "deny")
+	uci:set("babeld", "deny", "filter")
+	uci:set("babeld", "deny", "type", "redistribute")
+	uci:set("babeld", "deny", "action", "deny")
 
 	uci:save("babeld")
 

--- a/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
+++ b/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
@@ -43,6 +43,11 @@ function babeld.configure(args)
 	uci:set("babeld", "general", "general")
 	uci:set("babeld", "general", "local_port", "30003")
 
+	uci:set("babeld", "ula6", "filter")
+	uci:set("babeld", "ula6", "type", "redistribute")
+	uci:set("babeld", "ula6", "ip", "fc00::/7")
+	uci:set("babeld", "ula6", "action", "allow")
+
 	uci:set("babeld", "public6", "filter")
 	uci:set("babeld", "public6", "type", "redistribute")
 	uci:set("babeld", "public6", "ip", "2000::0/3")


### PR DESCRIPTION
right now, babeld doesn't route between clouds over ipv6, since `main_ipv6_address` is set to `fd%N1:%N2%N3:%N4%N5::/64`

also, conceptually it makes total sense to redistribute `fc00::/7` the same way `10.0.0.0/8` is redistributed