### PR TITLE
lime-proto-babeld: enable ubus bindings

### DIFF
--- a/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
+++ b/packages/lime-proto-babeld/files/usr/lib/lua/lime/proto/babeld.lua
@@ -42,6 +42,7 @@ function babeld.configure(args)
 
 	uci:set("babeld", "general", "general")
 	uci:set("babeld", "general", "local_port", "30003")
+	uci:set("babeld", "general", "ubus_bindings", "true")
 
 	uci:set("babeld", "ula6", "filter")
 	uci:set("babeld", "ula6", "type", "redistribute")


### PR DESCRIPTION
Makes it easier to debug and allows the usage of luci-app-babeld