### PR TITLE
New align screen

### DIFF
--- a/libremesh.sdk.config
+++ b/libremesh.sdk.config
@@ -73,7 +73,6 @@ CONFIG_PACKAGE_ubus-lime-fbw=m
 CONFIG_PACKAGE_ubus-lime-grondrouting=m
 CONFIG_PACKAGE_ubus-lime-location=m
 CONFIG_PACKAGE_ubus-lime-metrics=m
-CONFIG_PACKAGE_ubus-lime-openairview=m
 CONFIG_PACKAGE_ubus-lime-utils=m
 CONFIG_PACKAGE_watchping=m
 CONFIG_PACKAGE_bmx7-auto-gw-mode=m

--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lime-app
-PKG_VERSION:=v0.2.12
+PKG_VERSION:=v0.2.13
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=f54762680ed67360aabc1e671f338f42198861209352ccc9e6c522c75fe7a386
+PKG_HASH:=3ffceeb3f8e08f9023162d737cda71b36d92c2cfcd40b3165d811d08b98c710f
 PKG_SOURCE_URL:=https://github.com/libremesh/lime-app/releases/download/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk

--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lime-app
-PKG_VERSION:=v0.2.13
+PKG_VERSION:=v0.2.15
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=3ffceeb3f8e08f9023162d737cda71b36d92c2cfcd40b3165d811d08b98c710f
+PKG_HASH:=a7dff34069bee261c718b69417da32d3d569c5d277799d73436e3c9306c01fa3
 PKG_SOURCE_URL:=https://github.com/libremesh/lime-app/releases/download/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk

--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lime-app
-PKG_VERSION:=v0.2.10
+PKG_VERSION:=v0.2.12
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=0d1de42ecbe43a959dc912878ae1545cc8b355565d31775e10891fde84a8cf91
+PKG_HASH:=f54762680ed67360aabc1e671f338f42198861209352ccc9e6c522c75fe7a386
 PKG_SOURCE_URL:=https://github.com/libremesh/lime-app/releases/download/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk

--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -18,11 +18,11 @@ include $(INCLUDE_DIR)/package.mk
 define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	TITLE:=LimeApp
-	MAINTAINER:=Marcos Gutierrez <gmarcos@altermundi.net>
+	MAINTAINER:=German Ferrero <germanferrero@altermundi.net>
 	URL:=http://github.com/libremesh/lime-app
 	DEPENDS:=+rpcd +uhttpd +uhttpd-mod-ubus +uhttpd-mod-lua \
 		+ubus-lime-location +ubus-lime-metrics +ubus-lime-utils \
-		+ubus-lime-openairview +ubus-lime-grondrouting
+		+rpcd-mod-iwinfo +ubus-lime-grondrouting
 	PKGARCH:=all
 endef
 

--- a/packages/lime-app/files/usr/share/rpcd/acl.d/iwinfo.json
+++ b/packages/lime-app/files/usr/share/rpcd/acl.d/iwinfo.json
@@ -1,0 +1,14 @@
+{
+	"lime-app": {
+		"read": {
+			"ubus": {
+					"iwinfo": [ "assoclist" ]
+			}
+		},
+		"write": {
+			"ubus": {
+					"iwinfo": [ "assoclist" ]
+			}
+		}
+	}
+}

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -6,7 +6,6 @@ local config = require("lime.config")
 local json = require("luci.jsonc")
 local fs = require("nixio.fs")
 local nixio = require("nixio")
-local shared_state = require("shared-state")
 
 utils.BOARD_JSON_PATH = "/etc/board.json"
 utils.SHADOW_FILENAME = "/etc/shadow"
@@ -456,40 +455,6 @@ function utils.http_client_get(url, timeout_s, out_file)
     else
         return nil
     end
-end
-
-function utils.bathost_deserialize(hostname_plus_iface)
-    local partial_hostname = hostname_plus_iface
-    local iface
-    for _, ifname in ipairs(utils.get_ifnames()) do
-        local serialized_ifname = string.gsub(ifname, "%W", "_")
-        serialized_ifname = utils.literalize(serialized_ifname)
-        local replaced_hostname = hostname_plus_iface:gsub("_"..serialized_ifname, "")
-        -- hostname don't have underscores see utils.is_valid_hostname
-        replaced_hostname = replaced_hostname:gsub("_", "-")
-        if #replaced_hostname < #partial_hostname then
-            partial_hostname = replaced_hostname
-            iface = ifname
-        end
-    end
-    return partial_hostname, iface
-end
-
-function utils.get_bathost(mac, outgoing_iface)
-	local sharedState = shared_state.SharedState:new('bat-hosts')
-	local bathosts = sharedState:get()
-	local bathost = bathosts[mac:lower()]
-	if bathost == nil and outgoing_iface then
-		local ipv6ll = utils.mac2ipv6linklocal(mac) .. "%" .. outgoing_iface
-		sharedState:sync({ ipv6ll })
-		bathosts = sharedState:get()
-		bathost = bathosts[mac:lower()]
-	end
-	if bathost == nil then
-		return
-	end
-	local hostname, iface = utils.bathost_deserialize(bathost.data)
-	return { hostname = hostname, iface = iface }
 end
 
 function utils.release_info()

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -10,7 +10,6 @@ local shared_state = require("shared-state")
 
 utils.BOARD_JSON_PATH = "/etc/board.json"
 utils.SHADOW_FILENAME = "/etc/shadow"
-utils.BATHOSTS_FILENAME = "/etc/bat-hosts"
 utils.KEEP_ON_UPGRADE_FILES_BASE_PATH = '/lib/upgrade/keep.d/'
 
 function utils.log(...)

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -457,6 +457,16 @@ function utils.http_client_get(url, timeout_s, out_file)
     end
 end
 
+function utils.get_hostname(mac, iface)
+	local hostname = utils.unsafe_shell("grep " ..mac.. " /etc/bat-hosts | head -n 1 | cut -d ' ' -f 2"):gsub("\n", "")
+	hostname = hostname:gsub("_" .. iface:gsub("%W", "_"), ""):gsub("_", "-")
+	if hostname == '' then
+		local ipv6ll = utils.mac2ipv6linklocal(mac) .. "%" .. iface
+		hostname = utils.http_client_get("http://[" .. ipv6ll .. "]/cgi-bin/hostname", 10):gsub("\n", "")
+	end
+	return hostname
+end
+
 function utils.release_info()
     local result = {}
     local release_data = utils.read_file("/etc/openwrt_release")

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -490,9 +490,9 @@ function utils.get_bathost(mac, outgoing_iface)
 			line = bathosts:read("*l")
 		end
 	end
