### PR TITLE
shared-state check for babeld file existence before reading it

### DIFF
--- a/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
+++ b/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
@@ -47,7 +47,7 @@ for iface in $(ls /sys/class/net/) ; do
 		awk '{if ($3 == "from") print substr($4, 1, length($4)-1)'"\"%${iface}\""'}'
 done | sort -u -r)"
 
-babelCandidateAddresses="$(
+babelCandidateAddresses="$([ -e /var/etc/babeld.conf ] &&
 for iface in $(grep interface /var/etc/babeld.conf | awk '{print $2}'); do
 	ping6 -i 0.1 -c 2 ff02::1%${iface} 2> /dev/null | \
 		awk '{if ($3 == "from") print substr($4, 1, length($4)-1)'"\"%${iface}\""'}'


### PR DESCRIPTION
When installing shared-state without Babeld, the following error appears every time shared-state is used:

```
# shared-state sync dnsmasq-hosts
grep: /var/etc/babeld.conf: No such file or directory
```

I tested the proposed change and executes the code only if that file is present.

Tell me if you prefer I open also an issue on this.
