### PR TITLE
Allow changing wifi password

### DIFF
--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/wireless_service.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/wireless_service.lua
@@ -1,0 +1,53 @@
+local utils = require('lime.utils')
+local config = require('lime.config')
+local wireless = require('lime.wireless')
+
+local wireless_service = {}
+wireless_service.AP_BAND = '2ghz' -- TODO: grab from uci config
+
+
+local function get_node_ap_data(is_admin)
+    local result = {}
+    local cfg = wireless.get_band_config(wireless_service.AP_BAND)
+    result.enabled = utils.has_value(cfg.modes, 'apname')
+    result.has_password = (cfg.apname_encryption and
+                          cfg.apname_encryption ~= "none")
+    result.password = is_admin and cfg.apname_key or nil
+    result.ssid = wireless.resolve_ssid(cfg.apname_ssid)
+    return result
+end
+
+local function get_community_ap_data()
+    local result = {}
+    local cfg = wireless.get_band_config(wireless_service.AP_BAND)
+    local community_cfg = wireless.get_community_band_config(wireless_service.AP_BAND)
+    result.enabled = utils.has_value(cfg.modes, 'ap')
+    result.ssid = wireless.resolve_ssid(cfg.ap_ssid)
+    result.community = {}
+    result.community.enabled = utils.has_value(community_cfg.modes, 'ap')
+    return result
+end
+
+function wireless_service.get_access_points_data(is_admin)
+    local result = {}
+    result.node_ap = get_node_ap_data(is_admin)
+    result.community_ap = get_community_ap_data()
+    return result
+end
+
+function wireless_service.set_node_ap(has_password, password)
+    local config = {}
+    config.apname_encryption = has_password and 'psk2' or 'none'
+    config.apname_key = password or nil
+    wireless.set_band_config(wireless_service.AP_BAND, config)
+end
+
+function wireless_service.set_community_ap(enabled)
+    if enabled then
+        wireless.add_band_mode(wireless_service.AP_BAND, 'ap')
+    else
+        wireless.remove_band_mode(wireless_service.AP_BAND, 'ap')
+    end
+end
+
+return wireless_service

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/wireless-service
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/wireless-service
@@ -1,0 +1,39 @@
+#!/usr/bin/env lua
+--[[
+  Copyright (C) 2021 LibreMesh.org
+  This is free software, licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+
+  Copyright 2021 German Ferrero <germanferrero@altermundi.net>
+]]--
+
+local ubus = require "ubus"
+local json = require 'luci.jsonc'
+local utils = require 'lime.utils'
+local wireless = require 'lime.wireless_service'
+
+local conn = ubus.connect()
+if not conn then
+    error("Failed to connect to ubus")
+end
+
+local function get_wifi_data()
+    local data = wireless.get_access_points_data()
+    data.status = "ok"
+    return utils.printJson(data)
+end
+
+local methods = {
+    get_wifi_data = { no_params = 0 },
+}
+
+if arg[1] == 'list' then
+    utils.printJson(methods)
+end
+
+if arg[1] == 'call' then
+    local msg = utils.rpcd_readline()
+    msg = json.parse(msg)
+    if      arg[2] == 'get_wifi_data' then get_wifi_data(msg)
+    else utils.printJson({ error = "Method not found" })
+    end
+end

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/wireless-service-admin
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/wireless-service-admin
@@ -16,7 +16,7 @@ if not conn then
     error("Failed to connect to ubus")
 end
 
-local function get_wifi_data()
+local function get_access_points_data()
     local data = wireless.get_access_points_data(true)
     data.status = "ok"
     return utils.printJson(data)
@@ -33,7 +33,7 @@ local function set_community_ap(msg)
 end
 
 local methods = {
-    get_wifi_data = { no_params = 0 },
+    get_access_points_data = { no_params = 0 },
     set_node_ap = { has_password = 'value', password = 'value' },
     set_community_ap = { enabled = 'value' }
 }
@@ -45,7 +45,7 @@ end
 if arg[1] == 'call' then
     local msg = utils.rpcd_readline()
     msg = json.parse(msg)
