### PR TITLE
Improve get node status results

### DIFF
--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime-utils.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime-utils.lua
@@ -37,6 +37,7 @@ function limeutils.get_node_status()
     result.hostname = utils.hostname()
     result.ips = node_status.get_ips()
     result.most_active = node_status.get_most_active()
+    result.switch_status = node_status.switch_status()
     result.uptime = tostring(utils.uptime_s())
     result.status = "ok"
     return result

--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime-utils.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime-utils.lua
@@ -2,9 +2,9 @@
 
 -- Used on lime-utils ubus script
 local limewireless = require 'lime.wireless'
-local iwinfo = require 'iwinfo'
 local utils = require 'lime.utils'
 local upgrade = require 'lime.upgrade'
+local node_status = require 'lime.node_status'
 local hotspot_wwan = require "lime.hotspot_wwan"
 local ubus = require "ubus"
 
@@ -25,24 +25,6 @@ function limeutils.get_cloud_nodes()
     return result
 end
 
--- todo(kon): move to utility class?? 
-function limeutils.get_station_traffic(params)
-    local iface = params.iface
-    local mac = params.station_mac
-    local result = {}
-    local traffic = utils.unsafe_shell(
-                        "iw " .. iface .. " station get " .. mac ..
-                            " | grep bytes | awk '{ print $3}'")
-    words = {}
-    for w in traffic:gmatch("[^\n]+") do table.insert(words, w) end
-    rx = words[1]
-    tx = words[2]
-    result.station = mac
-    result.rx_bytes = tonumber(rx, 10)
-    result.tx_bytes = tonumber(tx, 10)
-    result.status = "ok"
-    return result
-end
 
 function limeutils.get_mesh_ifaces()
     local result = {}
@@ -53,66 +35,9 @@ end
 function limeutils.get_node_status()
     local result = {}
     result.hostname = utils.hostname()
-    result.ips = {}
-    local ips = utils.unsafe_shell(
-                    "ip a s br-lan | grep inet | awk '{ print $1, $2 }'")
-    for line in ips:gmatch("[^\n]+") do
-        local words = {}
-        for w in line:gmatch("%S+") do
-            if w ~= "" then table.insert(words, w) end
-        end
-        local version = words[1]
-        local address = words[2]
-        if version == "inet6" then
-            table.insert(result.ips, {version = "6", address = address})
-        else
-            table.insert(result.ips, {version = "4", address = address})
-        end
-    end
-    local ifaces = limewireless.mesh_ifaces()
-    local stations = {}
-    for _, iface in ipairs(ifaces) do
-        iface_type = iwinfo.type(iface)
-        iface_stations = iface_type and iwinfo[iface_type].assoclist(iface)
-        if iface_stations then
-            for mac, station in pairs(iface_stations) do
-                station['iface'] = iface
-                station.station_mac = mac
-                table.insert(stations, station)
-            end
-        end
-    end
-    if next(stations) ~= nil then
-        local most_active_rx = 0
-        local most_active = nil
-        for _, station in ipairs(stations) do
-            local traffic = utils.unsafe_shell(
-                                "iw " .. station.iface .. " station get " ..
-                                    station.station_mac ..
-                                    " | grep bytes | awk '{ print $3}'")
-            words = {}
-            for w in traffic:gmatch("[^\n]+") do
-                table.insert(words, w)
-            end
-            rx = words[1]
-            tx = words[2]
-            station.rx_bytes = tonumber(rx, 10)
-            station.tx_bytes = tonumber(tx, 10)
-            if station.rx_bytes > most_active_rx then
-                most_active_rx = station.rx_bytes
-                most_active = station
-            end
-        end
-        local station_traffic = limeutils.get_station_traffic({
-            iface = most_active.iface,
-            station_mac = most_active.station_mac
-        })
-        most_active.rx_bytes = station_traffic.rx_bytes
-        most_active.tx_bytes = station_traffic.tx_bytes
-        result.most_active = most_active
-    end
+    result.ips = node_status.get_ips()
+    result.most_active = node_status.get_most_active()
     result.uptime = tostring(utils.uptime_s())
-
     result.status = "ok"
     return result
 end

