### PR TITLE
keep.d: add banner.notes

### DIFF
--- a/packages/lime-system/files/lib/upgrade/keep.d/libremesh
+++ b/packages/lime-system/files/lib/upgrade/keep.d/libremesh
@@ -3,3 +3,4 @@
 /etc/config/libremap
 /etc/config/location
 /etc/lime-assets/
+/etc/banner.notes


### PR DESCRIPTION
Currently when upgrading with lime-sysupgrade banner.notes is lost. Let's add it to libremesh's keep.d
