### PR TITLE
readme: expanded instructions on ImageBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,43 @@ We encourage each network community to create its firmware profile on
 
 [In this page][1] we provide a list of requirements that ensure you to have a
 working LibreMesh node on your router. This list comes with no warranties: read
-carefully the [model-specific instructions on OpenWrt wiki][2] and be
+carefully the [model-specific instructions on OpenWrt wiki][OpenWrt-ToH] and be
 extra-careful when flashing your routers!
 
 ## Building a Firmware Image on Your PC
 
-The LibreMesh firmware can be compiled by following [these instructions][13].
+### Building the stable release LibreMesh 2020.1
 
-### Using the ImageBuilder
+#### Using the BuildRoot
 
-Start an ImageBuilder of your choice, use containers for an easier setup:
+The BuildRoot **will cross-compile the whole OpenWrt and the LibreMesh packages** on your computer, so it will take approx 10 GB of disk space and a few hours of compilation time.
+
+For compiling LibreMesh firmware with this method, you can follow [these instructions][development_page].
+
+#### Using the ImageBuilder
+
+The ImageBuilder method is not available for the stable release.
+
+### Building the experimental firmware
+
+The experimental code still has serious issues that have to be solved, use it only for developing or debugging.
+
+#### Using the BuildRoot
+
+As explained above, in the instuctions on the website you will find where to specify the version of the code to compile.
+
+#### Using the ImageBuilder
+
+The ImageBuiler **will download pre-compiled parts of the OpenWrt releases**, and add the pre-compiled LibreMesh packages, so it is **much faster** than the BuildRoot method (but less practical if you want to develop some new features modifying LibreMesh source code).
+
+Start an ImageBuilder of your choice, for example ath79-generic if your device is supported within it, use containers for an easier setup:
 
 ```shell
 mkdir ./images/
-docker run -it -v $(pwd)/images:/images/ ghcr.io/openwrt/imagebuilder:ath79-generic-v22.03.4
+docker run -it -v $(pwd)/images:/images/ ghcr.io/openwrt/imagebuilder:ath79-generic-v22.03.5
 ```
+
+If your device is not part of ath79-generic profiles, you can replace it with another <target>-<subtarget> combination. For knowing which target and subtarget is best suited for your router, check out the page about it in the [OpenWrt's Table of Hardware][OpenWrt-ToH].
 
 Within the container, add the `lime-packages` feed:
 
@@ -55,10 +77,17 @@ Now create an image of your choice, to see the names of supported profiles run
 `make info` first.
 
 ```shell
-make image PROFILE=ubnt_unifi PACKAGES="lime-system lime-proto-babeld" BIN_DIR=/images FILES=files
+make image PROFILE=ubnt_unifi PACKAGES="lime-system lime-proto-babeld lime-proto-batadv lime-proto-anygw lime-hwd-openwrt-wan -dnsmasq" BIN_DIR=/images FILES=files
 ```
 
 Your images should be available outside of the container in the `./images/` folder
+
+##### Possible errors from the ImageBuilder
+
+If you get a `docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.` error, means that you don't have Docker's daemon running. Make sure you have `docker` installed and start its daemon with `systemctl start docker.service`.
+
+If you get a `opkg_download: Check your network settings and connectivity.` error, both check the connectivity and make sure that the firewall rules of your computer allow the container to reach the internet.
+
 
 ## Testing
 
@@ -115,13 +144,13 @@ sponsor](https://opencollective.com/libremesh#sponsor)]
 <a href="https://opencollective.com/libremesh/sponsor/9/website" target="_blank"><img src="https://opencollective.com/libremesh/sponsor/9/avatar.svg"></a>
 
 [1]: https://libremesh.org/docs/hardware/
-[2]: https://openwrt.org/toh/start
+[OpenWrt-ToH]: https://openwrt.org/toh/start
 [4]: https://libremesh.org/howitworks.html
 [5]: https://libremesh.org/
 [8]: https://www.autistici.org/mailman/listinfo/libremesh
 [9]: https://libremesh.org/communication.html
 [10]: https://github.com/libremesh/network-profiles/
 [12]: https://opencollective.com/libremesh
-[13]: https://libremesh.org/development.html
+[development_page]: https://libremesh.org/development.html
 
 [lime-example]: https://github.com/libremesh/lime-packages/blob/master/packages/lime-docs/files/www/docs/lime-example.txt


### PR DESCRIPTION
In #1015, @aparcar created an excellent documentation about using the ImageBuilder for building LibreMesh on OpenWrt 22.03 (not yet supported!!).
In https://github.com/libremesh/lime-packages/pull/1015#issuecomment-1540906636 I suggested a few edits, here I implemented those and many others.