--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
@@ -94,7 +94,7 @@ function node_status.swconfig_get_link_status(ports)
             end
         end
     end
-    
+
     local swconfig = utils.unsafe_shell("swconfig dev switch0 show")
     local lines = {}
     for line in swconfig:gmatch("[^\r\n]+") do

--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
@@ -73,18 +73,33 @@ function node_status.get_most_active()
 end
 
 function node_status.switch_status()
+    local function add_device_to_port(ports, port_number, device)
+        for x, obj in pairs(ports) do
+            if obj.num == port_number then
+               obj["device"] = device
+            end
+        end
+    end
     local board = utils.getBoardAsTable()
-    local ports = {}
+    local response_ports = {}
     for _, port in ipairs(board['switch']['switch0']['ports']) do
         -- On tested routers, the switch directly conected to the cpu doesn't have role 
         if port['role']  then
-            table.insert(ports, { num = port['num'], role = port['role'] })
+            table.insert(response_ports, { num = port['num'], role = port['role'] })
         else
-            table.insert(ports, { num = port['num'], role = "cpu" })
+            table.insert(response_ports, { num = port['num'], role = "cpu" })
         end
     end
-    node_status.swconfig_get_link_status(ports)
-    return ports
+    for _, role in ipairs(board['switch']['switch0']['roles']) do
+        if role['ports'] and role['device'] then
+            for port_number in string.gmatch(role['ports'], "%d+") do
+                add_device_to_port(response_ports, tonumber(port_number), role['device'])
+            end
+
+        end
+    end
+    node_status.swconfig_get_link_status(response_ports)
+    return response_ports
 end
 
 

--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
@@ -51,7 +51,13 @@ function node_status.get_station_stats(station)
         string.match(iw_result, "rx bytes:%s+(.-)\n"), 10)
     station.tx_bytes = tonumber(
         string.match(iw_result, "tx bytes:%s+(.-)\n"), 10)
-    station.signal = string.match(iw_result, "signal:%s+(.-)\n")
+    local signal_str = string.match(iw_result, "signal:%s+(.-)\n")
+    local signal, chain = string.match(signal_str, "(%-?%d+)%s+%[(.-)%]")
+    station.signal = tonumber(signal)
+    station.chains = {}
+    for num in string.gmatch(chain, "%-?%d+") do
+        table.insert(station.chains, tonumber(num))
+    end
     return station
 end
 

--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
@@ -73,6 +73,12 @@ function node_status.get_most_active()
 end
 
 function node_status.switch_status()
+    local response_ports = node_status.board_get_ports()
+    node_status.swconfig_get_link_status(response_ports)
+    return response_ports
+end
+
+function node_status.boardjson_get_ports()
     local function add_device_to_port(ports, port_number, device)
         for x, obj in pairs(ports) do
             if obj.num == port_number then
@@ -98,10 +104,8 @@ function node_status.switch_status()
 
         end
     end
-    node_status.swconfig_get_link_status(response_ports)
     return response_ports
 end
-
 
 function node_status.swconfig_get_link_status(ports)
     local function add_link_status(port_number, status)

