### PR TITLE
Relax switch vlan filter

### DIFF
--- a/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
+++ b/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
@@ -92,11 +92,11 @@ end
 
 function babeld.setup_interface(ifname, args)
 	if not args["specific"] and ifname:match("^wlan%d+.ap") then
-		utils.log("lime.proto.babeld.setup_interface(...)", ifname, "ignored")
+		utils.log("lime.proto.babeld.setup_interface(%s, ...) ignored", ifname)
 		return
 	end
 
-	utils.log("lime.proto.babeld.setup_interface(...)", ifname)
+	utils.log("lime.proto.babeld.setup_interface(%s, ...)", ifname)
 
 	local vlanId = args[2] or 17
 	local vlanProto = args[3] or "8021ad"

--- a/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
+++ b/packages/lime-proto-batadv/files/usr/lib/lua/lime/proto/batadv.lua
@@ -63,8 +63,14 @@ end
 
 function batadv.setup_interface(ifname, args)
 	if not args["specific"] then
-		if ifname:match("^wlan%d+.ap") then return end
+		if ifname:match("^wlan%d+.ap") then
+			utils.log( "lime.proto.batadv.setup_interface(%s, ...) ignored",
+			           ifname )
+			return
+		end
 	end
+
+	utils.log("lime.proto.batadv.setup_interface(%s, ...)", ifname)
 
 	local vlanId = args[2] or "%N1"
 	local vlanProto = args[3] or "8021ad"


### PR DESCRIPTION
Address recent bug discovered in Quintana Libre with eth1.2 LibreRouter interface being ignored when specific configuration section for it is needed.