-	local valid_out_iface = outgoing_iface and utils.get_ifnames().has_value(outgoing_iface)
-	if hostname == nil and valid_out_iface then
-		local ipv6ll = utils.mac2ipv6linklocal(mac) .. "%" .. outgoing_iface
+	if hostname == nil and outgoing_iface then
+		iface = outgoing_iface
+		local ipv6ll = utils.mac2ipv6linklocal(mac) .. "%" .. iface
 		hostname = utils.http_client_get("http://[" .. ipv6ll .. "]/cgi-bin/hostname", 10)
 	end
 	if not hostname then
@@ -577,15 +577,6 @@ function utils.get_ifnames()
         table.insert(ifnames, ifname)
     end
     return ifnames
-end
-
-function utils.is_valid_mac(string)
-    local string = string:match("%w%w:%w%w:%w%w:%w%w:%w%w:%w%w")
-    if string then
-       return true
-    else
-       return false
-    end
 end
 
 return utils

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -490,9 +490,9 @@ function utils.get_bathost(mac, outgoing_iface)
 			line = bathosts:read("*l")
 		end
 	end
-	if hostname == nil and outgoing_iface then
-		iface = outgoing_iface
-		local ipv6ll = utils.mac2ipv6linklocal(mac) .. "%" .. iface
+	local valid_out_iface = outgoing_iface and utils.get_ifnames().has_value(outgoing_iface)
+	if hostname == nil and valid_out_iface then
+		local ipv6ll = utils.mac2ipv6linklocal(mac) .. "%" .. outgoing_iface
 		hostname = utils.http_client_get("http://[" .. ipv6ll .. "]/cgi-bin/hostname", 10)
 	end
 	if not hostname then
@@ -577,6 +577,15 @@ function utils.get_ifnames()
         table.insert(ifnames, ifname)
     end
     return ifnames
+end
+
+function utils.is_valid_mac(string)
+    local string = string:match("%w%w:%w%w:%w%w:%w%w:%w%w:%w%w")
+    if string then
+       return true
+    else
+       return false
+    end
 end
 
 return utils

--- a/packages/lime-system/tests/test_lime_utils.lua
+++ b/packages/lime-system/tests/test_lime_utils.lua
@@ -1,6 +1,5 @@
 local utils = require 'lime.utils'
 local test_utils = require 'tests.utils'
-local shared_state = require 'shared-state'
 local uci = nil
 
 describe('LiMe Utils tests #limeutils', function()
@@ -283,38 +282,6 @@ DISTRIB_TAINTS='no-all busybox'
         assert.is.same({foo = 'o'}, utils.read_obj_store(testfile))
 
      end)
