### PR TITLE
Fix shared state location publisher

### DIFF
--- a/packages/shared-state-nodes_and_links/files/usr/bin/shared-state-publish_nodes_and_links
+++ b/packages/shared-state-nodes_and_links/files/usr/bin/shared-state-publish_nodes_and_links
@@ -18,5 +18,7 @@
 local JSON = require("luci.jsonc")
 local location = require("lime.location")
 
-io.popen("shared-state insert nodes_and_links", "w"):write(JSON.stringify(location.nodes_and_links()))
+local hostname = io.input("/proc/sys/kernel/hostname"):read("*line")
+local result = { [hostname] = location.nodes_and_links() }
+io.popen("shared-state insert nodes_and_links", "w"):write(JSON.stringify(result))
 

--- a/packages/ubus-lime-location/tests/test_lime_location.lua
+++ b/packages/ubus-lime-location/tests/test_lime_location.lua
@@ -134,7 +134,6 @@ describe('ubus-lime-utils tests #liblocation', function()
     end)
 
     it('test nodes_and_links no wireless', function()
-        local hostname = io.input("/proc/sys/kernel/hostname"):read("*line")
         local result = location.nodes_and_links()
         assert.are.same({}, result.links)
         assert.are.same({lat="FIXME", lon="FIXME"}, result.coordinates)


### PR DESCRIPTION
At https://github.com/libremesh/lime-packages/pull/834 we have broken the shared state publisher for nodes_and_links.

The broken version would publish an entry for each field (links, hostname, macs, etc) in shared-state db, breaking the non-robust lime-app ui for the map.