--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
@@ -1,0 +1,97 @@
+local limewireless = require 'lime.wireless'
+local iwinfo = require 'iwinfo'
+
+-- Functions used by get_node_status
+local node_status = {}
+
+function node_status.get_station_traffic(params)
+    local iface = params.iface
+    local mac = params.station_mac
+    local result = {}
+    local traffic = utils.unsafe_shell(
+                        "iw " .. iface .. " station get " .. mac ..
+                            " | grep bytes | awk '{ print $3}'")
+    local words = {}
+    for w in traffic:gmatch("[^\n]+") do table.insert(words, w) end
+    local rx = words[1]
+    local tx = words[2]
+    result.station = mac
+    result.rx_bytes = tonumber(rx, 10)
+    result.tx_bytes = tonumber(tx, 10)
+    result.status = "ok"
+    return result
+end
+
+function node_status.get_ips()
+    local res = {}
+    local ips = utils.unsafe_shell(
+                    "ip a s br-lan | grep inet | awk '{ print $1, $2 }'")
+    for line in ips:gmatch("[^\n]+") do
+        local words = {}
+        for w in line:gmatch("%S+") do
+            if w ~= "" then table.insert(words, w) end
+        end
+        local version = words[1]
+        local address = words[2]
+        if version == "inet6" then
+            table.insert(res, {version = "6", address = address})
+        else
+            table.insert(res, {version = "4", address = address})
+        end
+    end
+    return res
+end
+
+function node_status.get_stations()
+    local res = {}
+    local ifaces = limewireless.mesh_ifaces()
+    for _, iface in ipairs(ifaces) do
+        local iface_type = iwinfo.type(iface)
+        local iface_stations = iface_type and iwinfo[iface_type].assoclist(iface)
+        if iface_stations then
+            for mac, station in pairs(iface_stations) do
+                station['iface'] = iface
+                station.station_mac = mac
+                table.insert(res, station)
+            end
+        end
+    end
+    return res
+end
+
+function node_status.get_most_active()
+    local res = {}
+    local stations = node_status.get_stations()
+    if next(stations) ~= nil then
+        local most_active_rx = 0
+        local most_active = nil
+        for _, station in ipairs(stations) do
+            local traffic = utils.unsafe_shell(
+                                "iw " .. station.iface .. " station get " ..
+                                    station.station_mac ..
+                                    " | grep bytes | awk '{ print $3}'")
+            local words = {}
+            for w in traffic:gmatch("[^\n]+") do
+                table.insert(words, w)
+            end
+            local rx = words[1]
+            local tx = words[2]
+            station.rx_bytes = tonumber(rx, 10)
+            station.tx_bytes = tonumber(tx, 10)
+            if station.rx_bytes > most_active_rx then
+                most_active_rx = station.rx_bytes
+                most_active = station
+            end
+        end
+        local station_traffic = node_status.get_station_traffic({
+            iface = most_active.iface,
+            station_mac = most_active.station_mac
+        })
+        most_active.rx_bytes = station_traffic.rx_bytes
+        most_active.tx_bytes = station_traffic.tx_bytes
+        res = most_active
+    end
+    return res
+end
+
+return node_status

--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
@@ -50,7 +50,7 @@ function node_status.get_station_stats(station)
     station.rx_bytes = tonumber(
         string.match(iw_result, "rx bytes:%s+(.-)\n"), 10)
     station.tx_bytes = tonumber(
-        string.match(iw_result, "rx bytes:%s+(.-)\n"), 10)
+        string.match(iw_result, "tx bytes:%s+(.-)\n"), 10)
     station.signal = string.match(iw_result, "signal:%s+(.-)\n")
     return station
 end
@@ -71,6 +71,5 @@ function node_status.get_most_active()
     end
     return res
 end
-
 
 return node_status

--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
@@ -125,3 +125,4 @@ function node_status.swconfig_get_link_status(ports)
 end
 
 return node_status
+

--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
@@ -76,11 +76,9 @@ function node_status.switch_status()
     local board = utils.getBoardAsTable()
     local ports = {}
     for _, port in ipairs(board['switch']['switch0']['ports']) do
-        -- todo(kon): check the only one without role is the 0, connected to the 
-        -- cpu one also in librerouters.
-        -- And see if this helps also https://github.com/libremesh/lime-packages/blob/master/packages/lime-system/files/usr/lib/lua/lime/network.lua#L265
+        -- On tested routers, the switch directly conected to the cpu doesn't have role 
         if port['role'] then
-            ports[port['num']] = { num = port['num'], role = port['role'] }
+            table.insert(ports, { num = port['num'], role = port['role'] })
         end
     end
     node_status.swconfig_get_link_status(ports)
@@ -96,6 +94,7 @@ function node_status.swconfig_get_link_status(ports)
             end
         end
     end
+    
     local swconfig = utils.unsafe_shell("swconfig dev switch0 show")
     local lines = {}
     for line in swconfig:gmatch("[^\r\n]+") do

--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
@@ -77,8 +77,10 @@ function node_status.switch_status()
     local ports = {}
     for _, port in ipairs(board['switch']['switch0']['ports']) do
         -- On tested routers, the switch directly conected to the cpu doesn't have role 