-    if      arg[2] == 'get_wifi_data' then get_wifi_data(msg)
+    if      arg[2] == 'get_access_points_data' then get_access_points_data(msg)
     elseif  arg[2] == 'set_node_ap' then set_node_ap(msg)
     elseif  arg[2] == 'set_community_ap' then set_community_ap(msg)
     else utils.printJson({ error = "Method not found" })

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/wireless-service-admin
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/wireless-service-admin
@@ -1,0 +1,53 @@
+#!/usr/bin/env lua
+--[[
+  Copyright (C) 2021 LibreMesh.org
+  This is free software, licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+
+  Copyright 2021 German Ferrero <germanferrero@altermundi.net>
+]]--
+
+local ubus = require "ubus"
+local json = require 'luci.jsonc'
+local utils = require 'lime.utils'
+local wireless = require 'lime.wireless_service'
+
+local conn = ubus.connect()
+if not conn then
+    error("Failed to connect to ubus")
+end
+
+local function get_wifi_data()
+    local data = wireless.get_access_points_data(true)
+    data.status = "ok"
+    return utils.printJson(data)
+end
+
+local function set_node_ap(msg)
+    wireless.set_node_ap(msg.has_password, msg.password)
+    return utils.printJson({status = 'ok'})
+end
+
+local function set_community_ap(msg)
+    wireless.set_community_ap(msg.enabled)
+    return utils.printJson({status = 'ok'})
+end
+
+local methods = {
+    get_wifi_data = { no_params = 0 },
+    set_node_ap = { has_password = 'value', password = 'value' },
+    set_community_ap = { enabled = 'value' }
+}
+
+if arg[1] == 'list' then
+    utils.printJson(methods)
+end
+
+if arg[1] == 'call' then
+    local msg = utils.rpcd_readline()
+    msg = json.parse(msg)
+    if      arg[2] == 'get_wifi_data' then get_wifi_data(msg)
+    elseif  arg[2] == 'set_node_ap' then set_node_ap(msg)
+    elseif  arg[2] == 'set_community_ap' then set_community_ap(msg)
+    else utils.printJson({ error = "Method not found" })
+    end
+end

--- a/packages/ubus-lime-utils/files/usr/share/rpcd/acl.d/wireless_service.json
+++ b/packages/ubus-lime-utils/files/usr/share/rpcd/acl.d/wireless_service.json
@@ -1,0 +1,23 @@
+{
+    "lime-app": {
+        "description": "lime-app public access",
+        "read": {
+            "ubus": {
+                "wireless-service": ['*'],
+            }
+        }
+    },
+    "root": {
+		"description": "root access only",
+		"read": {
+			"ubus": {
+                "wireless-service-admin": [ "*" ]
+			}
+		},
+		"write": {
+			"ubus": {
+                "wireless-service-admin": [ "*" ]
+			}
+		}
+	}
+}

--- a/packages/ubus-lime-utils/tests/test_ubus_wireless_service.lua
+++ b/packages/ubus-lime-utils/tests/test_ubus_wireless_service.lua
@@ -1,0 +1,76 @@
+local test_utils = require "tests.utils"
+local config = require 'lime.config'
+local wireless = require 'lime.wireless_service'
+
+local wireless_service = test_utils.load_lua_file_as_function(
+    "packages/ubus-lime-utils/files/usr/libexec/rpcd/wireless-service"
+)
+
+local wireless_service_admin = test_utils.load_lua_file_as_function(
+    "packages/ubus-lime-utils/files/usr/libexec/rpcd/wireless-service-admin"
+)
+
+
+local rpcd_call = test_utils.rpcd_call
+local uci
+local snapshot -- to revert luassert stubs and spies
+
+describe('ubus_wireless_service_admin #ubus_wireless_service', function()
+
+    it('get_wifi_data wires to with get_access_points_data lib', function()
+        local mocked_data = { some_data = "some_value" }
+        stub(wireless, "get_access_points_data", function () return mocked_data end)
+        local response = rpcd_call(wireless_service_admin, {'call', 'get_wifi_data'}, '')
+        assert.stub(wireless.get_access_points_data).was.called_with(true)
+        assert.is_equal("ok", response.status)
+        assert.is_equal(mocked_data.some_data, response.some_data)
+    end)
+
+    it('set_node_ap wires to set_node_ap lib', function()
+        stub(wireless, "set_node_ap", function () return end)
+        local response = rpcd_call(wireless_service_admin, {'call', 'set_node_ap'},
+            '{"has_password": true, "password": "some_password"}')
+        assert.stub(wireless.set_node_ap).was.called_with(true, 'some_password')
+        assert.is_equal("ok", response.status)
+    end)
+
+    it('set_community_ap wires to set_community_ap lib', function()
+        stub(wireless, "set_community_ap", function () return end)
+        local response = rpcd_call(wireless_service_admin, {'call', 'set_community_ap'},
+            '{"enabled": true}')
+        assert.stub(wireless.set_community_ap).was.called_with(true)
+        assert.is_equal("ok", response.status)
+    end)
+
+    before_each('', function()
+        snapshot = assert:snapshot()
+        uci = test_utils.setup_test_uci()
+    end)
+
+    after_each('', function()
+        snapshot:revert()
+        test_utils.teardown_test_uci(uci)
+    end)
+end)
+
+describe('ubus_wireless_service #ubus_wireless_service', function()
+
+    it('get_wifi_data wires to with get_acesss_points_data lib', function()
+        local mocked_data = { some_data = "some_value" }
+        stub(wireless, "get_access_points_data", function () return mocked_data end)
+        local response = rpcd_call(wireless_service, {'call', 'get_wifi_data'}, '')
+        assert.stub(wireless.get_access_points_data).was.called_with()
+        assert.is_equal("ok", response.status)
+        assert.is_equal(mocked_data.some_data, response.some_data)
+    end)
+
+    before_each('', function()
+        snapshot = assert:snapshot()
+        uci = test_utils.setup_test_uci()
+    end)
+
+    after_each('', function()
+        snapshot:revert()
+        test_utils.teardown_test_uci(uci)
+    end)
+end)

