### PR TITLE
lime-debug added iperf3 and jq

### DIFF
--- a/packages/lime-debug/Makefile
+++ b/packages/lime-debug/Makefile
@@ -27,7 +27,7 @@ define Package/$(PKG_NAME)
 		+busybox +ethtool +iwinfo +iw +mtr +ip \
 		+$(PING6_PACKAGE) +iputils-ping \
 		+sprunge +safe-reboot +netperf +pv +tcpdump-mini +bwm-ng \
-		+lime-report
+		+lime-report +iperf3 +jq
 	PKGARCH:=all
 endef
 


### PR DESCRIPTION
iperf3 is useful for checking the bandwidth of cabled or wireless connections
https://openwrt.org/packages/pkgdata/iperf3

jq is useful for reading directly the JSON files, like the ones from shared-state
https://openwrt.org/packages/pkgdata/jq