### PR TITLE
shared-state: parse babeld.conf interfaces in get_candidates_neigh

### DIFF
--- a/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
+++ b/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
@@ -46,6 +46,12 @@ for iface in $(ls /sys/class/net/) ; do
 		awk '{if ($3 == "from") print substr($4, 1, length($4)-1)'"\"%${iface}\""'}'
 done | sort -u -r)"
 
+babelCandidateAddresses="$(
+for iface in $(grep interface /var/etc/babeld.conf | awk '{print $2}'); do
+	ping6 -i 0.1 -c 2 ff02::1%${iface} 2> /dev/null | \
+		awk '{if ($3 == "from") print substr($4, 1, length($4)-1)'"\"%${iface}\""'}'
+done | sort -u -r)"
+
 wifi_get_macs="
 wireless = require('lime.wireless')
 iwinfo = require('iwinfo')
@@ -63,6 +69,7 @@ end
 wirelessCandidateAddresses=$(echo "$wifi_get_macs" | lua -  | sort -u -r)
 
 candidateAddresses="$batmanNonMeshCandidateAddresses
+$babelCandidateAddresses
 $wirelessCandidateAddresses
 $(ping6 -i 0.1 -c 2 ff02::1%br-lan | \
 	awk '{if ($3 == "from" && substr($7,6)+0 < 2) print substr($4, 1, length($4)-1)"%br-lan" }' | sort -u)"


### PR DESCRIPTION
make `shared-state` aware of interfaces used by babeld, and search for candidate neighs in those interfaces as well.