### PR TITLE
lime-report add opkg list-installed

### DIFF
--- a/packages/lime-report/files/lime-report.sh
+++ b/packages/lime-report/files/lime-report.sh
@@ -64,6 +64,7 @@ generate_status() {
     paste_cmd ebtables -t filter -L --Lc
     paste_cmd ebtables -t nat -L --Lc
     paste_cmd ebtables -t broute -L --Lc
+    paste_cmd opkg list-installed
 }
 
 generate_all() {


### PR DESCRIPTION
This adds another useful command to the lime-report reporting tool:
opkg list-installed