### PR TITLE
shared-state: provide compressed cgi-bin endpoints

### DIFF
--- a/packages/shared-state/files/www/cgi-bin/shared-state
+++ b/packages/shared-state/files/www/cgi-bin/shared-state
@@ -26,4 +26,11 @@ echo
 PATH_INFO="${PATH_INFO#/}"
 echo "$PATH_INFO" | grep -q '^[a-zA-Z0-9_-]*$' || exit 22
 
-cat - | shared-state reqsync "$PATH_INFO"
+case "$QUERY_STRING" in
+  *"gzip"*)
+    zcat - | shared-state reqsync "$PATH_INFO" | gzip -
+    ;;
+  *)
+    cat - | shared-state reqsync "$PATH_INFO"
+    ;;
+esac

--- a/packages/shared-state/files/www/cgi-bin/shared-state-multiwriter
+++ b/packages/shared-state/files/www/cgi-bin/shared-state-multiwriter
@@ -26,4 +26,11 @@ echo
 PATH_INFO="${PATH_INFO#/}"
 echo "$PATH_INFO" | grep -q '^[a-zA-Z0-9_-]*$' || exit 22
 
-cat - | shared-state-multiwriter reqsync "$PATH_INFO"
+case "$QUERY_STRING" in
+  *"gzip"*)
+    zcat - | shared-state-multiwriter reqsync "$PATH_INFO" | gzip -
+    ;;
+  *)
+    cat - | shared-state-multiwriter reqsync "$PATH_INFO"
+    ;;
+esac


### PR DESCRIPTION
Add compression support to the public synchronization endpoints so that the data is transmitted and received using gzip when `gzip` is part of the URL query-string. 

Why? mainly to help shared-state syncing when there is a bad quality link (low signal, too crowded airspace, etc) reducing the amount of packets that have to be transmitted. Also this leads to reduced bandwidth usage.

This change in its own does not change the current behaviour (uncompressed) but allows to use this feature in the future. There are two main possible mechanisms with different backwards compatibility policy:
1. Provide a backwards compatible mechanism that allows a node to know if the other node supports gzip or not and use the new endpoint in that case. There are many options to do this but all add complexity.
2. Add it in a backward incompatible way but with an upgrade path: provide compression support in the next libremesh release, with compression unused when syncing,  and then in a future release switch to "always" compress. 

I am more inclined to do the 2nd option as the first option not only adds code complexity but also runtime overhead and/or runtime complexity. What do you think?