### PR TITLE
Added a few commands to lime-report

### DIFF
--- a/packages/lime-report/files/lime-report.sh
+++ b/packages/lime-report/files/lime-report.sh
@@ -55,6 +55,7 @@ generate_status() {
     paste_cmd ip link show
     paste_cmd df
     paste_cmd logread -l 20
+    paste_cmd "logread | grep err"
     paste_cmd iw dev wlan0-mesh station dump
     paste_cmd iw dev wlan1-mesh station dump
     paste_cmd iw dev wlan2-mesh station dump

--- a/packages/lime-report/files/lime-report.sh
+++ b/packages/lime-report/files/lime-report.sh
@@ -43,6 +43,10 @@ generate_status() {
     paste_cmd bmx6 -c show=status show=interfaces show=links show=originators show=tunnels
     paste_cmd bmx7 -c show=status show=interfaces show=links show=originators show=tunnels
     paste_cmd "echo dump | nc ::1 30003"
+    paste_cmd ubus call babeld get_info
+    paste_cmd ubus call babeld get_neighbours
+    paste_cmd ubus call babeld get_xroutes
+    paste_cmd ubus call babeld get_routes
     paste_cmd free
     paste_cmd ps
     paste_cmd ip address show


### PR DESCRIPTION
The ubus bindings for Babeld have been activated in #987 
https://openwrt.org/docs/guide-user/services/babeld#ubus_bindings

The old `echo dump | nc ::1 30003` command has an additional output regarding the included interfaces, that I could not get from ubus, so I did not remove it.

Also, the errors from logread are included.