### PR TITLE
unstuck-wifi: send SIGTERM to iw-processes still running after 5 minutes

### DIFF
--- a/packages/wifi-unstuck-wa/files/usr/lib/lua/wifi_unstuck_wa.lua
+++ b/packages/wifi-unstuck-wa/files/usr/lib/lua/wifi_unstuck_wa.lua
@@ -46,6 +46,7 @@ function wu.wait_and_kill_on_timeout(pid_time_started)
 		while true do
 			pid,state,code = nixio.waitpid(nil,"nohang")
 			if not pid then break end
+			if pid == 0 then break end
 			pid_done[pid] = true
 		end
 

--- a/packages/wifi-unstuck-wa/tests/test_wifi_unstuck.lua
+++ b/packages/wifi-unstuck-wa/tests/test_wifi_unstuck.lua
@@ -16,8 +16,10 @@ describe('Wireless unstuck workarounds #unstuck', function()
     end)
 
     it('test get scan freq for iface', function()
-        stub(io, 'popen', function () return true end)
+        stub(nixio, 'exec', function () return true end)
+        stub(nixio, 'fork', function () return 0 end)
         stub(nixio, 'nanosleep', function () return true end)
+        stub(os, 'exit', function () return true end)
 
         local function fake_frequency(phy)
             if phy == 'wlan1-mesh' then
@@ -29,8 +31,68 @@ describe('Wireless unstuck workarounds #unstuck', function()
         stub(iwinfo.nl80211, 'frequency', fake_frequency)
 
         unstuck_wa.do_workaround()
-        assert.stub(io.popen).was.called_with('iw dev wlan1-mesh scan freq 2412 2462')
-        assert.stub(io.popen).was.called_with('iw dev wlan2-mesh scan freq 5180 5240')
+
+        assert.stub(nixio.exec).was.called_with('/bin/sh','-c','iw dev wlan1-mesh scan freq 2412 2462 >/dev/null')
+        assert.stub(nixio.exec).was.called_with('/bin/sh','-c','iw dev wlan2-mesh scan freq 5180 5240 >/dev/null')
+    end)
+
+    it('test pid-timeout-table', function()
+        stub(nixio, 'exec', function () return true end)
+        stub(nixio, 'nanosleep', function () return true end)
+        stub(os, 'time', function () return 10000 end)
+        stub(os, 'exit', function () return true end)
+        stub(unstuck_wa,'wait_and_kill_on_timeout', function() return true end)
+
+        local function fake_frequency(phy)
+            if phy == 'wlan1-mesh' then
+                return 2462
+            elseif phy == 'wlan2-mesh' then
+                return 5230
+            end
+        end
+        stub(iwinfo.nl80211, 'frequency', fake_frequency)
+
+        local pid = 11270
+        local function fake_fork()
+            pid = pid + 1
+            return pid
+        end
+        stub(nixio, 'fork', fake_fork)
+
+        unstuck_wa.do_workaround()
+
+        assert.stub(unstuck_wa.wait_and_kill_on_timeout).was.called_with(
+            { [11271]=10000, [11272]=10000 }
+        )
+    end)
+
+    it('test kill iw scan after timeout', function()
+        stub(nixio, 'nanosleep', function () return true end)
+        stub(nixio, 'kill', function () return true end)
+
+        local time = 10001
+        local function fake_time()
+            time = time + 1
+            return time
+        end
+        stub(os, 'time', fake_time)
+
+        local iw_is_done = false
+        local function fake_waitpid()
+            if iw_is_done then return nil,nil,nil end
+            if time >= 10003 then
+                iw_is_done = true
+                return 11271,'exited',0
+            end
+        end
+        stub(nixio, 'waitpid', fake_waitpid)
+
+        unstuck_wa.wait_and_kill_on_timeout({ [11271]=10000, [11272]=10000 })
+
+        assert.stub(nixio.kill).was._not.called_with(11271,15)
+        assert.stub(nixio.kill).was.called_with(11272,15)
+
+        stub(nixio, 'waitpid', function () return nil end)
     end)
 
     before_each('', function()


### PR DESCRIPTION
Modification of wifi_unstuck_wa.lua so that it sends SIGTERM to all iw-processes still running after 5 minutes.
Fixes #964