### PR TITLE
fbw: support community lime-assets

### DIFF
--- a/packages/first-boot-wizard/files/www/cgi-bin/lime/lime-community-assets
+++ b/packages/first-boot-wizard/files/www/cgi-bin/lime/lime-community-assets
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo 'Content-Type: application/x-tar'
+echo 'Content-Disposition: attachment; filename="lime-community-assets.tar.gz"'
+echo
+
+tar czf - -C /etc/lime-assets/ community/ 2>/dev/null


### PR DESCRIPTION
The lime-assets are documented here https://libremesh.org/docs/en_config.html#lime-assets
This PR only adds the lime-assets support to fbw.

The lime-assets of level community are shared as a tar.gz and fetched as part of the first boot wizard config step.

Fixes #846 