### PR TITLE
Adding the random-numgen command and use it for removing usage of $RANDOM

### DIFF
--- a/packages/check-date-http/Makefile
+++ b/packages/check-date-http/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+libuci-lua +lua \
+	DEPENDS:=+libuci-lua +lua +random-numgen \
 		+luci-lib-httpclient
 	PKGARCH:=all
 endef

--- a/packages/check-date-http/Makefile
+++ b/packages/check-date-http/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +libuci-lua +lua \
+	DEPENDS:=+libuci-lua +lua \
 		+luci-lib-httpclient
 	PKGARCH:=all
 endef

--- a/packages/check-date-http/files/etc/uci-defaults/check-date-http-cron
+++ b/packages/check-date-http/files/etc/uci-defaults/check-date-http-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/20 * * * * ((sleep $(($RANDOM % 600)); check-date-http &> /dev/null)&)'\
+	'*/20 * * * * ((sleep $(($(random-numgen) % 600)); check-date-http &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/eupgrade/Makefile
+++ b/packages/eupgrade/Makefile
@@ -11,7 +11,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=Utilities
   TITLE:=$(PKG_NAME) provides semi automated firmware upgrades
   MAINTAINER:=Santiago Piccinini <spiccinini@altermundi.net>
-  DEPENDS:=+lua +lime-system +luci-lib-jsonc +luci-lib-nixio +libubus-lua +libuci-lua
+  DEPENDS:=+lua +lime-system +luci-lib-jsonc +luci-lib-nixio +libubus-lua +libuci-lua +random-numgen
   PKGARCH:=all
 endef
 

--- a/packages/eupgrade/files/etc/uci-defaults/99-eupgrades-cron
+++ b/packages/eupgrade/files/etc/uci-defaults/99-eupgrades-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'0 */6 * * * ((sleep $(($RANDOM % 120)); eupgrade-check &> /dev/null)&)'\
+	'0 */6 * * * ((sleep $(($(random-numgen) % 120)); eupgrade-check &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/hotplug-initd-services/Makefile
+++ b/packages/hotplug-initd-services/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+libubox-lua +libubus-lua \
+	DEPENDS:=+libubox-lua +libubus-lua +random-numgen \
 		+lua +luci-lib-nixio
 	PKGARCH:=all
 endef

--- a/packages/hotplug-initd-services/Makefile
+++ b/packages/hotplug-initd-services/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +libubox-lua +libubus-lua \
+	DEPENDS:=+libubox-lua +libubus-lua \
 		+lua +luci-lib-nixio
 	PKGARCH:=all
 endef

--- a/packages/random-numgen/Makefile
+++ b/packages/random-numgen/Makefile
@@ -1,0 +1,39 @@
+# This is free software, licensed under the GNU General Public License v3.
+# See /LICENSES for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=random-numgen
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Ilario Gelmetti <ilario@sindominio.net>
+PKG_LICENSE:=GPL-3.0-or-later
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/random-numgen
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Generates a random number 0-65535
+endef
+
+define Package/random-numgen/description
+  Offers an alternative to the RANDOM shell variable,
+  generating a pseudo-random integer number from 0 to
+  65535 using /dev/urandom as a random data source.
+endef
+
+define Build/Compile
+endef
+
+define Build/Configure
+endef
+
+define Package/random-numgen/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) ./files/random-numgen $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,random-numgen))

--- a/packages/random-numgen/files/random-numgen
+++ b/packages/random-numgen/files/random-numgen
@@ -1,0 +1,7 @@
+#!/bin/sh
+#
+# Offers an alternative to the $RANDOM shell variable,
+# generating a pseudo-random integer number from 0 to
+# 32767 using /dev/urandom as a random data source.
+
+echo $(( $(hexdump -n 2 -e '"%u"' /dev/urandom) >> 1 ))

--- a/packages/shared-state-babeld_hosts/Makefile
+++ b/packages/shared-state-babeld_hosts/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +hotplug-initd-services \
+	DEPENDS:=+hotplug-initd-services \
 		+lua +luci-lib-jsonc shared-state
 	PKGARCH:=all
 endef

