### PR TITLE
lime-webui add dependency from luci-compat

### DIFF
--- a/packages/lime-webui/Makefile
+++ b/packages/lime-webui/Makefile
@@ -29,7 +29,7 @@ define Package/$(PKG_NAME)
 	+luci-mod-status +uhttpd +libiwinfo-lua \
 	+luci-theme-bootstrap +luci-i18n-base-en \
 	+LIMEWEBUI_ES:luci-i18n-base-es +LIMEWEBUI_PT:luci-i18n-base-pt \
-	+LIMEWEBUI_DE:luci-i18n-base-de
+	+LIMEWEBUI_DE:luci-i18n-base-de +luci-compat
 endef
 
 define Package/$(PKG_NAME)/config


### PR DESCRIPTION
[lime-webui](https://github.com/libremesh/lime-packages/tree/master/packages/lime-webui) is obsolete and has been replaced by [lime-app](https://github.com/libremesh/lime-app) since years.
Anyway, there are still users using it.

Since OpenWrt 19.07, some LuCI pieces have been moved to the [luci-compat](https://openwrt.org/packages/pkgdata/luci-compat) package and adding it as a dependency should not be a problem neither for people still using OpenWrt 18.06 as a base as an empty package with this name [has been added in its repositories](https://github.com/openwrt/luci/tree/openwrt-18.06/modules/luci-compat).

If this package is not selected, the shown error is the following:

```
/usr/lib/lua/luci/dispatcher.lua:1334: module 'luci.cbi' not found:
	no field package.preload['luci.cbi']
	no file './luci/cbi.lua'
	no file '/usr/share/lua/luci/cbi.lua'
	no file '/usr/share/lua/luci/cbi/init.lua'
	no file '/usr/lib/lua/luci/cbi.lua'
	no file '/usr/lib/lua/luci/cbi/init.lua'
	no file './luci/cbi.so'
	no file '/usr/lib/lua/luci/cbi.so'
	no file '/usr/lib/lua/loadall.so'
	no file './luci.so'
	no file '/usr/lib/lua/luci.so'
	no file '/usr/lib/lua/loadall.so'
stack traceback:
	[C]: in function 'require'
	/usr/lib/lua/luci/dispatcher.lua:1334: in function '_cbi'
	/usr/lib/lua/luci/dispatcher.lua:1023: in function 'dispatch'
	/usr/lib/lua/luci/dispatcher.lua:984: in function 'dispatch'
	/usr/lib/lua/luci/dispatcher.lua:478: in function </usr/lib/lua/luci/dispatcher.lua:477>
```