### PR TITLE
network.lua use an alternate string if ifname is not found by owrt_device_parser

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -256,8 +256,8 @@ function network.scandevices()
 		local created_device = section["name"]
 		local base_interface = section["ifname"]
 		utils.log( "network.scandevices.owrt_device_parser found base "..
-		           "interface %s and derived device %s", base_interface,
-		           created_device )
+		           "interface %s and derived device %s", base_interface or "not_found",
+		           created_device or "not_found")
 		dev_parser(created_device)
 		dev_parser(base_interface)
 	end


### PR DESCRIPTION
Fix #944