### PR TITLE
shared-state-dnsmasq_servers correct serversfile option setting

### DIFF
--- a/packages/shared-state-dnsmasq_servers/files/etc/uci-defaults/shared-state-dnsmasq_servers
+++ b/packages/shared-state-dnsmasq_servers/files/etc/uci-defaults/shared-state-dnsmasq_servers
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # dnsmasq upon SIGHUP will re-read this file containing "server=/example.com/1.2.3.4" lines
-echo "servers-file=/var/shared-state/dnsmasq_servers" > "/etc/dnsmasq.d/shared-state-dnsmasq_servers.conf"
+uci set dhcp.@dnsmasq[0].serversfile=/var/shared-state/dnsmasq_servers
+uci commit dhcp
 
 unique_append()
 {


### PR DESCRIPTION
Fix one of the two still existing errors from this issue: https://github.com/libremesh/lime-packages/issues/970#issuecomment-1490091329

If the option gets set out of UCI, then ujail forbids the access to the `/var/shared-state/dnsmasq_servers` file, resulting in a `No such file or directory` error.