--- a/packages/ubus-lime-utils/tests/test_ubus_wireless_service.lua
+++ b/packages/ubus-lime-utils/tests/test_ubus_wireless_service.lua
@@ -17,10 +17,10 @@ local snapshot -- to revert luassert stubs and spies
 
 describe('ubus_wireless_service_admin #ubus_wireless_service', function()
 
-    it('get_wifi_data wires to with get_access_points_data lib', function()
+    it('get_access_points_data wires to get_access_points_data lib', function()
         local mocked_data = { some_data = "some_value" }
         stub(wireless, "get_access_points_data", function () return mocked_data end)
-        local response = rpcd_call(wireless_service_admin, {'call', 'get_wifi_data'}, '')
+        local response = rpcd_call(wireless_service_admin, {'call', 'get_access_points_data'}, '')
         assert.stub(wireless.get_access_points_data).was.called_with(true)
         assert.is_equal("ok", response.status)
         assert.is_equal(mocked_data.some_data, response.some_data)

--- a/packages/ubus-lime-utils/tests/test_wireless_service.lua
+++ b/packages/ubus-lime-utils/tests/test_wireless_service.lua
@@ -1,0 +1,172 @@
+local utils = require "lime.utils"
+local test_utils = require "tests.utils"
+local wireless_service = require "lime.wireless_service"
+local wireless = require "lime.wireless"
+local config = require "lime.config"
+local network = require "lime.network"
+local system = require "lime.system"
+
+local snapshot -- to revert luassert stubs and spies
+local uci = nil
+
+local function mock_wifi_config()
+    local defaults = [[
+        config lime wifi
+            option apname_ssid 'LibreMesh.org/%H'
+            option ap_ssid 'LibreMesh.org'
+        
+        config lime-wifi-band '2ghz'
+            list modes 'ap'
+            list modes 'apname'
+    ]]
+        
+    local community = [[
+        config lime wifi
+            option apname_ssid 'OurCommunity.org/%H'
+            option ap_ssid 'OurCommunity.org'
+    ]]
+    
+    local node = [[
+        config lime wifi
+            option apname_encryption 'psk2'
+            option apname_key 'testpassword'
+        
+        config lime-wifi-band '2ghz'
+            list modes 'apname'
+    ]]
+
+    test_utils.write_uci_file(uci, config.UCI_DEFAULTS_NAME, defaults)
+    test_utils.write_uci_file(uci, config.UCI_COMMUNITY_NAME, community)
+    test_utils.write_uci_file(uci, config.UCI_NODE_NAME, node)
+    config.uci_autogen()
+end
+
+describe('wireless-service #wireless_service', function()
+    describe('get_access_points_data', function()
+        it('returns privileged node_ap settings when is_admin', function()
+            mock_wifi_config()
+            local result = wireless_service.get_access_points_data(true)
+            local expected = {
+                enabled = true, has_password = true,
+                password = 'testpassword', ssid = 'OurCommunity.org/host'
+            }
+            assert.are.same(expected, result.node_ap)
+        end)
+        
+        it('returns unprivileged node_ap settings when not is_admin', function()
+            mock_wifi_config()
+            local result = wireless_service.get_access_points_data()
+            local expected = {
+                enabled = true, has_password = true, ssid = 'OurCommunity.org/host'
+            }
+            assert.are.same(expected, result.node_ap)
+        end)
+
+        it('returns community_ap settings', function()
+            mock_wifi_config()
+            local result = wireless_service.get_access_points_data()
+            local expected = {
+                enabled = false, ssid = 'OurCommunity.org',
+                community = {
+                    enabled = true
+                }
+            }
+            assert.are.same(expected, result.community_ap)
+        end)
+    end)
+
+    describe('set_node_ap', function()
+        it('changes apname password in node config', function()
+            mock_wifi_config()
+            wireless_service.set_node_ap(true, 'testpassword2')
+            local password = uci:get(config.UCI_NODE_NAME, '2ghz', 'apname_key')
+            local encryption = uci:get(config.UCI_NODE_NAME, '2ghz', 'apname_encryption')
+            assert.is_equal('testpassword2', password)
+            assert.is_equal('psk2', encryption)
+            local node_ap = wireless_service.get_access_points_data(true).node_ap
+            assert.is_true(node_ap.has_password)
+            assert.is_equal('testpassword2', node_ap.password)
+        end)
+
+        it('removes apname password in node config', function()
+            mock_wifi_config()
+            wireless_service.set_node_ap(false)
+            local encryption = uci:get(config.UCI_NODE_NAME, '2ghz', 'apname_encryption')
+            assert.is_equal('none', encryption)
+            local node_ap = wireless_service.get_access_points_data().node_ap
+            assert.is_false(node_ap.has_password)
+        end)
+    end)
+
+    describe('set_community_ap', function()
+        local function mock_community_ap_disabled()
+            local defaults = [[
+                config lime wifi
+                    list modes 'ap'
+                    list modes 'apname'
+            ]]
+            
+            local community = [[
+                config lime wifi
+            ]]
+
+            local node = [[
+                config lime wifi
+                    list modes 'apname'
+            ]]
+        
+            test_utils.write_uci_file(uci, config.UCI_DEFAULTS_NAME, defaults)
+            test_utils.write_uci_file(uci, config.UCI_COMMUNITY_NAME, community)
+            test_utils.write_uci_file(uci, config.UCI_NODE_NAME, node)
+            config.uci_autogen()
+        end
+
+        local function mock_community_ap_enabled()
+            local defaults = [[
+                config lime wifi
+                    list modes 'ap'
+                    list modes 'apname'
+            ]]
+            local community = [[
+                config lime wifi
+            ]]
+
+            local node = [[
+                config lime wifi
+            ]]
+                
+            test_utils.write_uci_file(uci, config.UCI_DEFAULTS_NAME, defaults)
+            test_utils.write_uci_file(uci, config.UCI_COMMUNITY_NAME, community)
+            test_utils.write_uci_file(uci, config.UCI_NODE_NAME, node)
+            config.uci_autogen()
+        end
+
+        it('enables community ap', function()
+            mock_community_ap_disabled()
+            wireless_service.set_community_ap(true)
+            local modes = uci:get(config.UCI_NODE_NAME, '2ghz', 'modes')
+            local all = uci:get_all(config.UCI_NODE_NAME, '2ghz')
+            assert.is_true(utils.has_value(modes, 'ap'))
+        end)
+
+        it('disables community ap', function()
+            mock_community_ap_enabled()
+            wireless_service.set_community_ap(false)
+            local modes = uci:get(config.UCI_NODE_NAME, '2ghz', 'modes')
+            assert.are.same({'apname'}, modes)
+        end)
+    end)
+
+    before_each('', function()
+        stub(system, "get_hostname", function () return 'host' end)
+        stub(network, "primary_mac", function () return  {'00', '00', '00', '00', '00', '00'} end)
+        stub(utils, "unsafe_shell", function () config.uci_autogen() end)
+        snapshot = assert:snapshot()
+        uci = test_utils.setup_test_uci()
+    end)
+
+    after_each('', function()
+        snapshot:revert()
+        test_utils.teardown_test_uci(uci)
+    end)
+end)


### PR DESCRIPTION
This PR is rebased with the branch of this PR: https://github.com/libremesh/lime-packages/pull/896
Please review that one first.

It adds ubus endpoints for enabling/disabling the ap mode in 2ghz radios.
And for setting up a wifi password for the apname mode in 2ghz radios.

This serves as a backend for a UI in the LimeApp to do the same. 