### PR TITLE
Fixes in the ansible script and tools

### DIFF
--- a/tools/ansible/cloud_and_node_packages.yml
+++ b/tools/ansible/cloud_and_node_packages.yml
@@ -1,0 +1,27 @@
+- name: Install packages
+  hosts: localhost
+  become: yes
+  connection: local
+  gather_facts: no
+  tasks:
+   - name: Install bridge_utils
+     apt:
+      name: bridge-utils
+      state: present
+   - name: Install clusterssh
+     apt:
+      name: clusterssh
+      state: present
+   - name: Install dnsmasq
+     apt: 
+      name: dnsmasq
+      state: present
+   - name: Install iptables
+     apt:
+      name: iptables
+      state: present
+   - name: Install qemusystem
+     apt:
+      name: qemu-system-x86
+      state: present
+

--- a/tools/ansible/modules/linux_bridge.py
+++ b/tools/ansible/modules/linux_bridge.py
@@ -56,11 +56,6 @@ class LinuxBridge (object) :
         self.state = module.params['state']
         return
 
-    def brctl (self, cmd) :
-
-       	return self.module.run_command (['brctl'] + cmd)
-
-
     def ip(self, cmd) : 
 
         return self.module.run_command (['ip'] + cmd) 

--- a/tools/ansible/modules/linux_bridge.py
+++ b/tools/ansible/modules/linux_bridge.py
@@ -54,17 +54,16 @@ class LinuxBridge (object) :
         self.module = module
         self.bridge = module.params['bridge']
         self.state = module.params['state']
-
         return
 
     def brctl (self, cmd) :
 
-        return self.module.run_command (['brctl'] + cmd)
+       	return self.module.run_command (['brctl'] + cmd)
 
 
-    def ifconfig (self, cmd) :
+    def ip(self, cmd) : 
 
-        return self.module.run_command (['ifconfig'] + cmd)
+        return self.module.run_command (['ip'] + cmd) 
 
 
     def br_exists (self) :
@@ -79,22 +78,22 @@ class LinuxBridge (object) :
 
 
     def addbr (self) :
-        
-        (rc, out, err) = self.brctl (['addbr', self.bridge])
+    
+        (rc, out, err) = self.ip (['link', 'add', 'name', self.bridge, 'type', 'bridge'])
 
         if rc != 0 :
             raise Exception (err)
 
-        self.ifconfig ([self.bridge, 'up'])
+        self.ip(['link','set','up', self.bridge]) 
 
         return
 
 
     def delbr (self) :
         
-        self.ifconfig ([self.bridge, 'down'])
-
-        (rc, out, err) = self.brctl (['delbr', self.bridge])
+        self.ip(['link','set', 'down', self.bridge]) 
+        
+        (rc, out, err) = self.ip (['link', 'del', self.bridge])
 
         if rc != 0 :
             raise Exception (err)

--- a/tools/ansible/modules/linux_bridge_port.py
+++ b/tools/ansible/modules/linux_bridge_port.py
@@ -60,10 +60,9 @@ class LinuxPort (object) :
 
         return
 
+    def ip(self, cmd) :
 
-    def brctl (self, cmd) :
-        
-        return self.module.run_command (['brctl'] + cmd)
+        return self.module.run_command (['ip'] + cmd)
 
 
     def port_exists (self) :
@@ -79,7 +78,7 @@ class LinuxPort (object) :
 
     def addif (self) :
 
-        (rc, out, err) = self.brctl (['addif', self.bridge, self.port])
+        (rc, out, err) = self.ip (['link', 'set', self.port,'master',self.bridge])
         
         if rc != 0 :
             raise Exception (err)
@@ -89,7 +88,7 @@ class LinuxPort (object) :
 
     def delif (self) :
 
-        (rc, out, err) = self.brctl (['delif', self.bridge, self.port])
+        (rc, out, err) = self.ip (['link', 'del', self.port,'dev',self.bridge])
         
         if rc != 0 :
             raise Exception (err)

