### PR TITLE
Moved udhcpc.user file to installer script

### DIFF
--- a/packages/ubus-lime-utils/files/etc/uci-defaults/ubus-lime-utils-udhcpc.user-setup_hotspot_watchping
+++ b/packages/ubus-lime-utils/files/etc/uci-defaults/ubus-lime-utils-udhcpc.user-setup_hotspot_watchping
@@ -1,7 +1,7 @@
 #!/bin/sh
 grep setup_hotspot_watchping /etc/udhcpc.user || {
 	echo "ubus-lime-utils: adding setup_hotspot_watchping to /etc/udhcpc.user"
-	cat > /etc/udhcpc.user << EOF
+	cat >> /etc/udhcpc.user << EOF
 setup_hotspot_watchping() {
     ifname="client-wwan"
     gw=$(ip r show default dev $ifname | while read default via ip rest; do [[ $via == "via" ]] && echo $ip && break; done)

--- a/packages/ubus-lime-utils/files/etc/uci-defaults/ubus-lime-utils-udhcpc.user-setup_hotspot_watchping
+++ b/packages/ubus-lime-utils/files/etc/uci-defaults/ubus-lime-utils-udhcpc.user-setup_hotspot_watchping
@@ -1,3 +1,7 @@
+#!/bin/sh
+grep setup_hotspot_watchping /etc/udhcpc.user || {
+	echo "ubus-lime-utils: adding setup_hotspot_watchping to /etc/udhcpc.user"
+	cat > /etc/udhcpc.user << EOF
 setup_hotspot_watchping() {
     ifname="client-wwan"
     gw=$(ip r show default dev $ifname | while read default via ip rest; do [[ $via == "via" ]] && echo $ip && break; done)
@@ -17,3 +21,7 @@ case "$1" in
 		setup_hotspot_watchping
 	;;
 esac
+EOF
+}
+
+


### PR DESCRIPTION
Fix #927
Taken inspiration from these other uci-defaults files:
https://github.com/libremesh/lime-packages/blob/2c4b783f68860f2542b3910fc6c46f9566b1b205/packages/lime-proto-bmx6/files/etc/uci-defaults/85-add-bmx6-addresses-to-hosts
and
https://github.com/libremesh/lime-packages/blob/f4f8d004ff8564452ab705b02687eff9cc063334/packages/lime-app/files/etc/uci-defaults/95-lime-app-rpc-acl
Should work, but I still have to test it on a router.