### PR TITLE
lime-proto-anygw: set thisnode.info to local node IP

### DIFF
--- a/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
+++ b/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
@@ -102,7 +102,7 @@ function anygw.configure(args)
 	--! it wildcards subdomains)
 	uci:set("dhcp", "anygw_dns", "hostrecord")
 	uci:set("dhcp", "anygw_dns", "name", {"anygw", unpack(anygw.FQDN)})
-	uci:set("dhcp", "anygw_dns", "ip", anygw_ipv4:host():string() .. "," .. anygw_ipv6:host():string())
+	uci:set("dhcp", "anygw_dns", "ip", ipv4:host():string() .. "," .. ipv6:host():string())
 
 	uci:save("dhcp")
 


### PR DESCRIPTION
Seems that the possibility to use the Anygw IP for connecting to the web or the SSH interface is not going to be restored, see https://github.com/libremesh/lime-packages/issues/1008#issuecomment-1508445716

So, in order to have http://thisnode.info working, we can have it pointing to the local node IP, rather to the Anygw IP.

Up to now I checked that the gateway IP used by the clients is still being the same, and that thisnode.info is resolved as the directly-connected node IP.
What I still have to check is, from the point of view of the clients, whether the DNS resolver is the anygw IP or the local node IP.