### PR TITLE
Port lime-proto-bmx7 to fw4 and nftables

### DIFF
--- a/packages/lime-proto-bmx7/Makefile
+++ b/packages/lime-proto-bmx7/Makefile
@@ -5,7 +5,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LibreMesh
   TITLE:=LiMe Bmx7 proto support
   DEPENDS:=+bmx7 +bmx7-json +bmx7-sms +bmx7-table +bmx7-uci-config +bmx7-tun \
-           +lime-system +lua +libuci-lua +kmod-ebtables-ipv6 +ebtables \
+           +lime-system +lua +libuci-lua +ebtables-nft \
 	   +luci-lib-nixio
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   VERSION:=$(if $(PKG_VERSION),$(PKG_VERSION),$(PKG_SRC_VERSION))

--- a/packages/lime-proto-bmx7/Makefile
+++ b/packages/lime-proto-bmx7/Makefile
@@ -5,7 +5,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LibreMesh
   TITLE:=LiMe Bmx7 proto support
   DEPENDS:=+bmx7 +bmx7-json +bmx7-sms +bmx7-table +bmx7-uci-config +bmx7-tun \
-           +lime-system +lua +libuci-lua +ebtables-nft \
+           +lime-system +lua +libuci-lua +kmod-ebtables-ipv6 +ebtables-nft \
 	   +luci-lib-nixio
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   VERSION:=$(if $(PKG_VERSION),$(PKG_VERSION),$(PKG_SRC_VERSION))

--- a/packages/lime-proto-bmx7/files/etc/init.d/lime-bmx7-not-over-bat0-ebtables
+++ b/packages/lime-proto-bmx7/files/etc/init.d/lime-bmx7-not-over-bat0-ebtables
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+START=22
+USE_PROCD=0
+
+IPV6_ETHER_TYPE="86DD" # Workaround missing /etc/ethertypes
+UDP_PROTO_NUMBER="17" # Workaround missing 
+
+RULE_BMX_NOT_OVER_BAT0="POSTROUTING -t nat -o bat0 -p $IPV6_ETHER_TYPE --ip6-proto $UDP_PROTO_NUMBER --ip6-sport 6270 --ip6-dport 6270 -j DROP"
+
+start_service() {
+	ebtables -A $RULE_BMX_NOT_OVER_BAT0
+}
+
+stop_service() {
+	ebtables -D $RULE_BMX_NOT_OVER_BAT0
+}

--- a/packages/lime-proto-bmx7/files/etc/init.d/lime-bmx7tun-mtu_fix
+++ b/packages/lime-proto-bmx7/files/etc/init.d/lime-bmx7tun-mtu_fix
@@ -1,0 +1,16 @@
+#!/bin/sh /etc/rc.common
+
+START=22
+USE_PROCD=0
+
+TCP_PROTO_NUMBER="6" # Workaround missing /etc/protocols file
+
+RULE_BMX7TUN_MTU_FIX="FORWARD -t mangle -o X7+ -p $TCP_PROTO_NUMBER --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
+
+start_service() {
+	ebtables -A $RULE_BMX7TUN_MTU_FIX
+}
+
+stop_service() {
+	ebtables -D $RULE_BMX7TUN_MTU_FIX
+}

--- a/packages/lime-proto-bmx7/files/usr/lib/lua/lime/proto/bmx7.lua
+++ b/packages/lime-proto-bmx7/files/usr/lib/lua/lime/proto/bmx7.lua
@@ -152,18 +152,15 @@ function bmx7.configure(args)
 		uci:set("bmx7", "lm_net_br_lan", "dev", "br-lan")
 
 		if(hasBatadv and not bmxOverBatdv) then
-			fs.mkdir("/etc/firewall.lime.d")
-			fs.writefile("/etc/firewall.lime.d/20-bmx7-not-over-bat0-ebtables",
-			"ebtables -t nat -A POSTROUTING -o bat0 -p ipv6"..
-			" --ip6-proto udp --ip6-sport 6270 --ip6-dport 6270 -j DROP\n")
+			utils.unsafe_shell("/etc/init.d/lime-bmx7-not-over-bat0-ebtables enable || true")
 		else
-			fs.remove("/etc/firewall.lime.d/20-bmx7-not-over-bat0-ebtables")
+			utils.unsafe_shell("/etc/init.d/lime-bmx7-not-over-bat0-ebtables disable || true")
 		end
 	end
 
 	uci:save(bmx7.f)
 
-	if utils.is_installed("firewall") then
+	if utils.is_installed("firewall") or utils.is_installed("firewall4") then
 		uci:delete("firewall", "bmxtun")
 
 		uci:set("firewall", "bmxtun", "zone")
@@ -188,6 +185,7 @@ function bmx7.configure(args)
 			"iptables -t mangle -A FORWARD -o X7+ -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu\n"
 		)
 	end
+	
 end
 
 function bmx7.setup_interface(ifname, args)

--- a/packages/lime-proto-bmx7/files/usr/lib/lua/lime/proto/bmx7.lua
+++ b/packages/lime-proto-bmx7/files/usr/lib/lua/lime/proto/bmx7.lua
@@ -175,17 +175,11 @@ function bmx7.configure(args)
 
 		uci:save("firewall")
 
-		fs.remove("/etc/firewall.lime.d/20-bmx7tun-mtu_fix")
+		utils.unsafe_shell("/etc/init.d/lime-bmx7tun-mtu_fix disable || true")
 	else
-		fs.mkdir("/etc/firewall.lime.d")
-		fs.writefile(
-			"/etc/firewall.lime.d/20-bmx7tun-mtu_fix",
-			"\n" ..
-			"iptables -t mangle -D FORWARD -o X7+ -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu\n" ..
-			"iptables -t mangle -A FORWARD -o X7+ -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu\n"
-		)
+		utils.unsafe_shell("/etc/init.d/lime-bmx7tun-mtu_fix enable || true")
 	end
-	
+
 end
 
 function bmx7.setup_interface(ifname, args)


### PR DESCRIPTION
This should make lime-proto-bmx7 compatible to firewall4 and nftables. The ebtables rules are now added with an init.d script, as well as the iptables rules for the mtu fix in case there is no firewall installed.