### PR TITLE
Add meuno.info to anygw for portuguese acessibility

### DIFF
--- a/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
+++ b/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
@@ -11,7 +11,7 @@ anygw = {}
 anygw.configured = false
 
 anygw.SAFE_CLIENT_MTU = 1350
-anygw.FQDN = {"thisnode.info", "minodo.info"}
+anygw.FQDN = {"thisnode.info", "minodo.info", "meuno.info"}
 
 function anygw.configure(args)
 	if anygw.configured then return end


### PR DESCRIPTION
Currently lime-app is only acessible through thisnode.info and minodo.info, neither make sense for portuguese speakers. Since it seems an easy update and the domain is very cheap, I'd like to start this process, which will make our lives in Brasil much easier when supporting CN processes, by making addresses acessible.

What would be the next steps? Buy the domain? Does anything need to be done with it?