### PR TITLE
Fix tmate black screen when joining

### DIFF
--- a/packages/ubus-tmate/files/usr/lib/lua/tmate.lua
+++ b/packages/ubus-tmate/files/usr/lib/lua/tmate.lua
@@ -39,6 +39,7 @@ end
 
 function tmate.open_session()
   tmate.cmd_as_str("new-session -d")
+  tmate.cmd_as_str("send-keys C-c")
 end
 
 function tmate.wait_session_ready()


### PR DESCRIPTION
Tmate shows an initial screen like this:
![Screenshot_20210621_234039](https://user-images.githubusercontent.com/7140856/122854562-4531bd80-d2ea-11eb-80dc-1a711c9b0098.png)

For a recently created session, but only for ssh/terminal clients, in the web client (as in the LimeApp) a black screen is shown instead.

By sending CTRL + c right after opening the session, that screen is not shown anymore, and both ssh/terminal and web clients see the Libremesh Banner and the prompt when joining.