### PR TITLE
LimeApp updated to v0.2.17

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lime-app
-PKG_VERSION:=v0.2.16
+PKG_VERSION:=v0.2.17
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=42e3e96853a4854d09fe97f1c1bbba47a267d5a331db84256f08c6d874e2b0e1
+PKG_HASH:=53eebb12895086d88e9c4a2801555a41ca75239caa19e8144dfabd6491ec9012
 PKG_SOURCE_URL:=https://github.com/libremesh/lime-app/releases/download/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Update LimeApp to v0.2.17, which adds many portuguese translations.