### PR TITLE
lime-utils-admin: add firmware upload acl permission

### DIFF
--- a/packages/ubus-lime-utils/files/usr/share/rpcd/acl.d/lime-utils-admin.json
+++ b/packages/ubus-lime-utils/files/usr/share/rpcd/acl.d/lime-utils-admin.json
@@ -9,6 +9,10 @@
 		},
 		"write": {
 			"cgi-io": [ "upload" ],
+			"file": {
+				"/tmp/firmware.bin": [ "write" ],
+				"/tmp/upgrade.sh": [ "write" ]
+			},
 			"ubus": {
 					"lime-utils-admin": [ "*" ],
 					"system": [ "*" ]


### PR DESCRIPTION
Add the missing file upload permissions. Somehow before 19.07 they were not "needed" because luci was providing them.