### PR TITLE
lime-app: update to version v0.2.23

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lime-app
-PKG_VERSION:=v0.2.20
+PKG_VERSION:=v0.2.23
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=c18adcdb29f7630d6c013a4e568e8d88e21c306508f854bb9754e6948a64f355
-PKG_SOURCE_URL:=https://github.com/libremesh/lime-app/releases/download/$(PKG_VERSION)
+PKG_HASH:=6f2ae40404c229e75a8aff10e26cff32f43163bde7a468d69559baede3d570dd
+PKG_SOURCE_URL:=https://repo.libremesh.org/limeapp/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -10,7 +10,7 @@ PKG_VERSION:=v0.2.23
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=6f2ae40404c229e75a8aff10e26cff32f43163bde7a468d69559baede3d570dd
+PKG_HASH:=562912e0956699feb2a53f0afd97754e9a5e413796fcd36cfee358ea14322acc
 PKG_SOURCE_URL:=https://repo.libremesh.org/limeapp/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
This PR updates lime-app reference to the last build from v0.2.23.
Since Travis open source software support is gone, I'm doing this integration manually.
The build was uploaded to repo.libremesh.org.

Changelog is [here](https://github.com/libremesh/lime-app/blob/develop/CHANGELOG.md)
