### PR TITLE
lime-utils: remove debugging print

### DIFF
--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/upgrade.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/upgrade.lua
@@ -20,7 +20,6 @@ pkg.LIME_SYSUPGRADE_BACKUP_EXTRA_DIR = "/tmp/lime-sysupgrade/preserve"
 pkg.UPGRADE_METADATA_FILE = "/etc/upgrade_metadata"
 
 function pkg.safe_upgrade_confirm_remaining_s()
-    print("safe_upgrade_confirm_remaining_s")
     local remaining_s = tonumber(utils.unsafe_shell("safe-upgrade confirm-remaining"))
     if not remaining_s then
         remaining_s = -1


### PR DESCRIPTION
Fixes the get_upgrade_info ubus endpoint, broken by the intrusion of the print into the json output.