### PR TITLE
Replace OpenWrt 19.07 switch config style with OpenWrt 21.02 one in proto-lan and network.lua's device parser

### DIFF
--- a/packages/lime-hwd-openwrt-wan/files/usr/lib/lua/lime/hwd/openwrt_wan.lua
+++ b/packages/lime-hwd-openwrt-wan/files/usr/lib/lua/lime/hwd/openwrt_wan.lua
@@ -1,5 +1,13 @@
 #!/usr/bin/lua
 
+--! LibreMesh community mesh networks meta-firmware
+--!
+--! Copyright (C) 2014-2023  Gioacchino Mazzurco <gio@eigenlab.org>
+--! Copyright (C) 2023  Asociación Civil Altermundi <info@altermundi.net>
+--!
+--! SPDX-License-Identifier: AGPL-3.0-only
+
+
 local hardware_detection = require("lime.hardware_detection")
 local config = require("lime.config")
 local utils = require("lime.utils")
@@ -22,7 +30,7 @@ function openwrt_wan.detect_hardware()
 		if networkTable then
 			local wanTable = networkTable['wan']
 			if wanTable then
-				ifname = wanTable['ifname']
+				ifname = wanTable['device']
 			end
 		end
 		if ifname and ifname ~= "" then
@@ -47,8 +55,10 @@ function openwrt_wan.detect_hardware()
 			config.set(openwrt_wan.sectionName, "protocols", protos)
 			config.set(openwrt_wan.sectionName, "linux_name", ifname)
 			config.end_batch()
+
+			utils.dbg("WAN interface:", ifname)
 		else
-			utils.log("No wan interface detected")
+			utils.dbg("WAN interface not found")
 		end
 	end
 end

--- a/packages/lime-proto-wan/files/usr/lib/lua/lime/proto/wan.lua
+++ b/packages/lime-proto-wan/files/usr/lib/lua/lime/proto/wan.lua
@@ -1,5 +1,12 @@
 #!/usr/bin/lua
 
+--! LibreMesh community mesh networks meta-firmware
+--!
+--! Copyright (C) 2014-2023  Gioacchino Mazzurco <gio@eigenlab.org>
+--! Copyright (C) 2023  Asociación Civil Altermundi <info@altermundi.net>
+--!
+--! SPDX-License-Identifier: AGPL-3.0-only
+
 local libuci = require("uci")
 local fs = require("nixio.fs")
 local utils = require("lime.utils")
@@ -20,7 +27,7 @@ end
 
 function wan.setup_interface(ifname, args)
 	local uci = libuci:cursor()
-	uci:set("network", "wan", "ifname", ifname)
+	uci:set("network", "wan", "device", ifname)
 	uci:save("network")
 
 	if utils.is_installed('firewall') then

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -1,5 +1,12 @@
 #!/usr/bin/lua
 
+--! LibreMesh community mesh networks meta-firmware
+--!
+--! Copyright (C) 2013-2023  Gioacchino Mazzurco <gio@eigenlab.org>
+--! Copyright (C) 2023  Asociación Civil Altermundi <info@altermundi.net>
+--!
+--! SPDX-License-Identifier: AGPL-3.0-only
+
 network = {}
 
 local ip = require("luci.ip")
