### PR TITLE
lime-app: update title in lime-app

### DIFF
--- a/packages/lime-app/files/etc/uci-defaults/99-lime-app-update-title
+++ b/packages/lime-app/files/etc/uci-defaults/99-lime-app-update-title
@@ -1,0 +1,10 @@
+#!/bin/sh
+cat << EOF >> /usr/bin/lime-apply
+
+# Update title in lime-app
+[ -f /www/app/index.html ] && {
+        sed -i -e "s/\(<title>\).*\(<\/title>\)/\1\${hostname}\2/g" /www/app/index.html
+}
+EOF
+/usr/bin/lime-apply
+exit 0


### PR DESCRIPTION
Append a sed command to lime-apply that update the tag <title> in /www/app/index.html
to allow users to save the lime-app page of their device as a bookmark in the browser, without having to manually override the default title Lime.

I thought it was better to use a single sed command through an uci-default script instead of adding another dependency to lime-app itself, like https://www.npmjs.com/package/react-helmet to manage headers.