### PR TITLE
watchping: change starting value for last_hook_run

### DIFF
--- a/packages/watchping/files/usr/bin/watchping
+++ b/packages/watchping/files/usr/bin/watchping
@@ -17,7 +17,7 @@ run_hooks () {
 
 watchping_ping() {
 	local ifname="$1"; local timeout="$2"; local pinghosts="$3"; local pinginterval="$4"; local hookname="$5"
-	local last_hooks_run="fail"
+	local last_hooks_run="undefined"
 	local pingexec="ping"
 
 	if [ ! -r "/sys/class/net/$ifname/ifindex" ] ; then


### PR DESCRIPTION
Currently, *-ok hooks run when ping success after the daemon has started,
but *-fail hooks don't in the case that the ping keep failing until timeout .

With this change, the same logic is applied for both cases: success and failure.