@@ -452,6 +459,7 @@ function network.createVlanIface(linuxBaseIfname, vid, openwrtNameSuffix, vlanPr
 		uci:set("network", owrtDeviceName, "device")
 		uci:set("network", owrtDeviceName, "type", vlanProtocol)
 		uci:set("network", owrtDeviceName, "name", linux802adIfName)
+		--! This is ifname also on current OpenWrt
 		uci:set("network", owrtDeviceName, "ifname", linuxBaseIfname)
 		uci:set("network", owrtDeviceName, "vid", vlanId)
 	end
@@ -468,7 +476,7 @@ function network.createVlanIface(linuxBaseIfname, vid, openwrtNameSuffix, vlanPr
 	--! ifname in network because it is already set in wireless, because
 	--! setting ifname on both places cause a netifd race condition
 	if vid ~= 0 or not linux802adIfName:match("^wlan") then
-		uci:set("network", owrtInterfaceName, "ifname", linux802adIfName)
+		uci:set("network", owrtInterfaceName, "device", linux802adIfName)
 	end
 
 	uci:save("network")
@@ -495,14 +503,16 @@ function network.createMacvlanIface(baseIfname, linuxName, argsDev, argsIf)
 
 	local owrtDeviceName = network.limeIfNamePrefix..baseIfname.."_"..linuxName.."_dev"
 	local owrtInterfaceName = network.limeIfNamePrefix..baseIfname.."_"..linuxName.."_if"
-	owrtDeviceName = owrtDeviceName:gsub("[^%w_]", "_") -- sanitize uci section name
-	owrtInterfaceName = owrtInterfaceName:gsub("[^%w_]", "_") -- sanitize uci section name
+	--! sanitize uci sections name
+	owrtDeviceName = owrtDeviceName:gsub("[^%w_]", "_")
+	owrtInterfaceName = owrtInterfaceName:gsub("[^%w_]", "_")
 
 	local uci = config.get_uci_cursor()
 
 	uci:set("network", owrtDeviceName, "device")
 	uci:set("network", owrtDeviceName, "type", "macvlan")
 	uci:set("network", owrtDeviceName, "name", linuxName)
+	--! This is ifname also on current OpenWrt
 	uci:set("network", owrtDeviceName, "ifname", baseIfname)
 	for k,v in pairs(argsDev) do
 		uci:set("network", owrtDeviceName, k, v)
@@ -510,7 +520,7 @@ function network.createMacvlanIface(baseIfname, linuxName, argsDev, argsIf)
 
 	uci:set("network", owrtInterfaceName, "interface")
 	uci:set("network", owrtInterfaceName, "proto", "none")
-	uci:set("network", owrtInterfaceName, "ifname", linuxName)
+	uci:set("network", owrtInterfaceName, "device", linuxName)
 	uci:set("network", owrtInterfaceName, "auto", "1")
 	for k,v in pairs(argsIf) do
 		uci:set("network", owrtInterfaceName, k, v)

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -272,11 +272,13 @@ function network.scandevices()
 		dev_parser(base_interface)
 		--! With DSA switch config, lan* ports are included in br-lan as "ports"
 		local ports = section["ports"]
-		for _,port in pairs(ports) do
-		utils.log( "network.scandevices.owrt_device_parser found "..
-			   "interface %s with port %s",
-			   created_device or "not_found", port or "not_found")
-			   dev_parser(port)
+		if ports ~= "" and ports ~= nil then
+			for _,port in pairs(ports) do
+				utils.log( "network.scandevices.owrt_device_parser found "..
+					   "interface %s with port %s",
+					   created_device or "not_found", port or "not_found")
+					   dev_parser(port)
+			end
 		end
 	end
 

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -238,6 +238,16 @@ function network.scandevices()
 			utils.log( "network.scandevices.dev_parser found LAN port %s " ..
 			           "and marking %s as nobridge", dev, lower_if )
 		end
+		--! With DSA, the WAN is named wan. Copying the code from the lan case.
+		if dev:match("^wan$") then
+			local lower_if_path = utils.unsafe_shell("ls -d /sys/class/net/" .. dev .. "/lower*")
+			local lower_if_table = utils.split(lower_if_path, "_")
+			local lower_if = lower_if_table[#lower_if_table]:gsub("\n", "")
+			devices[lower_if] = { nobridge = true }
+			devices[dev] = {}
+			utils.log( "network.scandevices.dev_parser found WAN port %s " ..
+			           "and marking %s as nobridge", dev, lower_if )
+		end
 
 		if dev:match("^wlan%d+"..wireless.wifiModeSeparator.."%w+$") then
 			devices[dev] = {}

--- a/packages/lime-system/files/usr/lib/lua/lime/proto/lan.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/proto/lan.lua
@@ -48,7 +48,10 @@ function lan.setup_interface(ifname, args)
 
 	local uci = config.get_uci_cursor()
 	local bridgedIfs = {}
-	local oldIfs = uci:get("network", "lan", "ifname") or {}
+	-- here we bet that the first device section is the bridge one,
+	-- as it does not have a name for addressing it
+	local oldIfs = uci:get("network", "@device[0]", "ports") or {}
+	-- it should be a table, it was a string in old OpenWrt releases
 	if type(oldIfs) == "string" then oldIfs = utils.split(oldIfs, " ") end
 	for _,iface in pairs(oldIfs) do
 		if iface ~= ifname then
@@ -56,7 +59,7 @@ function lan.setup_interface(ifname, args)
 		end
 	end
 	table.insert(bridgedIfs, ifname)
-	uci:set("network", "lan", "ifname", bridgedIfs)
+	uci:set("network", "@device[0]", "ports", bridgedIfs)
 	uci:save("network")
 end
 

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -1,5 +1,12 @@
 #!/usr/bin/lua
 
+--! LibreMesh community mesh networks meta-firmware
+--!
+--! Copyright (C) 2014-2023  Gioacchino Mazzurco <gio@eigenlab.org>
+--! Copyright (C) 2023  Asociación Civil Altermundi <info@altermundi.net>
+--!
+--! SPDX-License-Identifier: AGPL-3.0-only
+
 utils = {}
 
 local config = require("lime.config")
@@ -10,6 +17,22 @@ local nixio = require("nixio")
 utils.BOARD_JSON_PATH = "/etc/board.json"
 utils.SHADOW_FILENAME = "/etc/shadow"
 utils.KEEP_ON_UPGRADE_FILES_BASE_PATH = '/lib/upgrade/keep.d/'
+
+function utils.dbg(...)
+	local ofd = io.stderr
+
+	ofd:write( debug.getinfo(2, 'S').source, ":",
+	           debug.getinfo(2, 'l').currentline, " ",
+	           debug.getinfo(2, 'n').name )
+
+	for n=1, select('#', ...) do
+		--! Assigantion needed to take only the Nth element discarding the rest
+		local nE = select(n, ...)
+		ofd:write(" ", nE)
+	end
+
+	ofd:write("\n")
+end
 
 function utils.log(...)
 	if DISABLE_LOGGING ~= nil then return end

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -568,4 +568,13 @@ function utils.deepcompare(t1,t2)
     return true
 end
 
+function utils.is_dsa()
+    --! Code adapted from Jow https://forum.openwrt.org/t/how-to-detect-dsa/111868/4
+    local shell_output = utils.unsafe_shell("grep -s DEVTYPE=dsa /sys/class/net/*/uevent")
+    if shell_output ~= "" and shell_output ~= nil then
+        return true
+    end
+    return false
+end
+
 return utils


### PR DESCRIPTION
See #951 

Specifically, here I tried to address two big differences that can be spotted in the reports attached in #951:

* the fact that with current code and when DSA is present, bat0 interface was not being added to br-lan bridge, see #958
* the fact that with current code and when DSA is present, eth0 was selected for addition to the bridge
* the fact that with current code and when DSA is present, the VLAN interfaces from the ethernet ports were not added inside bat0

On the last point, there are two big doubts:

* with DSA, eth0.1 does not exist anymore and has been replaced by lan1, lan2, lan3... So which interfaces should be created and added to bat0? I decided to create a VLAN for each of these, for example lan1_29, lan2_29, lan3_29...
* why the WAN interface was added to bat0? With the current code, there are interfaces like eth0-2_29 (a VLAN created on top of the WAN) being added to bat0, but this sounds useless and unsafe to me. So I did not add WAN interface to bat0, but only LAN ones.

I coarsely tested on a single router, so this PR is not ready to merge at all.

Indeed, what I observed is that only lan1_29 gets added to bat0, while lan2_29... do not get added, even if in `/etc/config/network` they are all indicated to be part of bat0 in the same way. No idea what is happening here.