### PR TITLE
Expose get_loss

### DIFF
--- a/packages/ubus-lime-metrics/files/usr/lib/lua/lime-metrics.lua
+++ b/packages/ubus-lime-metrics/files/usr/lib/lua/lime-metrics.lua
@@ -35,6 +35,22 @@ function metrics.get_metrics(target)
     return result
 end
 
+function metrics.get_loss(target)
+    local result = {}
+    local node = target
+    local loss = nil
+
+    if lutils.is_installed("lime-proto-babeld") then
+        loss = utils.get_loss(node, 4)
+    else
+        return {status="error", error={msg="No lime-proto-babeld found", code="1"}}
+    end
+    result.loss = loss
+    result.status = "ok"
+    return result
+end
+
+
 function metrics.get_gateway()
     local result = {}
     local gw = nil

--- a/packages/ubus-lime-metrics/files/usr/libexec/rpcd/lime-metrics
+++ b/packages/ubus-lime-metrics/files/usr/libexec/rpcd/lime-metrics
@@ -24,6 +24,11 @@ local function get_metrics(msg)
     utils.printJson(result)
 end
 
+local function get_loss(msg)
+    local result = metrics.get_loss(msg.target)
+    utils.printJson(result)
+end
+
 local function get_gateway(msg)
     utils.printJson(metrics.get_gateway())
 end
@@ -42,6 +47,7 @@ end
 
 local methods = {
 	get_metrics = { target = 'value' },
+	get_loss = { target = 'value' },
     get_gateway = { no_params = 0 },
     get_path = { target = 'value' },
     get_last_internet_path = { no_params = 0 },
@@ -57,6 +63,7 @@ if arg[1] == 'call' then
     local msg = io.read()
     msg = json.parse(msg)
     if       arg[2] == 'get_metrics'            then get_metrics(msg)
+    elseif   arg[2] == 'get_loss'               then get_loss(msg)
     elseif   arg[2] == 'get_gateway'            then get_gateway(msg)
     elseif   arg[2] == 'get_path'               then get_path(msg)
     elseif   arg[2] == 'get_last_internet_path' then get_path(msg)


### PR DESCRIPTION
It expose the get_loss function for IPv4 ips. It will be used to do diagnosis of where the last internet path is broken, from the frontend on the new landing page. It just return ping loose to specific ip, example:

```bash
ubus call lime-metrics get_loss '{"target" : "1.1.1.4"}'
{
	"status": "ok",
	"loss": "0"
}
```