-
-     it('test get_bathost #bathost', function()
-        shared_state.DATA_DIR = test_utils.setup_test_dir()
-        local sharedState = shared_state.SharedState:new('bat-hosts')
-        sharedState:insert({
-            ["02:95:39:ab:cd:00"] = "LiMe_abcd00_wlan1_mesh",
-            ["52:00:00:ab:cd:a0"] = "LiMe_abcd01_wlan2_mesh_17",
-            ["d6:67:58:8e:cd:92"] = "LiMe_abcd02_wlan0_adhoc_29",
-            ["12:00:00:00:00:00"] = "LiMe_abcd03_wlan1_adhoc"
-        })
-        local ifaces = {'wlan1-mesh', 'wlan2-mesh', 'wlan2-mesh_17', 'wlan0-adhoc_29', 'wlan1-adhoc'}
-        stub(utils, "get_ifnames", function () return ifaces end)
-        assert.is.same({hostname='LiMe-abcd00', iface='wlan1-mesh'}, utils.get_bathost('02:95:39:ab:cd:00'))
-        assert.is.same({hostname='LiMe-abcd01', iface='wlan2-mesh_17'}, utils.get_bathost('52:00:00:ab:cd:a0'))
-        assert.is.same({hostname='LiMe-abcd02', iface='wlan0-adhoc_29'}, utils.get_bathost('d6:67:58:8e:cd:92'))
-        assert.is.same({hostname='LiMe-abcd03', iface='wlan1-adhoc'}, utils.get_bathost('12:00:00:00:00:00'))
-        local ipv6ll = utils.mac2ipv6linklocal('52:00:00:ab:cd:00') .. '%wlan1-mesh'
-        local dataTypeOfSync = nil
-        local urlsOfSync = nil
-        local function syncMock (self, urls)
-            dataTypeOfSync = self.dataType
-            urlsOfSync = urls
-            self:insert({['52:00:00:ab:cd:00'] = "Lime_abcd04_wlan1_mesh"})
-        end
-        stub(shared_state.SharedState, "sync", syncMock)
-        local bathost = utils.get_bathost('52:00:00:ab:cd:00', 'wlan1-mesh')
-        assert.is.same(urlsOfSync, { ipv6ll })
-        assert.is.equal(dataTypeOfSync, 'bat-hosts')
-        assert.is.same({hostname='Lime-abcd04', iface='wlan1-mesh'}, bathost)
-        assert.is_nil(utils.get_bathost('00:aa:bb:cc:dd:00', 'wlan1'))
-        assert.is_nil(utils.get_bathost('00:aa:bb:cc:dd:00'))
-    end)
 
     before_each('', function()
         uci = test_utils.setup_test_uci()

--- a/packages/lime-system/tests/test_lime_utils.lua
+++ b/packages/lime-system/tests/test_lime_utils.lua
@@ -1,7 +1,6 @@
 local utils = require 'lime.utils'
 local test_utils = require 'tests.utils'
 local shared_state = require 'shared-state'
-local match = require 'luassert.match'
 local uci = nil
 
 describe('LiMe Utils tests #limeutils', function()
@@ -302,16 +301,16 @@ DISTRIB_TAINTS='no-all busybox'
         assert.is.same({hostname='LiMe-abcd03', iface='wlan1-adhoc'}, utils.get_bathost('12:00:00:00:00:00'))
         local ipv6ll = utils.mac2ipv6linklocal('52:00:00:ab:cd:00') .. '%wlan1-mesh'
         local dataTypeOfSync = nil
-	local urlsOfSync = nil
-	local function syncMock (self, urls)
-		dataTypeOfSync = self.dataType
-		urlsOfSync = urls
-                self:insert({['52:00:00:ab:cd:00'] = "Lime_abcd04_wlan1_mesh"})
+        local urlsOfSync = nil
+        local function syncMock (self, urls)
+            dataTypeOfSync = self.dataType
+            urlsOfSync = urls
+            self:insert({['52:00:00:ab:cd:00'] = "Lime_abcd04_wlan1_mesh"})
         end
         stub(shared_state.SharedState, "sync", syncMock)
         local bathost = utils.get_bathost('52:00:00:ab:cd:00', 'wlan1-mesh')
-	assert.is.same(urlsOfSync, { ipv6ll })
-	assert.is.equal(dataTypeOfSync, 'bat-hosts')
+        assert.is.same(urlsOfSync, { ipv6ll })
+        assert.is.equal(dataTypeOfSync, 'bat-hosts')
         assert.is.same({hostname='Lime-abcd04', iface='wlan1-mesh'}, bathost)
         assert.is_nil(utils.get_bathost('00:aa:bb:cc:dd:00', 'wlan1'))
         assert.is_nil(utils.get_bathost('00:aa:bb:cc:dd:00'))

--- a/packages/lime-system/tests/test_lime_utils.lua
+++ b/packages/lime-system/tests/test_lime_utils.lua
@@ -1,6 +1,6 @@
 local utils = require 'lime.utils'
 local test_utils = require 'tests.utils'
-
+local shared_state = require 'shared-state'
 local uci = nil
 
 describe('LiMe Utils tests #limeutils', function()
@@ -285,28 +285,28 @@ DISTRIB_TAINTS='no-all busybox'
      end)
 
      it('test get_bathost', function()
-        local TEST_BATHOST_FILENAME = '/tmp/bat-hosts'
-        utils.BATHOSTS_FILENAME = TEST_BATHOST_FILENAME
-        local bathosts_content = [[
-02:95:39:ab:cd:00 LiMe_abcd00_wlan1_mesh
-52:00:00:ab:cd:a0 LiMe_abcd01_wlan2_mesh_17
-d6:67:58:8e:cd:92 LiMe_abcd02_wlan0_adhoc_29
-12:00:00:00:00:00 LiMe_abcd03_wlan1_adhoc
-]]
-        utils.write_file(TEST_BATHOST_FILENAME, bathosts_content)
+        shared_state.DATA_DIR = test_utils.setup_test_dir()
+        local sharedState = shared_state.SharedState:new('bat-hosts')
+        sharedState:insert({
+            ["02:95:39:ab:cd:00"] = "LiMe_abcd00_wlan1_mesh",
+            ["52:00:00:ab:cd:a0"] = "LiMe_abcd01_wlan2_mesh_17",
+            ["d6:67:58:8e:cd:92"] = "LiMe_abcd02_wlan0_adhoc_29",
+            ["12:00:00:00:00:00"] = "LiMe_abcd03_wlan1_adhoc"
+        })
         local ifaces = {'wlan1-mesh', 'wlan2-mesh', 'wlan2-mesh_17', 'wlan0-adhoc_29', 'wlan1-adhoc'}
-        stub(utils, "get_ifnames", function () return ifaces  end)
+        stub(utils, "get_ifnames", function () return ifaces end)
         assert.is.same({hostname='LiMe-abcd00', iface='wlan1-mesh'}, utils.get_bathost('02:95:39:ab:cd:00'))
         assert.is.same({hostname='LiMe-abcd01', iface='wlan2-mesh_17'}, utils.get_bathost('52:00:00:ab:cd:a0'))
         assert.is.same({hostname='LiMe-abcd02', iface='wlan0-adhoc_29'}, utils.get_bathost('d6:67:58:8e:cd:92'))
         assert.is.same({hostname='LiMe-abcd03', iface='wlan1-adhoc'}, utils.get_bathost('12:00:00:00:00:00'))
-        stub(utils, "http_client_get", function (url, timeout) return 'Lime-abcd04' end)
-        local bathost = utils.get_bathost('52:00:00:ab:cd:00', 'wlan1-mesh')
         local ipv6ll = utils.mac2ipv6linklocal('52:00:00:ab:cd:00') .. '%wlan1-mesh'
-        assert.stub(utils.http_client_get).was.called_with('http://[' .. ipv6ll .. ']/cgi-bin/hostname', 10)
+        local function syncMock (self, urls)
+            self:insert({['52:00:00:ab:cd:00'] = "Lime_abcd04_wlan1_mesh"})
+        end
+        stub(shared_state.SharedState, "sync", syncMock)
+        local bathost = utils.get_bathost('52:00:00:ab:cd:00', 'wlan1-mesh')
+        assert.stub(shared_state.SharedState.sync).was.called_with(sharedState, { ipv6ll })
         assert.is.same({hostname='Lime-abcd04', iface='wlan1-mesh'}, bathost)
-
-        stub(utils, "http_client_get", function (url, timeout) return nil end)
         assert.is_nil(utils.get_bathost('00:aa:bb:cc:dd:00', 'wlan1'))
         assert.is_nil(utils.get_bathost('00:aa:bb:cc:dd:00'))
     end)

--- a/packages/lime-system/tests/test_lime_utils.lua
+++ b/packages/lime-system/tests/test_lime_utils.lua
@@ -294,15 +294,21 @@ d6:67:58:8e:cd:92 LiMe_abcd02_wlan0_adhoc_29
 12:00:00:00:00:00 LiMe_abcd03_wlan1_adhoc
 ]]
         utils.write_file(TEST_BATHOST_FILENAME, bathosts_content)
+        local ifaces = {'wlan1-mesh', 'wlan2-mesh', 'wlan2-mesh_17', 'wlan0-adhoc_29', 'wlan1-adhoc'}
+        stub(utils, "get_ifnames", function () return ifaces  end)
         assert.is.same({hostname='LiMe-abcd00', iface='wlan1-mesh'}, utils.get_bathost('02:95:39:ab:cd:00'))
-        assert.is.same({hostname='LiMe-abcd01', iface='wlan2-mesh-17'}, utils.get_bathost('52:00:00:ab:cd:a0'))
-        assert.is.same({hostname='LiMe-abcd02', iface='wlan0-adhoc-29'}, utils.get_bathost('d6:67:58:8e:cd:92'))
+        assert.is.same({hostname='LiMe-abcd01', iface='wlan2-mesh_17'}, utils.get_bathost('52:00:00:ab:cd:a0'))
+        assert.is.same({hostname='LiMe-abcd02', iface='wlan0-adhoc_29'}, utils.get_bathost('d6:67:58:8e:cd:92'))
         assert.is.same({hostname='LiMe-abcd03', iface='wlan1-adhoc'}, utils.get_bathost('12:00:00:00:00:00'))
         stub(utils, "http_client_get", function (url, timeout) return 'Lime-abcd04' end)
         local bathost = utils.get_bathost('52:00:00:ab:cd:00', 'wlan1-mesh')
         local ipv6ll = utils.mac2ipv6linklocal('52:00:00:ab:cd:00') .. '%wlan1-mesh'
         assert.stub(utils.http_client_get).was.called_with('http://[' .. ipv6ll .. ']/cgi-bin/hostname', 10)
