### PR TITLE
removed extra info from shared state

### DIFF
--- a/packages/shared-state/files/usr/libexec/rpcd/shared-state
+++ b/packages/shared-state/files/usr/libexec/rpcd/shared-state
@@ -19,14 +19,22 @@ local function getFromSharedState(msg)
     local sharedState = shared_state.SharedState:new(msg.data_type, 
 		nixio.syslog)
     local resultTable = sharedState:get()
-    utils.printJson(resultTable)
+    local response ={}
+    for k,v in pairs(resultTable) do
+        response[k]=v.data
+    end
+    utils.printJson(response)
 end
 
 local function getFromSharedStateMultiWriter(msg)
     local sharedState = shared_state.SharedStateMultiWriter:new(msg.data_type, 
 		nixio.syslog)
     local resultTable = sharedState:get()
-    utils.printJson(resultTable)
+    local response ={}
+    for k,v in pairs(resultTable) do
+        response[k]=v.data
+    end
+    utils.printJson(response)
 end
 
 local function insertIntoSharedStateMultiWriter(msg)


### PR DESCRIPTION
Shared-state rpcd interface doesn't need to show shared state metadata, only payload data. 
This pull request improves the previous version of the module by exposing only relevant data. 