--- a/packages/shared-state-babeld_hosts/Makefile
+++ b/packages/shared-state-babeld_hosts/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+hotplug-initd-services \
+	DEPENDS:=+hotplug-initd-services +random-numgen \
 		+lua +luci-lib-jsonc shared-state
 	PKGARCH:=all
 endef

--- a/packages/shared-state-babeld_hosts/files/etc/uci-defaults/shared-state-babeld_hosts-cron
+++ b/packages/shared-state-babeld_hosts/files/etc/uci-defaults/shared-state-babeld_hosts-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync babeld-hosts &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state sync babeld-hosts &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-bat_hosts/Makefile
+++ b/packages/shared-state-bat_hosts/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +lua +luci-lib-jsonc \
+	DEPENDS:=+lua +luci-lib-jsonc \
 		shared-state +lime-system +luci-lib-nixio +libubus-lua
 	PKGARCH:=all
 endef

--- a/packages/shared-state-bat_hosts/Makefile
+++ b/packages/shared-state-bat_hosts/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc \
+	DEPENDS:=+lua +luci-lib-jsonc +random-numgen \
 		shared-state +lime-system +luci-lib-nixio +libubus-lua
 	PKGARCH:=all
 endef

--- a/packages/shared-state-bat_hosts/files/etc/uci-defaults/shared-state-bat_hosts-cron
+++ b/packages/shared-state-bat_hosts/files/etc/uci-defaults/shared-state-bat_hosts-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync bat-hosts &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state sync bat-hosts &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-dnsmasq_hosts/Makefile
+++ b/packages/shared-state-dnsmasq_hosts/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc \
+	DEPENDS:=+lua +luci-lib-jsonc +random-numgen \
 		shared-state
 	PKGARCH:=all
 endef

--- a/packages/shared-state-dnsmasq_hosts/Makefile
+++ b/packages/shared-state-dnsmasq_hosts/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +lua +luci-lib-jsonc \
+	DEPENDS:=+lua +luci-lib-jsonc \
 		shared-state
 	PKGARCH:=all
 endef

--- a/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
+++ b/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-hosts &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state sync dnsmasq-hosts &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-dnsmasq_leases/Makefile
+++ b/packages/shared-state-dnsmasq_leases/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+libuci-lua +lua \
+	DEPENDS:=+libuci-lua +lua +random-numgen \
 		+luci-lib-jsonc shared-state +shared-state-dnsmasq_hosts \
 		+luci-lib-nixio
 	PKGARCH:=all

--- a/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
+++ b/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
@@ -12,7 +12,7 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-leases &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state sync dnsmasq-leases &> /dev/null)&)'\
 	/etc/crontabs/root
 
 exit 0

--- a/packages/shared-state-dnsmasq_servers/Makefile
+++ b/packages/shared-state-dnsmasq_servers/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LiMe
 	MAINTAINER:=Gui iribarren <gui@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +lua +luci-lib-jsonc \
+	DEPENDS:=+lua +luci-lib-jsonc \
 		shared-state
 	PKGARCH:=all
 endef

--- a/packages/shared-state-dnsmasq_servers/Makefile
+++ b/packages/shared-state-dnsmasq_servers/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LiMe
 	MAINTAINER:=Gui iribarren <gui@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc \
+	DEPENDS:=+lua +luci-lib-jsonc +random-numgen \
 		shared-state
 	PKGARCH:=all
 endef

--- a/packages/shared-state-dnsmasq_servers/files/etc/uci-defaults/shared-state-dnsmasq_servers
+++ b/packages/shared-state-dnsmasq_servers/files/etc/uci-defaults/shared-state-dnsmasq_servers
@@ -9,5 +9,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-servers &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state sync dnsmasq-servers &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-network_nodes/Makefile
+++ b/packages/shared-state-network_nodes/Makefile
@@ -12,7 +12,7 @@ define Package/$(PKG_NAME)
   TITLE:=$(PKG_NAME) provides shared state database of all times network nodes
   MAINTAINER:=Germán Ferrero <germanferrero@altermundi.net>
   DEPENDS:=+shared-state +shared-state-nodes_and_links +lime-system +luci-lib-jsonc \