-        assert.is.same({hostname = 'Lime-abcd04', iface = nil}, bathost)
+        assert.is.same({hostname='Lime-abcd04', iface='wlan1-mesh'}, bathost)
+
+        stub(utils, "http_client_get", function (url, timeout) return nil end)
+        assert.is_nil(utils.get_bathost('00:aa:bb:cc:dd:00', 'wlan1'))
+        assert.is_nil(utils.get_bathost('00:aa:bb:cc:dd:00'))
     end)
 
     before_each('', function()

--- a/packages/shared-state-bat_hosts/files/usr/lib/lua/bat-hosts.lua
+++ b/packages/shared-state-bat_hosts/files/usr/lib/lua/bat-hosts.lua
@@ -1,0 +1,42 @@
+#!/usr/bin/lua
+
+bat_hosts = {}
+
+local shared_state = require("shared-state")
+local utils = require("lime.utils")
+
+function bat_hosts.bathost_deserialize(hostname_plus_iface)
+    local partial_hostname = hostname_plus_iface
+    local iface
+    for _, ifname in ipairs(utils.get_ifnames()) do
+        local serialized_ifname = string.gsub(ifname, "%W", "_")
+        serialized_ifname = utils.literalize(serialized_ifname)
+        local replaced_hostname = hostname_plus_iface:gsub("_"..serialized_ifname, "")
+        -- hostname don't have underscores see utils.is_valid_hostname
+        replaced_hostname = replaced_hostname:gsub("_", "-")
+        if #replaced_hostname < #partial_hostname then
+            partial_hostname = replaced_hostname
+            iface = ifname
+        end
+    end
+    return partial_hostname, iface
+end
+
+function bat_hosts.get_bathost(mac, outgoing_iface)
+	local sharedState = shared_state.SharedState:new('bat-hosts')
+	local bathosts = sharedState:get()
+	local bathost = bathosts[mac:lower()]
+	if bathost == nil and outgoing_iface then
+		local ipv6ll = utils.mac2ipv6linklocal(mac) .. "%" .. outgoing_iface
+		sharedState:sync({ ipv6ll })
+		bathosts = sharedState:get()
+		bathost = bathosts[mac:lower()]
+	end
+	if bathost == nil then
+		return
+	end
+	local hostname, iface = bat_hosts.bathost_deserialize(bathost.data)
+	return { hostname = hostname, iface = iface }
+end
+
+return bat_hosts

--- a/packages/shared-state-bat_hosts/files/usr/lib/lua/bat-hosts.lua
+++ b/packages/shared-state-bat_hosts/files/usr/lib/lua/bat-hosts.lua
@@ -1,9 +1,7 @@
-#!/usr/bin/lua
-
-bat_hosts = {}
-
 local shared_state = require("shared-state")
 local utils = require("lime.utils")
+
+local bat_hosts = {}
 
 function bat_hosts.bathost_deserialize(hostname_plus_iface)
     local partial_hostname = hostname_plus_iface

--- a/packages/shared-state-bat_hosts/files/usr/libexec/rpcd/bat-hosts
+++ b/packages/shared-state-bat_hosts/files/usr/libexec/rpcd/bat-hosts
@@ -21,6 +21,11 @@ local function get_bathost(msg)
       utils.printJson({ status = "error", message = "invalid mac" })
       return
     end
+
+    if msg.outgoing_iface and not utils.has_value(utils.get_ifnames(), msg.outgoing_iface) then
+      utils.printJson({ status = "error", message = "invalid outgoing interface" })
+      return
+    end
     local bathost = bat_hosts.get_bathost(msg.mac, msg.outgoing_iface)
     local result = {}
     if bathost.hostname ~= nil then

--- a/packages/shared-state-bat_hosts/files/usr/libexec/rpcd/bat-hosts
+++ b/packages/shared-state-bat_hosts/files/usr/libexec/rpcd/bat-hosts
@@ -1,0 +1,50 @@
+#!/usr/bin/env lua
+--[[
+  Copyright (C) 2013-2020 LibreMesh.org
+  This is free software, licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+
+  Copyright 2020 German Ferrero <germanferrero@altermundi.net>
+]]--
+
+local ubus = require "ubus"
+local json = require 'luci.jsonc'
+local utils = require 'lime.utils'
+local bat_hosts = require 'bat-hosts'
+
+local conn = ubus.connect()
+if not conn then
+    error("Failed to connect to ubus")
+end
+
+local function get_bathost(msg)
+    if not msg.mac or not utils.is_valid_mac(msg.mac) then
+      utils.printJson({ status = "error", message = "invalid mac" })
+      return
+    end
+    local bathost = bat_hosts.get_bathost(msg.mac, msg.outgoing_iface)
+    local result = {}
+    if bathost.hostname ~= nil then
+      result.status = "ok"
+      result.bathost = bathost
+    else
+      result.status = "error"
+      result.error = "Couldn't retrieve hostname"
+    end
+    utils.printJson(result)
+end
+
+local methods = {
+    get_bathost = { mac = 'value', outgoing_iface = 'value'}
+}
+
+if arg[1] == 'list' then
+    utils.printJson(methods)
+end
+
+if arg[1] == 'call' then
+    local msg = utils.rpcd_readline() or '{}'
+    msg = json.parse(msg)
+    if  arg[2] == 'get_bathost' then get_bathost(msg)
+    else utils.printJson({ error = "Method not found" })
+    end
+end

--- a/packages/shared-state-bat_hosts/files/usr/share/acl.d/bat-hosts.json
+++ b/packages/shared-state-bat_hosts/files/usr/share/acl.d/bat-hosts.json
@@ -1,0 +1,15 @@
+{
+    "lime-app": {
+        "description": "lime-app public access",
+        "read": {
+            "ubus": {
+                    "bat-hosts": [ "*" ]
+            }
+        },
+        "write": {
+            "ubus": {
+                    "bat-hosts": [ "*" ]
+            }
+        }
+    }
+}

--- a/packages/shared-state-bat_hosts/tests/test_bat_hosts.lua
+++ b/packages/shared-state-bat_hosts/tests/test_bat_hosts.lua
@@ -1,0 +1,36 @@
+local bat_hosts = require('bat-hosts')
+local utils = require('lime.utils')
+local test_utils = require('tests.utils')
+local shared_state = require('shared-state')
+
+it('test get_bathost #bathost', function()
+    shared_state.DATA_DIR = test_utils.setup_test_dir()
+    local sharedState = shared_state.SharedState:new('bat-hosts')
+    sharedState:insert({
+        ["02:95:39:ab:cd:00"] = "LiMe_abcd00_wlan1_mesh",
+        ["52:00:00:ab:cd:a0"] = "LiMe_abcd01_wlan2_mesh_17",
+        ["d6:67:58:8e:cd:92"] = "LiMe_abcd02_wlan0_adhoc_29",
+        ["12:00:00:00:00:00"] = "LiMe_abcd03_wlan1_adhoc"
+    })
+    local ifaces = {'wlan1-mesh', 'wlan2-mesh', 'wlan2-mesh_17', 'wlan0-adhoc_29', 'wlan1-adhoc'}
+    stub(utils, "get_ifnames", function () return ifaces end)
+    assert.is.same({hostname='LiMe-abcd00', iface='wlan1-mesh'}, bat_hosts.get_bathost('02:95:39:ab:cd:00'))
+    assert.is.same({hostname='LiMe-abcd01', iface='wlan2-mesh_17'}, bat_hosts.get_bathost('52:00:00:ab:cd:a0'))
+    assert.is.same({hostname='LiMe-abcd02', iface='wlan0-adhoc_29'}, bat_hosts.get_bathost('d6:67:58:8e:cd:92'))
+    assert.is.same({hostname='LiMe-abcd03', iface='wlan1-adhoc'}, bat_hosts.get_bathost('12:00:00:00:00:00'))
+    local ipv6ll = utils.mac2ipv6linklocal('52:00:00:ab:cd:00') .. '%wlan1-mesh'
+    local dataTypeOfSync = nil
+    local urlsOfSync = nil
+    local function syncMock (self, urls)
+        dataTypeOfSync = self.dataType
+        urlsOfSync = urls
+        self:insert({['52:00:00:ab:cd:00'] = "Lime_abcd04_wlan1_mesh"})
+    end
+    stub(shared_state.SharedState, "sync", syncMock)
+    local bathost = bat_hosts.get_bathost('52:00:00:ab:cd:00', 'wlan1-mesh')
+    assert.is.same(urlsOfSync, { ipv6ll })
+    assert.is.equal(dataTypeOfSync, 'bat-hosts')
+    assert.is.same({hostname='Lime-abcd04', iface='wlan1-mesh'}, bathost)
+    assert.is_nil(bat_hosts.get_bathost('00:aa:bb:cc:dd:00', 'wlan1'))
+    assert.is_nil(bat_hosts.get_bathost('00:aa:bb:cc:dd:00'))
+end)

--- a/packages/shared-state-bat_hosts/tests/test_ubus_bat_hosts.lua
+++ b/packages/shared-state-bat_hosts/tests/test_ubus_bat_hosts.lua
@@ -1,0 +1,22 @@
+local bat_hosts = require "bat-hosts"
+local test_utils = require "tests.utils"
+
+local test_file_name = "packages/shared-state-bat_hosts/files/usr/libexec/rpcd/bat-hosts"
+local ubus_bat_hosts = test_utils.load_lua_file_as_function(test_file_name)
+
+local rpcd_call = test_utils.rpcd_call
+
+describe('ubus-bat-hosts tests #ubusbathosts', function()
+    it('test get_bathost', function()
+        stub(bat_hosts, "get_bathost",
+            function() return { hostname = 'lime', iface = 'wlan1-mesh' } end
+        )
+        local response  = rpcd_call(ubus_bat_hosts, {'call', 'get_bathost'}, '{}')
+        assert.is.equal("error", response.status)
+        assert.is.equal("invalid mac", response.message)
+        local response  = rpcd_call(ubus_bat_hosts, 
+            {'call', 'get_bathost'}, '{"mac":"02:95:39:ab:cd:00"}')
+        assert.is.equal("ok", response.status)
+        assert.is.same({ hostname = 'lime', iface = 'wlan1-mesh' }, response.bathost)
+    end)
+end)

--- a/packages/shared-state-bat_hosts/tests/test_ubus_bat_hosts.lua
+++ b/packages/shared-state-bat_hosts/tests/test_ubus_bat_hosts.lua
@@ -14,8 +14,20 @@ describe('ubus-bat-hosts tests #ubusbathosts', function()
         local response  = rpcd_call(ubus_bat_hosts, {'call', 'get_bathost'}, '{}')
         assert.is.equal("error", response.status)
         assert.is.equal("invalid mac", response.message)
-        local response  = rpcd_call(ubus_bat_hosts, 
+        local response  = rpcd_call(ubus_bat_hosts,
             {'call', 'get_bathost'}, '{"mac":"02:95:39:ab:cd:00"}')
+        assert.is.equal("ok", response.status)
+        assert.is.same({ hostname = 'lime', iface = 'wlan1-mesh' }, response.bathost)
+
+
+        stub(utils, "get_ifnames", function() return {'wlan1-mesh'} end)
+        local response  = rpcd_call(ubus_bat_hosts,
+            {'call', 'get_bathost'}, '{"mac":"02:95:39:ab:cd:00", "outgoing_iface":"foo"}')
+        assert.is.equal("error", response.status)
+        assert.is.equal("invalid outgoing interface", response.message)
+
+        local response  = rpcd_call(ubus_bat_hosts,
+            {'call', 'get_bathost'}, '{"mac":"02:95:39:ab:cd:00", "outgoing_iface":"wlan1-mesh"}')
         assert.is.equal("ok", response.status)
         assert.is.same({ hostname = 'lime', iface = 'wlan1-mesh' }, response.bathost)
     end)

--- a/packages/ubus-lime-openairview/Readme.md
+++ b/packages/ubus-lime-openairview/Readme.md
@@ -2,10 +2,6 @@
 
 | Path             | Procedure          | Signature                          | Description                                                                                                                                |
 | ---------------- | ------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| lime-openairview | get_interfaces     | {}                                 | Get list of adhoc interfaces                                                                                                               |
-| lime-openairview | get_stations       | {device:STRING}                    | List of stations transmitting on the same frequency as the selected device/interface.                                                      |
-| lime-openairview | get_iface_stations | {iface:STRING}                     | List of stations attached to the interface.                                                                                                |
-| lime-openairview | get_station_signal | {station_mac:STRING, iface:STRING} | Get the signal level with which an interface sees a particular device                                                                      |
 | lime-openairview | spectral_scan      | {device:STRING, spectrum:STRING}   | Get the fft-eval scan results. specturm can by: 2ghz, 5ghz or current. "current" means scan only the channel on which the interface is set. This will work only if fft-eval is installed |
 
 ## Examples
@@ -16,46 +12,5 @@ If the openairview was never established, return the openairview of the communit
 
 ```
 'lime-openairview' @4bd5f4f5
-	"get_interfaces":{"no_params":"Integer"}
- "get_stations":{"device":"String"}
-	"get_iface_stations":{"iface":"String"}
-	"get_station_signal":{"station_mac":"String","iface":"String"}
 	"spectral_scan":{"device":"String","spectrum":"String"}
-```
-
-### ubus call lime-openairview get_interfaces
-
-```json
-{
-  "interfaces": ["wlan1-adhoc", "wlan0-adhoc"]
-}
-```
-
-### ubus call lime-openairview get_stations '{"device":"wlan1-adhoc"}'
-
-```json
-{
-  "stations": [
-    {
-      "station_mac": "A0:F3:C1:86:31:35",
-      "station_hostname": "herradura_wlan1-adhoc",
-      "attributes": {
-        "inactive": 16870,
-        "channel": 112,
-        "signal": "-82"
-      },
-      "link_type": "wifi"
-    },
-    {
-      "station_mac": "A0:F3:C1:86:32:11",
-      "station_hostname": "marisa_wlan1-adhoc",
-      "attributes": {
-        "inactive": 10,
-        "channel": 112,
-        "signal": "-74"
-      },
-      "link_type": "wifi"
-    }
-  ]
-}
 ```

--- a/packages/ubus-lime-openairview/files/usr/libexec/rpcd/lime-openairview
+++ b/packages/ubus-lime-openairview/files/usr/libexec/rpcd/lime-openairview
@@ -29,7 +29,7 @@ local function spectral_scan(msg)
         return
     end
 
-	local device = msg.device
+	local device = utils.shell_quote(msg.device)
 	local spectrum = msg.spectrum
 
 	local result = {
@@ -78,7 +78,7 @@ function sample_current_channel(path_ath9k)
     nixio.fs.writefile(path_ath9k .. "spectral_scan_ctl", "manual")
     nixio.fs.writefile(path_ath9k .. "spectral_scan_ctl", "trigger")
 	print("fft_eval " .. path_ath9k .. "spectral_scan0")
-    local samples = utils.unsafe_shell("fft_eval " .. path_ath9k .. "spectral_scan0")
+    local samples = utils.unsafe_shell(utils.shell_quote("fft_eval " .. path_ath9k .. "spectral_scan0"))
     nixio.fs.writefile(path_ath9k .. "spectral_scan_ctl", "disable")
 
     return samples

--- a/packages/ubus-lime-openairview/files/usr/libexec/rpcd/lime-openairview
+++ b/packages/ubus-lime-openairview/files/usr/libexec/rpcd/lime-openairview
@@ -9,7 +9,6 @@ You may obtain a copy of the License at
 
 require "ubus"
 local nixio = require "nixio",require "nixio.fs"
-local iwinfo = require("iwinfo")
 local json = require 'luci.jsonc'
 local utils = require("lime.utils")
 
@@ -17,109 +16,10 @@ local function printJson (obj)
     print(json.stringify(obj))
 end
 
-local function shell(command)
-    -- TODO(nicoechaniz): sanitize or evaluate if this is a security risk
-    local handle = io.popen(command)
-    local result = handle:read("*a")
-    handle:close()
-    return result
-end
-
-local function file_exists(file)
-    -- check if the file exists
-    local f = io.open(file, "rb")
-    if f then f:close() end
-    return f ~= nil
-end
-
-local function list_from_file(file)
-    -- get all lines from a file with one value per line and return a list type table
-    -- return an empty table if the file does not exist
-    if not file_exists(file) then return {} end
-    local list = {}
-    for line in io.lines(file) do
-        table.insert(list, line)
-    end
-    return list
-end	
-
-local function dict_from_file(file)
-    -- get all lines from a file with two values per line and return a dict type table
-    -- return an empty table if the file does not exist
-    if not file_exists(file) then return {} end
-    dict = {}
-    for line in io.lines(file) do
-        words = {}
-        for w in line:gmatch("%S+") do table.insert(words, w) end
-        if #words == 2 and type(words[1]) == "string" then
-            dict[string.lower(words[1])] = words[2]
-        end
-    end
-    return dict
-end
 
 local conn = ubus.connect()
 if not conn then
     error("Failed to connect to ubus")
-end
-
-function get_stations(msg)
-	local function lines(str)
-		-- split a string into lines separated by line endings
-		local t = {}
-		local function helper(line) table.insert(t, line) return "" end
-		helper((str:gsub("(.-)\r?\n", helper)))
-		return t
-	end
-
-	local function file_exists(file)
-		-- check if the file exists
-		local f = io.open(file, "rb")
-		if f then f:close() end
-		return f ~= nil
-	end
-
-	local function network_links(iface)
-		local result = {}
-		result.stations = {}
-		local channel = iwinfo.nl80211.channel(iface)
-		local assoclist = iwinfo.nl80211.assoclist(iface)
-		local bat_hosts = dict_from_file("/etc/bat-hosts")
-		for station_mac, link_data in pairs(assoclist) do
-			local wifilink = {
-				link_type = "wifi",
-				station_mac = station_mac,
-				hostname = station_hostname,
-				station_hostname = bat_hosts[string.lower(station_mac)] or station_mac,
-				attributes = { signal = tostring(link_data.signal),
-							channel = channel, inactive= link_data.inactive }
-			}
-			table.insert(result.stations, wifilink)
-		end
-		return result
-	end
-
-	local net_links = {
-		stations = network_links(msg.device).stations
-	}
-
-	printJson(net_links)
-end
-
-function get_interfaces(msg)
-	local dev
-	local devices = conn:call("uci", "get", { config="wireless", type="wifi-iface"})
-	local result = {}
-	local interfaces = {}
-    if devices ~= nil then
-        for iface,iface_conf in pairs(devices.values) do
-            if iface_conf.mode == "adhoc" or iface_conf.mode == "mesh" then
-                table.insert(interfaces, { name = iface_conf.ifname, mode = iface_conf.mode })
-            end
-        end
-    end
-    result.interfaces = interfaces
-	printJson(result)
 end
 
 local function spectral_scan(msg)
@@ -178,7 +78,7 @@ function sample_current_channel(path_ath9k)
     nixio.fs.writefile(path_ath9k .. "spectral_scan_ctl", "manual")
     nixio.fs.writefile(path_ath9k .. "spectral_scan_ctl", "trigger")
 	print("fft_eval " .. path_ath9k .. "spectral_scan0")
-    local samples = shell("fft_eval " .. path_ath9k .. "spectral_scan0")
+    local samples = utils.unsafe_shell("fft_eval " .. path_ath9k .. "spectral_scan0")
     nixio.fs.writefile(path_ath9k .. "spectral_scan_ctl", "disable")
 
     return samples
@@ -195,54 +95,16 @@ function sample_whole_spectrum(device, path_ath9k, freqs)
 
     local cmd = "iw dev " .. device .. " scan"
     if #freqs > 0 then cmd = cmd .. " freq " .. table.concat(freqs, " ") end
-    shell(cmd)
+    utils.unsafe_shell(cmd)
 
     nixio.fs.writefile(path_ath9k .. "spectral_scan_ctl", "disable")
-    local samples = shell("fft_eval " .. path_ath9k .. "spectral_scan0")
+    local samples = utils.unsafe_shell("fft_eval " .. path_ath9k .. "spectral_scan0")
 
     return samples
 end
 
-local function get_station_signal(msg)
-    local iface = msg.iface
-    local mac = msg.station_mac
-    local result = {}
-    local assoclist = iwinfo.nl80211.assoclist(iface)
-    result.station = mac
-    result.signal = tostring(assoclist[mac].signal)
-    result.status = "ok"
-    printJson(result)
-end
-
-local function get_iface_stations(msg)
-    local iface = msg.iface
-    local result = {}
-    local stations = {}
-    local assoclist = iwinfo.nl80211.assoclist(iface)
-    local bat_hosts = dict_from_file("/etc/bat-hosts")
-    for mac, link_data in pairs(assoclist) do
-        local hostname = bat_hosts[string.lower(mac)] or mac
-        local station_data = {
-            hostname = hostname,
-            mac = mac,
-            signal = tostring(link_data.signal),
-            iface = iface,
-            rx_packets = link_data.rx_packets,
-            tx_packets = link_data.tx_packets,
-        }
-        table.insert(stations, station_data)
-    end
-    result.stations = stations
-    result.status = "ok"
-    printJson(result)
-end
-
 local methods = {
-	get_stations = { device = 'value' },
-	get_interfaces = { no_params = 0 },
-	spectral_scan = { device = 'value', spectrum = 'value' },
-	get_station_signal = { iface = 'value', station_mac = 'value' },
-	get_iface_stations = { iface = 'value' }
+	spectral_scan = { device = 'value', spectrum = 'value' }
 }
 
 if arg[1] == 'list' then
@@ -252,11 +114,7 @@ end
 if arg[1] == 'call' then
     local msg = io.read()
     msg = json.parse(msg)
-    if       arg[2] == 'get_stations'           then get_stations(msg)
-    elseif   arg[2] == 'get_interfaces'         then get_interfaces(msg)
-    elseif   arg[2] == 'spectral_scan'          then spectral_scan(msg)
-    elseif   arg[2] == 'get_station_signal'     then get_station_signal(msg)
-    elseif   arg[2] == 'get_iface_stations'     then get_iface_stations(msg)
+    if   arg[2] == 'spectral_scan'          then spectral_scan(msg)
     else      printJson({ error = "Method not found" })
     end
 end

--- a/packages/ubus-lime-utils/Makefile
+++ b/packages/ubus-lime-utils/Makefile
@@ -13,7 +13,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Santiago Piccinini <spiccinini@altermundi.net>
   SUBMENU:=3. Applications
   TITLE:=LIbremesh ubus utils module
-  DEPENDS:= +lua +libubox-lua +libubus-lua +libuci-lua +lime-system +cgi-io +rpcd-mod-file
+  DEPENDS:= +lua +libubox-lua +libubus-lua +libuci +lime-system +libiwinfo-lua +cgi-io +rpcd-mod-file
   PKGARCH:=all
 endef
 

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
@@ -35,8 +35,10 @@ local function get_cloud_nodes(msg)
 end
 
 local function get_bathost(msg)
-    mac = utils.shell_quote(msg.mac)
-    iface = utils.shell_quote(msg.outgoing_iface)
+    if not utils.is_valid_mac(msg.mac) then
+      utils.printJson({ status = "error", message = "invalid mac" })
+      return
+    end
     local bathost = utils.get_bathost(msg.mac, msg.outgoing_iface)
     local result = {}
     if bathost.hostname ~= nil then

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
@@ -35,9 +35,8 @@ local function get_cloud_nodes(msg)
 end
 
 local function get_bathost(msg)
-    if not utils.is_valid_mac(msg.mac) then
-      utils.printJson({status = "error", message = "invalid mac"})
-      return
+    mac = utils.shell_quote(msg.mac)
+    iface = utils.shell_quote(msg.outgoing_iface)
     local bathost = utils.get_bathost(msg.mac, msg.outgoing_iface)
     local result = {}
     if bathost.hostname ~= nil then
@@ -45,7 +44,7 @@ local function get_bathost(msg)
       result.bathost = bathost
     else
       result.status = "error"
-      result.message = "Couldn't retrieve hostname"
+      result.error = "Couldn't retrieve hostname"
     end
     utils.printJson(result)
 end

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
@@ -34,6 +34,21 @@ local function get_cloud_nodes(msg)
     return
 end
 
+local function get_hostname(msg)
+    mac = utils.shell_quote(msg.mac)
+    iface = utils.shell_quote(msg.iface)
+    local hostname = utils.get_hostname(msg.mac, msg.iface)
+    local result = {}
+    if hostname ~= nil then
+      result.status = "ok"
+      result.hostname = hostname
+    else
+      result.status = "error"
+      result.error = "Couldn't retrieve hostname"
+    end
+    utils.printJson(result)
+end
+
 local function get_station_traffic(params)
     local iface = params.iface
     local mac = params.station_mac
@@ -247,6 +262,7 @@ end
 
 local methods = {
     get_cloud_nodes = { no_params = 0 },
+    get_hostname = { mac = 'value', iface = 'value'},
     get_mesh_ifaces = { no_params = 0 },
     get_node_status = { no_params = 0 },
     get_notes = { no_params = 0},
@@ -265,6 +281,7 @@ if arg[1] == 'call' then
     local msg = utils.rpcd_readline()
     msg = json.parse(msg)
     if      arg[2] == 'get_cloud_nodes' then get_cloud_nodes(msg)
+    elseif  arg[2] == 'get_hostname' then get_hostname(msg)
     elseif  arg[2] == 'get_mesh_ifaces' then get_mesh_ifaces(msg)
     elseif  arg[2] == 'get_node_status' then get_node_status(msg)
     elseif  arg[2] == 'get_notes' then get_notes(msg)

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
@@ -34,14 +34,14 @@ local function get_cloud_nodes(msg)
     return
 end
 
-local function get_hostname(msg)
+local function get_bathost(msg)
     mac = utils.shell_quote(msg.mac)
-    iface = utils.shell_quote(msg.iface)
-    local hostname = utils.get_hostname(msg.mac, msg.iface)
+    iface = utils.shell_quote(msg.outgoing_iface)
+    local bathost = utils.get_bathost(msg.mac, msg.outgoing_iface)
     local result = {}
-    if hostname ~= nil then
+    if bathost.hostname ~= nil then
       result.status = "ok"
-      result.hostname = hostname
+      result.bathost = bathost
     else
       result.status = "error"
       result.error = "Couldn't retrieve hostname"
@@ -66,7 +66,8 @@ local function get_station_traffic(params)
 end
 
 local function get_mesh_ifaces(msg)
-    local result = limewireless.mesh_ifaces()
+    local result = {}
+    result.ifaces = limewireless.mesh_ifaces()
     utils.printJson(result)
 end
 
@@ -91,8 +92,9 @@ local function get_node_status(msg)
     for _, iface  in ipairs(ifaces) do
         iface_stations = iwinfo[iwinfo.type(iface)].assoclist(iface)
         if iface_stations then
-            for _, station in pairs(iface_stations) do
+            for mac, station in pairs(iface_stations) do
                 station['iface'] = iface
+                station.station_mac = mac
                 table.insert(stations, station)
             end
         end
@@ -262,7 +264,7 @@ end
 
 local methods = {
     get_cloud_nodes = { no_params = 0 },
-    get_hostname = { mac = 'value', iface = 'value'},
+    get_bathost = { mac = 'value', outgoing_iface = 'value'},
     get_mesh_ifaces = { no_params = 0 },
     get_node_status = { no_params = 0 },
     get_notes = { no_params = 0},
@@ -281,7 +283,7 @@ if arg[1] == 'call' then
     local msg = utils.rpcd_readline()
     msg = json.parse(msg)
     if      arg[2] == 'get_cloud_nodes' then get_cloud_nodes(msg)
-    elseif  arg[2] == 'get_hostname' then get_hostname(msg)
+    elseif  arg[2] == 'get_bathost' then get_bathost(msg)
     elseif  arg[2] == 'get_mesh_ifaces' then get_mesh_ifaces(msg)
     elseif  arg[2] == 'get_node_status' then get_node_status(msg)
     elseif  arg[2] == 'get_notes' then get_notes(msg)

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
@@ -35,8 +35,9 @@ local function get_cloud_nodes(msg)
 end
 
 local function get_bathost(msg)
-    mac = utils.shell_quote(msg.mac)
-    iface = utils.shell_quote(msg.outgoing_iface)
+    if not utils.is_valid_mac(msg.mac) then
+      utils.printJson({status = "error", message = "invalid mac"})
+      return
     local bathost = utils.get_bathost(msg.mac, msg.outgoing_iface)
     local result = {}
     if bathost.hostname ~= nil then
@@ -44,7 +45,7 @@ local function get_bathost(msg)
       result.bathost = bathost
     else
       result.status = "error"
-      result.error = "Couldn't retrieve hostname"
+      result.message = "Couldn't retrieve hostname"
     end
     utils.printJson(result)
 end

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
@@ -75,7 +75,8 @@ local function get_node_status(msg)
     local ifaces = limewireless.mesh_ifaces()
     local stations = {}
     for _, iface  in ipairs(ifaces) do
-        iface_stations = iwinfo[iwinfo.type(iface)].assoclist(iface)
+        iface_type = iwinfo.type(iface)
+        iface_stations = iface_type and iwinfo[iface_type].assoclist(iface)
         if iface_stations then
             for mac, station in pairs(iface_stations) do
                 station['iface'] = iface

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
@@ -11,6 +11,7 @@
 local ubus = require "ubus"
 local json = require 'luci.jsonc'
 local limewireless = require 'lime.wireless'
+local iwinfo = require 'iwinfo'
 local utils = require 'lime.utils'
 local upgrade = require 'lime.upgrade'
 
@@ -49,6 +50,11 @@ local function get_station_traffic(params)
     return result
 end
 
+local function get_mesh_ifaces(msg)
+    local result = limewireless.mesh_ifaces()
+    utils.printJson(result)
+end
+
 local function get_node_status(msg)
     local result = {}
     result.hostname = io.input("/proc/sys/kernel/hostname"):read("*line")
@@ -68,7 +74,7 @@ local function get_node_status(msg)
     local ifaces = limewireless.mesh_ifaces()
     local stations = {}
     for _, iface  in ipairs(ifaces) do
-        iface_stations = conn:call("lime-openairview", "get_stations", {device = iface}).stations
+        iface_stations = iwinfo[iwinfo.type(iface)].assoclist(iface)
         if iface_stations then
             for _, station in pairs(iface_stations) do
                 station['iface'] = iface
@@ -241,6 +247,7 @@ end
 
 local methods = {
     get_cloud_nodes = { no_params = 0 },
+    get_mesh_ifaces = { no_params = 0 },
     get_node_status = { no_params = 0 },
     get_notes = { no_params = 0},
     set_notes = { text = 'value' },
@@ -258,6 +265,7 @@ if arg[1] == 'call' then
     local msg = utils.rpcd_readline()
     msg = json.parse(msg)
     if      arg[2] == 'get_cloud_nodes' then get_cloud_nodes(msg)
+    elseif  arg[2] == 'get_mesh_ifaces' then get_mesh_ifaces(msg)
     elseif  arg[2] == 'get_node_status' then get_node_status(msg)
     elseif  arg[2] == 'get_notes' then get_notes(msg)
     elseif  arg[2] == 'set_notes' then set_notes(msg)

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils
@@ -34,23 +34,6 @@ local function get_cloud_nodes(msg)
     return
 end
 
-local function get_bathost(msg)
-    if not utils.is_valid_mac(msg.mac) then
-      utils.printJson({ status = "error", message = "invalid mac" })
-      return
-    end
-    local bathost = utils.get_bathost(msg.mac, msg.outgoing_iface)
-    local result = {}
-    if bathost.hostname ~= nil then
-      result.status = "ok"
-      result.bathost = bathost
-    else
-      result.status = "error"
-      result.error = "Couldn't retrieve hostname"
-    end
-    utils.printJson(result)
-end
-
 local function get_station_traffic(params)
     local iface = params.iface
     local mac = params.station_mac
@@ -266,7 +249,6 @@ end
 
 local methods = {
     get_cloud_nodes = { no_params = 0 },
-    get_bathost = { mac = 'value', outgoing_iface = 'value'},
     get_mesh_ifaces = { no_params = 0 },
     get_node_status = { no_params = 0 },
     get_notes = { no_params = 0},
@@ -285,7 +267,6 @@ if arg[1] == 'call' then
     local msg = utils.rpcd_readline()
     msg = json.parse(msg)
     if      arg[2] == 'get_cloud_nodes' then get_cloud_nodes(msg)
-    elseif  arg[2] == 'get_bathost' then get_bathost(msg)
     elseif  arg[2] == 'get_mesh_ifaces' then get_mesh_ifaces(msg)
     elseif  arg[2] == 'get_node_status' then get_node_status(msg)
     elseif  arg[2] == 'get_notes' then get_notes(msg)


### PR DESCRIPTION
This PR introduces the v0.2.15 of the LimeApp, We have skipped v0.2.11 through v0.2.14 so all the new changes are:

firmware upgrade: add one click firmware upgrade
firstbootwizard: add do not ask again option to fbw banner
align: New align screen
remotesupport: Add support for handling and joining tmate sessions.

for more info checkout the [changelog](https://github.com/libremesh/lime-app/blob/develop/CHANGELOG.md)

The new align screen uses rpcd-mod-iwinfo ubus endpoints instead of lime-openairview.
All the functionality of lime-openairview except of spectral scan is removed. Which breaks compatibility with prior lime-app versions. That's why this PR includes changes + release bump altogether.