### PR TITLE
dnsmasq move confdir setting for ujail, avoiding to fix batman-adv-auto-gw-mode

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -154,11 +154,11 @@ function network.setup_dns()
 			uci:set("dhcp", s[".name"], "expandhosts", "1")
 			uci:set("dhcp", s[".name"], "domainneeded", "1")
 			uci:set("dhcp", s[".name"], "server", resolvers)
+			uci:set("dhcp", s[".name"], "confdir", "/etc/dnsmasq.d")
 		end
 	)
 	uci:save("dhcp")
 
-	fs.writefile("/etc/dnsmasq.conf", "conf-dir=/etc/dnsmasq.d\n")
 	fs.mkdir("/etc/dnsmasq.d")
 end
 


### PR DESCRIPTION
Fix #970

This is identical to #971 but without the commits that would be needed for fixing batman-adv-auto-gw-mode.

batman-adv-auto-gw-mode is severely outdated and will likely be archived, see #977

Please consider merging.