### PR TITLE
lime-proto-anygw: use the configured domain as a hostrecord

### DIFF
--- a/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
+++ b/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
@@ -18,6 +18,10 @@ function anygw.configure(args)
 	anygw.configured = true
 
 	local cloudDomain = config.get("system", "domain")
+	if not utils.has_value(anygw.FQDN, cloudDomain) then
+		table.insert(anygw.FQDN, cloudDomain)
+	end
+
 	local ipv4, ipv6 = network.primary_address()
 	local anygw_mac = config.get("network", "anygw_mac")
 	anygw_mac = utils.applyNetTemplate16(anygw_mac)


### PR DESCRIPTION
If a system domain is being configured use it as a domain for this
router by configuring the DNS hostrecord to use it together with
thisnode.info and minodo.info.