### PR TITLE
lime-utils: on upgrade preserve configs by default

### DIFF
--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/upgrade.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/upgrade.lua
@@ -102,6 +102,9 @@ function pkg.firmware_upgrade(fw_path, preserve_config, metadata, fw_type)
     end
 
     local backup = ""
+    if preserve_config == nil then
+        preserve_config = true
+    end
     if not preserve_config then
         backup = "DO_NOT_BACKUP=1"
     end

--- a/packages/ubus-lime-utils/tests/test_lime_utils_admin.lua
+++ b/packages/ubus-lime-utils/tests/test_lime_utils_admin.lua
@@ -82,7 +82,7 @@ describe('ubus-lime-utils-admin tests #ubuslimeutilsadmin', function()
                                     '{"fw_path": "/foo.bin"}')
         assert.is.equal("ok", response.status)
         assert.is.equal("LiMe 96dcfa439d27570...", response.metadata.old_release_description)
-        assert.is_false(response.metadata.config_preserved)
+        assert.is_true(response.metadata.config_preserved)
     end)
 
     it('test firmware_upgrade with metadata', function()


### PR DESCRIPTION
If no preserve config option is passed (`preserve_config = nil`) then preserve the config instead of not preserving it. This semantic matches better the sysupgrade semantic.
As in the last lime-app release there is no longer a preserve config checkbox, this change enforces (fixes) the intended behaviour of preserving the config instead of not doint it.
