### PR TITLE
bat-hosts: add ipv6ll2bat util

### DIFF
--- a/packages/shared-state-bat_hosts/files/usr/bin/ipv6ll2bat
+++ b/packages/shared-state-bat_hosts/files/usr/bin/ipv6ll2bat
@@ -1,0 +1,2 @@
+#!/bin/sh
+cat | sed "$(sed -nr "{s/..:..:..:..:(..):(..)[[:space:]]+([^[:space:]]+).*/s|fe80.*\1\2|\3|Ig;/p}" /etc/bat-hosts)"


### PR DESCRIPTION
Replaces fe80 addresses with matching bat host based on the last two groups of the fe80 address.
