### PR TITLE
Add unittests with coverage to GitHub-CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: tests
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  unittests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: run tests
+        run: ./run_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,3 +18,5 @@ jobs:
 
       - name: run tests
         run: ./run_tests
+      - name: coverage
+        run: bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,6 @@ jobs:
             all_branches: true
             condition: $TRAVIS_BRANCH != master
 
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+#after_success:
+#  - bash <(curl -s https://codecov.io/bash)
 


### PR DESCRIPTION
Also disable coverage in travis.

After this PR is merged we have all the CI functionality, that we had with travis, in github-ci. So I will open another PR after this is merger to disable travis completly.