### PR TITLE
remove old iw/iw-full compatibility check

### DIFF
--- a/packages/prometheus-node-exporter-lua-location-latlon/Makefile
+++ b/packages/prometheus-node-exporter-lua-location-latlon/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
   TITLE:=Prometheus node exporter (location_latlon collector)
   PKGARCH:=all
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
-  DEPENDS:= +lua +libuci-lua @(PACKAGE_iw||PACKAGE_iw-full) +libubus-lua
+  DEPENDS:= +lua +libuci-lua +iw +libubus-lua
 endef
 
 define Build/Compile

--- a/packages/prometheus-node-exporter-lua-wifi-params/Makefile
+++ b/packages/prometheus-node-exporter-lua-wifi-params/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
   TITLE:=Prometheus node exporter (wifi_params collector)
   PKGARCH:=all
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
-  DEPENDS:= +lua +libuci-lua @(PACKAGE_iw||PACKAGE_iw-full)
+  DEPENDS:= +lua +libuci-lua +iw
 endef
 
 define Build/Compile

--- a/packages/prometheus-node-exporter-lua-wifi-stations-extra/Makefile
+++ b/packages/prometheus-node-exporter-lua-wifi-stations-extra/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
   TITLE:=Prometheus node exporter (wifi_stations_extra collector)
   PKGARCH:=all
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
-  DEPENDS:= +lua +libuci-lua @(PACKAGE_iw||PACKAGE_iw-full) +libubus-lua
+  DEPENDS:= +lua +libuci-lua +iw +libubus-lua
 endef
 
 define Build/Compile

--- a/packages/prometheus-node-exporter-lua-wifi-survey/Makefile
+++ b/packages/prometheus-node-exporter-lua-wifi-survey/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
   TITLE:=Prometheus node exporter (wifi_survey collector)
   PKGARCH:=all
   MAINTAINER:=Gui Iribarren <gui@altermundi.net>
-  DEPENDS:= +lua @(PACKAGE_iw||PACKAGE_iw-full) +libubus-lua
+  DEPENDS:= +lua +iw +libubus-lua
 endef
 
 define Build/Compile


### PR DESCRIPTION
This remove a compatibility check that search for `iw` and if not found select `iw-full` in prometheus related packages.
The `iw` package is listed since 18.06 https://openwrt.org/packages/index_owrt18_6/start

Instead this check cause a recursive-dependency error, and make the compiler fails.
```
tmp/.config-package.in:60497:error: recursive dependency detected!
tmp/.config-package.in:60497:	symbol PACKAGE_profile-calafou-indoor depends on PACKAGE_iw
tmp/.config-package.in:131539:	symbol PACKAGE_iw is selected by PACKAGE_kmod-cfg80211
tmp/.config-package.in:22741:	symbol PACKAGE_kmod-cfg80211 is selected by PACKAGE_kmod-batman-adv
tmp/.config-package.in:16661:	symbol PACKAGE_kmod-batman-adv is selected by PACKAGE_lime-proto-batadv
tmp/.config-package.in:61230:	symbol PACKAGE_lime-proto-batadv is selected by PACKAGE_profile-calafou-indoor
For a resolution refer to Documentation/kbuild/kconfig-language.rst
subsection "Kconfig recursive dependency limitations"

```