-        if port['role'] then
+        if port['role']  then
             table.insert(ports, { num = port['num'], role = port['role'] })
+        else
+            table.insert(ports, { num = port['num'], role = "cpu" })
         end
     end
     node_status.swconfig_get_link_status(ports)

--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
@@ -74,23 +74,27 @@ end
 
 function node_status.switch_status()
     local response_ports = node_status.boardjson_get_ports()
-    node_status.swconfig_get_link_status(response_ports)
+    if #response_ports ~= 0 then
+        node_status.swconfig_get_link_status(response_ports)
+    end
     return response_ports
 end
 
 function node_status.boardjson_get_ports()
     local response_ports = {}
     local board = utils.getBoardAsTable()
-    for _, role in ipairs(board['switch']['switch0']['roles']) do
-        for port_number in string.gmatch(role['ports'], "%S+") do
-            if not tonumber(port_number) then
-                local n = tonumber(string.match(port_number, "^%d+"))
-                table.insert(response_ports, { num = n, role = "cpu", device = role['device']})
-            else
-                table.insert(response_ports, { num = tonumber(port_number), role = role['role'], device = role['device']})
+    if board['switch'] ~= nil and board['switch']['switch0'] ~= nil then
+        for _, role in ipairs(board['switch']['switch0']['roles']) do
+            for port_number in string.gmatch(role['ports'], "%S+") do
+                if not tonumber(port_number) then
+                    local n = tonumber(string.match(port_number, "^%d+"))
+                    table.insert(response_ports, { num = n, role = "cpu", device = role['device']})
+                else
+                    table.insert(response_ports, { num = tonumber(port_number), role = role['role'], device = role['device']})
+                end
             end
-        end
 
+        end
     end
     return response_ports
 end

--- a/packages/ubus-lime-utils/tests/test_ubus_lime_utils.lua
+++ b/packages/ubus-lime-utils/tests/test_ubus_lime_utils.lua
@@ -458,3 +458,4 @@ mocks.switch_status_result = [[
     }
   ]
 ]]
+

--- a/packages/ubus-lime-utils/tests/test_ubus_lime_utils.lua
+++ b/packages/ubus-lime-utils/tests/test_ubus_lime_utils.lua
@@ -3,9 +3,12 @@ local test_utils = require "tests.utils"
 local hotspot_wwan = require 'lime.hotspot_wwan'
 local limeutils = require "lime-utils"
 local json = require 'luci.jsonc'
+local node_status = require 'lime.node_status'
 
 local uci
 local snapshot -- to revert luassert stubs and spies
