### PR TITLE
lime-utils: do not run lime-apply after set_hostname

### DIFF
--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils-admin
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils-admin
@@ -36,7 +36,7 @@ local function set_hostname(msg)
         local uci = config.get_uci_cursor()
         uci:set(config.UCI_NODE_NAME, 'system', 'hostname', msg.hostname)
         uci:commit(config.UCI_NODE_NAME)
-        utils.unsafe_shell("lime-config && lime-apply")
+        utils.unsafe_shell("lime-config")
         return utils.printJson({ status = 'ok'})
     else
         local err


### PR DESCRIPTION
Thus, preventing apname clients from getting disconnected from the AP, when setting the hostname in the LimeApp.
Instead, they will be prompt to reboot to apply changes.