### PR TITLE
Lime app to version v0.2.25

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lime-app
-PKG_VERSION:=v0.2.20
+PKG_VERSION:=v0.2.25
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=c18adcdb29f7630d6c013a4e568e8d88e21c306508f854bb9754e6948a64f355
+PKG_HASH:=7804eb39686d94c50347170cf01b2d4d810e8cae33b7c1ed2787c19f4a4c2046
 PKG_SOURCE_URL:=https://github.com/libremesh/lime-app/releases/download/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk

--- a/packages/lime-app/files/etc/uci-defaults/90_lime-app
+++ b/packages/lime-app/files/etc/uci-defaults/90_lime-app
@@ -4,6 +4,8 @@ uci set rpcd.@login[1].username='lime-app'
 uci set rpcd.@login[1].password='$1$$ta3C2yX4TvVObdaJyQ9Md1'
 uci add_list rpcd.@login[1].read='lime-app'
 uci add_list rpcd.@login[1].write='lime-app'
+uci add_list rpcd.@login[1].read='unauthenticated'
+uci add_list rpcd.@login[1].write='unauthenticated'
 uci commit rpcd
 uci set uhttpd.main.ubus_cors='1'
 uci commit uhttpd

--- a/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils-admin
+++ b/packages/ubus-lime-utils/files/usr/libexec/rpcd/lime-utils-admin
@@ -36,7 +36,7 @@ local function set_hostname(msg)
         local uci = config.get_uci_cursor()
         uci:set(config.UCI_NODE_NAME, 'system', 'hostname', msg.hostname)
         uci:commit(config.UCI_NODE_NAME)
-        utils.unsafe_shell("lime-config && lime-apply")
+        utils.unsafe_shell("lime-config")
         return utils.printJson({ status = 'ok'})
     else
         local err


### PR DESCRIPTION
We have been testing a new version of limeapp v0.2.25 in different communities, and it is working well.
This PR also add two small fixes needed by this new version.