### PR TITLE
Split network.lua's owrt_ifname_parser

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -272,12 +272,14 @@ function network.scandevices()
 			           ifn )
 			dev_parser(ifn)
 		end
-		if ( type(ifn) == "table" ) then
-			for _,v in pairs(ifn) do
-				utils.log( "network.scandevices.owrt_ifname_parser found " ..
-				           "ifname %s in compound interface", v )
-				dev_parser(v)
-			end
+	end
+
+	function owrt_network_interface_parser(section)
+		local ifn = section["device"]
+		if ( type(ifn) == "string" ) then
+			utils.log( "network.scandevices.owrt_network_interface_parser found ifname %s",
+			           ifn )
+			dev_parser(ifn)
 		end
 	end
 
@@ -321,7 +323,7 @@ function network.scandevices()
 	uci:foreach("wireless", "wifi-iface", owrt_ifname_parser)
 
 	--! Scrape from uci network
-	uci:foreach("network", "interface", owrt_ifname_parser)
+	uci:foreach("network", "interface", owrt_network_interface_parser)
 	uci:foreach("network", "device", owrt_device_parser)
 	uci:foreach("network", "switch_vlan", owrt_switch_vlan_parser)
 


### PR DESCRIPTION
From OpenWrt 19.07 to 21.02, the content of `/etc/config/wireless` did not change (except #997) but the content of interfaces and devices in `/etc/config/network` changed significantly.

Inside lime-system's network.lua, the owrt_ifname_parser was used both for parsing `wifi-iface` from  `/etc/config/wireless` and for `interface` from `/etc/config/network`.

In this yet-to-be-tested code, I added a new section for probing only the interfaces from `/etc/config/networks`.

Also, I removed the "compound interface" code from owrt_ifname_parser as I suppose this was needed for br-lan, that now passed from being an `interface` to a `device` and so is taken care by owrt_device_parser.