-	   +libubus-lua
+	   +libubus-lua +random-numgen
   PKGARCH:=all
 endef
 

--- a/packages/shared-state-network_nodes/files/etc/uci-defaults/shared-state-network_nodes-cron
+++ b/packages/shared-state-network_nodes/files/etc/uci-defaults/shared-state-network_nodes-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state-multiwriter sync network_nodes &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state-multiwriter sync network_nodes &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-nodes_and_links/Makefile
+++ b/packages/shared-state-nodes_and_links/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Nicolas Pace <nico@libre.ws>
 	URL:=http://libremesh.org
-	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +lua +luci-lib-jsonc \
+	DEPENDS:=+lua +luci-lib-jsonc \
 		shared-state +ubus-lime-location
 	PKGARCH:=all
 endef

--- a/packages/shared-state-nodes_and_links/Makefile
+++ b/packages/shared-state-nodes_and_links/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Nicolas Pace <nico@libre.ws>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc \
+	DEPENDS:=+lua +luci-lib-jsonc +random-numgen \
 		shared-state +ubus-lime-location
 	PKGARCH:=all
 endef

--- a/packages/shared-state-nodes_and_links/files/etc/uci-defaults/shared-state-bat_nodes_and_links
+++ b/packages/shared-state-nodes_and_links/files/etc/uci-defaults/shared-state-bat_nodes_and_links
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync nodes_and_links &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state sync nodes_and_links &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-pirania/Makefile
+++ b/packages/shared-state-pirania/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Marcos Gutierrez <gmacos@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc \
+	DEPENDS:=+lua +luci-lib-jsonc +random-numgen \
 		shared-state +pirania
 	PKGARCH:=all
 endef

--- a/packages/shared-state-pirania/Makefile
+++ b/packages/shared-state-pirania/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Marcos Gutierrez <gmacos@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+@BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT +lua +luci-lib-jsonc \
+	DEPENDS:=+lua +luci-lib-jsonc \
 		shared-state +pirania
 	PKGARCH:=all
 endef

--- a/packages/shared-state-pirania/files/etc/uci-defaults/90-pirania-cron
+++ b/packages/shared-state-pirania/files/etc/uci-defaults/90-pirania-cron
@@ -6,7 +6,7 @@ unique_append()
 }
 
 unique_append \
-	'*/2 * * * * ((sleep $(($RANDOM % 30)); /etc/shared-state/publishers/shared-state-publish_vouchers && shared-state sync pirania-vouchers &> /dev/null)&)'\
+	'*/2 * * * * ((sleep $(($(random-numgen) % 30)); /etc/shared-state/publishers/shared-state-publish_vouchers && shared-state sync pirania-vouchers &> /dev/null)&)'\
 	/etc/crontabs/root
 
 exit 0

--- a/packages/shared-state/Makefile
+++ b/packages/shared-state/Makefile
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=+libuci-lua +lime-system +lua +luci-lib-jsonc +luci-lib-nixio \
-		+$(PING6_PACKAGE) +uclient-fetch
+		+$(PING6_PACKAGE) +uclient-fetch +random-numgen
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state/files/etc/uci-defaults/shared-state-publishers-cron
+++ b/packages/shared-state/files/etc/uci-defaults/shared-state-publishers-cron
@@ -6,7 +6,7 @@ unique_append()
 }
 
 unique_append \
-	'*/30 * * * * ((sleep $(($RANDOM % 1000)); shared-state-publish-all &> /dev/null)&)'\
+	'*/30 * * * * ((sleep $(($(random-numgen) % 1000)); shared-state-publish-all &> /dev/null)&)'\
 	/etc/crontabs/root
 
 unique_append \


### PR DESCRIPTION
Fix #800 
Replaces the (other half of) #980 

When https://github.com/openwrt/packages/pull/20728 will be included in openwrt-22.03, the package will need to be removed from lime-packages repository.

