### PR TITLE
Added CNAME for Github Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+libremesh.org


### PR DESCRIPTION
The CNAME file is needed for having Github Pages answering to `libremesh.org`.
Maybe this will not be enough for copying the CNAME file to the gh-pages branch, in that case we will have to specify this in the `_config.yml` file. On this possile issue see https://github.com/criptowiki/criptowiki/issues/15