### PR TITLE
fbw: add optional country config

### DIFF
--- a/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
+++ b/packages/first-boot-wizard/files/usr/lib/lua/firstbootwizard.lua
@@ -278,13 +278,16 @@ function fbw.read_configs()
 end
 
 -- Apply configuration for a new network ( used in ubus daemon)
-function fbw.create_network(ssid, hostname, password)
+function fbw.create_network(ssid, hostname, password, country)
     fbw.log('apply_file_config(ssid=' .. ssid .. ', hostname=' .. hostname .. ')')
     local uci_cursor = config.get_uci_cursor()
 
     -- Save changes in lime-community
     if password ~= nil and password ~= '' then
         lutils.set_shared_root_password(password)
+    end
+    if country then
+        uci_cursor:set("lime-community", 'wifi', 'country', country)
     end
     uci_cursor:set("lime-community", 'wifi', 'ap_ssid', ssid)
     uci_cursor:set("lime-community", 'wifi', 'apname_ssid', ssid..'/%H')

--- a/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
+++ b/packages/ubus-lime-fbw/files/usr/libexec/daemon/lime-fbw
@@ -69,12 +69,13 @@ local methods = {
             function(req, msg)
                 if (msg.network ~= nil and msg.hostname ~= nil) then
                     conn:reply(req, { status = 'done' })
-                    fbw.create_network(msg.network, msg.hostname, msg.adminPassword)
+                    fbw.create_network(msg.network, msg.hostname, msg.adminPassword, msg.country)
                     return
                 else
                     conn:reply(req, { status = 'error', msg = "Network and hostname are required" })
                 end
-            end, { network = ubus.STRING, hostname = ubus.STRING, password = ubus.STRING }
+            end, { network = ubus.STRING, hostname = ubus.STRING, password = ubus.STRING,
+                   country = ubus.STRING }
         },
         dismiss = {
             function (req, msg)


### PR DESCRIPTION
This change adds the ability to configure the country (for the wireless config) at network creation in the First Boot Wizard.
This needs to be exposed in the lime-app to be useful.