+
+local mocks = {}
 
 describe('ubus-lime-utils tests #ubuslimeutils', function()
 
@@ -51,6 +54,23 @@ describe('ubus-lime-utils tests #ubuslimeutils', function()
         assert.is.equal("123", response.uptime)
     end)
 
+
+    it('test get_most_active return most active iface with stats from iw', function()
+        stub(utils, "unsafe_shell", function (cmd) 
+            if string.match(cmd, "wlan0") then 
+                return mocks.iw_station_get_result_wlan0
+            end
+            return mocks.iw_station_get_result_wlan1
+        end
+        )
+        stub(node_status, "get_stations", function () return mocks.get_stations end)
+        local most_active = node_status.get_most_active()
+        assert.is.equal("wlan0-mesh", most_active["iface"])
+        assert.is.equal("13 [10, 11] dBm", most_active["signal"])
+        assert.is.equal(3116498, most_active["rx_bytes"])
+        assert.is.equal(1166333, most_active["tx_bytes"])
+    end)
+
     it('test get_upgrade_info', function()
         stub(utils, "unsafe_shell", function () return '-1' end)
         stub(os, "execute", function () return '0' end)
@@ -94,3 +114,130 @@ describe('ubus-lime-utils tests #ubuslimeutils', function()
         test_utils.teardown_test_uci(uci)
     end)
 end)
+
+
+mocks.iw_station_get_result_wlan1 = [[
+Station c0:4a:00:be:7b:0a (on wlan1-mesh)
+    inactive time:  50 ms
+    rx bytes:  503044
+    rx packets:  3976
+    tx bytes:  545116
+    tx packets:  1237
+    tx retries:  9
+    tx failed:  0
+    rx drop misc:  3
+    signal:    -14 [-17, -16] dBm
+    signal avg:  -12 [-14, -15] dBm
+    Toffset:  46408315 us
+    tx bitrate:  300.0 MBit/s MCS 15 40MHz short GI
+    rx bitrate:  300.0 MBit/s MCS 15 40MHz short GI
+    rx duration:  0 us
+    expected throughput:  58.43Mbps
+    mesh llid:  5944
+    mesh plid:  1241
+    mesh plink:  ESTAB
+    mesh local PS mode:  ACTIVE
+    mesh peer PS mode:  ACTIVE
+    mesh non-peer PS mode:  ACTIVE
+    authorized:  yes
+    authenticated:  yes
+    associated:  yes
+    preamble:  long
+    WMM/WME:  yes
+    MFP:    no
+    TDLS peer:  no
+    DTIM period:  2
+    beacon interval:100
+    short slot time:yes
+    connected time:  139 seconds
+]]
+
+
+mocks.iw_station_get_result_wlan0 = [[
+    Station c0:4a:00:be:7b:09 (on wlan0-mesh)
+	inactive time:	140 ms
+	rx bytes:	3116498
+	rx packets:	31613
+	tx bytes:	1166333
+	tx packets:	4462
+	tx retries:	2448
+	tx failed:	15
+	rx drop misc:	938
+	signal:  	13 [10, 11] dBm
+	signal avg:	25 [-28, -15] dBm
+	Toffset:	18446744073577465064 us
+	tx bitrate:	6.5 MBit/s MCS 0
+	rx bitrate:	39.0 MBit/s MCS 10
+	rx duration:	0 us
+	expected throughput:	2.197Mbps
+	mesh llid:	63041
+	mesh plid:	61249
+	mesh plink:	ESTAB
+	mesh local PS mode:	ACTIVE
+	mesh peer PS mode:	ACTIVE
+	mesh non-peer PS mode:	ACTIVE
+	authorized:	yes
+	authenticated:	yes
+	associated:	yes
+	preamble:	long
+	WMM/WME:	yes
+	MFP:		no
+	TDLS peer:	no
+	DTIM period:	2
+	beacon interval:100
+	short slot time:yes
+	connected time:	5070 seconds
+]]
+
+
+
+mocks.get_stations = {
+    [1] = {
+        ["rx_short_gi"] = false,
+        ["station_mac"] = "C0:4A:00:BE:7B:09",
+        ["rx_vht"] = false,
+        ["rx_mhz"] = 20,
+        ["rx_40mhz"] = false,
+        ["tx_packets"] = 1574,
+        ["tx_mhz"] = 20,
+        ["rx_packets"] = 16879,
+        ["rx_ht"] = true,
+        ["tx_mcs"] = 9,
+        ["noise"] = -95,
+        ["rx_mcs"] = 1,
+        ["tx_ht"] = true,
+        ["iface"] = "wlan0-mesh",
+        ["tx_rate"] = 26000,
+        ["inactive"] = 1390,
+        ["tx_short_gi"] = false,
+        ["tx_40mhz"] = false,
+        ["expected_throughput"] = 11437,
+        ["tx_vht"] = false,
+        ["rx_rate"] = 13000,
+        ["signal"] = 13
+      },
+    [2] = {
+        ["rx_short_gi"] = true,
+        ["station_mac"] = "C0:4A:00:BE:7B:0A",
+        ["rx_vht"] = false,
+        ["rx_mhz"] = 40,
+        ["rx_40mhz"] = true,
+        ["tx_packets"] = 7078,
+        ["tx_mhz"] = 40,
+        ["rx_packets"] = 54294,
+        ["rx_ht"] = true,
+        ["tx_mcs"] = 15,
+        ["noise"] = -91,
+        ["rx_mcs"] = 15,
+        ["tx_ht"] = true,
+        ["iface"] = "wlan1-mesh",
+        ["tx_rate"] = 300000,
+        ["inactive"] = 70,
+        ["tx_short_gi"] = true,
+        ["tx_40mhz"] = true,
+        ["expected_throughput"] = 59437,
+        ["tx_vht"] = false,
+        ["rx_rate"] = 300000,
+        ["signal"] = -13
+      }
+}

--- a/packages/ubus-lime-utils/tests/test_ubus_lime_utils.lua
+++ b/packages/ubus-lime-utils/tests/test_ubus_lime_utils.lua
@@ -82,7 +82,9 @@ describe('ubus-lime-utils tests #ubuslimeutils', function()
         stub(node_status, "get_stations", function () return mocks.get_stations end)
         local most_active = node_status.get_most_active()
         assert.is.equal("wlan0-mesh", most_active["iface"])
-        assert.is.equal("13 [10, 11] dBm", most_active["signal"])
+        assert.is.equal(-14, most_active["signal"])
+        assert.is.equal(-17, most_active["chains"][1])
+        assert.is.equal(-18, most_active["chains"][2])
         assert.is.equal(3116498, most_active["rx_bytes"])
         assert.is.equal(1166333, most_active["tx_bytes"])
     end)
@@ -179,8 +181,8 @@ mocks.iw_station_get_result_wlan0 = [[
 	tx retries:	2448
 	tx failed:	15
 	rx drop misc:	938
-	signal:  	13 [10, 11] dBm
-	signal avg:	25 [-28, -15] dBm
+	signal:  	-14 [-17, -18] dBm
+	signal avg:	-14 [-17, -18] dBm
 	Toffset:	18446744073577465064 us
 	tx bitrate:	6.5 MBit/s MCS 0
 	rx bitrate:	39.0 MBit/s MCS 10


### PR DESCRIPTION
Improve get node status results with following improvements:

- Split and refactor the code to be more atomic and redeable
- Add chain information to the result:

```json
"signal":  -14,
"chains": [
    -17,
    -16
],
```
- It also add information of the switch status (port, role, interface and link up or down). 

To get the switch status it combine the parsing of `/etc/board.json` to get the roles and `swconfig dev switch0 show` to get if they are up or not. The switches connected directly yo the cpu doesn't have a role attribute on the `/etc/board.json` so they are discarded. 

Using `ubus call lime-utils get_node_status '{}'`

```json
{
	"ips": [
		{
			"version": "4",
			"address": "10.219.123.10/16"
		},
		{
			"version": "6",
			"address": "fddb:f81c:47ba::a7b:be00/64"
		},
		{
			"version": "6",
			"address": "fe80::c24a:ff:febe:7b0a/64"
		}
	],
	"hostname": "lapastoramesh-c",
	"switch_status": [
		{
			"device": "eth0.1",
			"num": 2,
			"role": "lan",
			"link": "up"
		},
		{
			"device": "eth0.1",
			"num": 3,
			"role": "lan",
			"link": "down"
		},
		{
			"device": "eth0.1",
			"num": 4,
			"role": "lan",
			"link": "down"
		},
		{
			"device": "eth0.1",
			"num": 5,
			"role": "lan",
			"link": "down"
		},
		{
			"device": "eth0.1",
			"num": 0,
			"role": "cpu",
			"link": "up"
		},
		{
			"device": "eth0.2",
			"num": 1,
			"role": "wan",
			"link": "down"
		},
		{
			"device": "eth0.2",
			"num": 0,
			"role": "cpu",
			"link": "up"
		}
	],
	"status": "ok",
	"uptime": "3186.15",
	"most_active": {
		"rx_short_gi": true,
		"station_mac": "C0:4A:00:DD:69:1C",
		"tx_bytes": 13809119,
		"rx_vht": false,
		"rx_mhz": 40,
		"rx_40mhz": true,
		"tx_packets": 31706,
		"tx_mhz": 40,
		"rx_packets": 97813,
		"rx_ht": true,
		"tx_mcs": 15,
		"noise": -90,
		"rx_mcs": 15,
		"chains": [
			-17,
			-16
		],
		"rx_bytes": 19464143,
		"tx_ht": true,
		"iface": "wlan1-mesh",
		"tx_rate": 300000,
		"inactive": 30,
		"tx_short_gi": true,
		"tx_40mhz": true,
		"expected_throughput": 59437,
		"tx_vht": false,
		"rx_rate": 300000,
		"signal": -14
	}
}
```