### PR TITLE
shared-state get neigh avoid outputting empty lines

### DIFF
--- a/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
+++ b/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
@@ -91,5 +91,5 @@ $(echo "$candidateAddresses" | grep -v "$cIp")"
 
 done
 
-echo "$candidateAddresses" | tee "$cacheFile"
+echo "$candidateAddresses" | grep -v "^$" | tee "$cacheFile"
 get_uptime > "$lastRunFile"


### PR DESCRIPTION
This removes the empty lines from the output of `shared-state-get_candidates_neigh` so that shared-state does not try to contact empty addresses (that causes the error shown below).

```
# shared-state-get_candidates_neigh 

# shared-state sync dnsmasq-hosts
Failed to send request: Operation not permitted
```