--- a/tools/ansible/only_one_node.yml
+++ b/tools/ansible/only_one_node.yml
@@ -1,0 +1,35 @@
+- import_playbook: cloud_and_node_packages.yml
+
+- name: run only one node
+  hosts: localhost
+  become: yes
+  connection: local
+  vars:
+      rootfs_url: https://repo.librerouter.org/lros/releases/1.5/targets/x86/64/librerouteros-1.5-r0+11434-e93615c947-x86-64-generic-rootfs.tar.gz
+      ramfs_url: https://repo.librerouter.org/lros/releases/1.5/targets/x86/64/librerouteros-1.5-r0+11434-e93615c947-x86-64-ramfs.bzImage
+      rootfs: ./files/generic-rootfs.tar.gz
+      ramfs: ./files/ramfs.bzImage
+      param: param
+  tasks:
+     - name: run qemu
+       shell: | 
+        (chmod +x qemu_dev_start)
+        (../qemu_dev_start {{param}} {{ rootfs }} {{ ramfs }}&)
+        
+
+- name: useful info for doing ssh
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+     - name: info
+       run_once: yes
+       pause:
+        seconds: 5
+        prompt: |
+          ===================================
+          
+          to access to node you can do:
+          sudo ssh -o StrictHostKeyChecking=no -o"HostkeyAlgorithms +ssh-rsa" 10.13.0.1
+
+          ===================================

--- a/tools/ansible/qemu_cloud_start.yml
+++ b/tools/ansible/qemu_cloud_start.yml
@@ -104,5 +104,8 @@
           now to manage the cloud you can do:
 
           clusterssh {{ linklocals | join(' ') }}
+          
+          to access to node you can do:
+          ssh -o StrictHostKeyChecking=no -o"HostkeyAlgorithms +ssh-rsa" {{ linklocals | join(' ') }}
 
           ===================================

--- a/tools/ansible/qemu_cloud_start.yml
+++ b/tools/ansible/qemu_cloud_start.yml
@@ -4,8 +4,9 @@
 #  you can use --limit regexp to start just two clouds, for example:
 #  sudo ansible-playbook qemu_cloud_start.yml -l *cloud[AB]*
 
-- name: create bridges for qemu nodes
+- import_playbook: cloud_and_node_packages.yml
 
+- name: create bridges for qemu nodes
   hosts: all
   connection: local
   gather_facts: no
@@ -102,10 +103,7 @@
         prompt: |
           ===================================
           now to manage the cloud you can do:
-
-          clusterssh {{ linklocals | join(' ') }}
           
-          to access to node you can do:
-          ssh -o StrictHostKeyChecking=no -o"HostkeyAlgorithms +ssh-rsa" {{ linklocals | join(' ') }}
+          clusterssh -o "-o "StrictHostKeyChecking=no" -o HostKeyAlgorithms=+ssh-rsa" root@{{ linklocals | join(' ') }}
 
           ===================================

--- a/tools/qemu_dev_start
+++ b/tools/qemu_dev_start
@@ -216,7 +216,7 @@ if [ -n "$_arg_enable_wan" ]; then
     fi
 
     # DHCP server for WAN ifc
-    dnsmasq -F 172.99.0.100,172.99.0.100 --dhcp-option=3,172.99.0.1 -i "$WAN_IFC" --dhcp-authoritative --log-dhcp
+    dnsmasq -F 172.99.0.100,172.99.0.100 --dhcp-option=3,172.99.0.1 -i "$WAN_IFC" --dhcp-authoritative --log-dhcp --port=5353 --bind-dynamic
 
     # enable forwarding and NAT
     echo 1 > /proc/sys/net/ipv4/ip_forward

--- a/tools/qemu_dev_stop
+++ b/tools/qemu_dev_stop
@@ -1,3 +1,4 @@
 NODE_ID=${1:-0}
 [ ${#NODE_ID} = 1 ] && NODE_ID=0${NODE_ID} # Pad with leading zero
 echo system_powerdown | nc -N 127.0.0.1 "454${NODE_ID}"
+ip link del lime_br0


### PR DESCRIPTION
1. Remove host interface
        It remove an interface that was created on the host after starting a node with qemu_dev_start
2. Put the message in ansible to access the cloud nodes
        By raising a cloud of nodes we were able to access each one by clusterssh. When you wanted to do it with ssh, it was not 
        possible because there was a problem with the keys, so a message is added indicating how you can access any cloud 
        node through ssh.
3. Add "files" in ansible with the images
4. Port change
        When I wanted to launch a node with internet access using --enable-wan for qemu_dev_start, a port collision occurred as 
        dnsmasq uses port 53 by default, which is usually occupied by the systemd-resolved service. To fix this, another port is 
        allocated so that this collision does not occur.
5. Change ifconfig to IP
        In the linux_bridge.py module, there were calls to ifconfig, and since modern Linux distributions don't have this command 
        to view the TCP/IP configuration, it wasn't possible to run the node cloud (unless you installed the net- tools for the use of 
        ifconfig). To avoid this inconvenience for any other user, calls that were previously made with ifconfig are now made with IP.