### PR TITLE
add freq information

### DIFF
--- a/packages/shared-state-wifi_links_info/Makefile
+++ b/packages/shared-state-wifi_links_info/Makefile
@@ -20,7 +20,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=
 	URL:=http://libremesh.org
 	DEPENDS:=+lua +luci-lib-jsonc +ubus-lime-utils \
-		+lime-system shared-state 
+		+lime-system +libiwinfo-lua shared-state 
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-wifi_links_info/files/usr/bin/shared-state-publish_wifi_links_info
+++ b/packages/shared-state-wifi_links_info/files/usr/bin/shared-state-publish_wifi_links_info
@@ -20,6 +20,8 @@
 local JSON = require("luci.jsonc")
 local node_status = require ("lime.node_status")
 local network = require ("lime.network")
+local iwinfo = require "iwinfo"
+
 
 function get_wifi_links_info()
 	local stations = node_status.get_stations()
@@ -28,9 +30,10 @@ function get_wifi_links_info()
 		macparts = network.get_mac(station.iface)
 		src_macaddr = table.concat(macparts,":")
 		local station_stats = node_status.get_station_stats(station)
+		local freq = iwinfo.nl80211.frequency(station.iface)
 		table.insert(links, {src_mac=src_macaddr ,dst_mac=station.station_mac,
 		signal=station_stats.signal,chains=station_stats.chains,
-		rx_rate=station_stats.rx_rate,tx_rate=station_stats.tx_rate } )
+		rx_rate=station_stats.rx_rate,tx_rate=station_stats.tx_rate,freq=freq } )
 	end
 	return links
 end

--- a/packages/shared-state-wifi_links_info/tests/test_shared-state_wifi_links_info.lua
+++ b/packages/shared-state-wifi_links_info/tests/test_shared-state_wifi_links_info.lua
@@ -13,7 +13,8 @@ it('a simple test to get links info and assert requiered fields are present', fu
         return iwinfo.mocks.iw_station_get_result_wlan1
     end)
     stub(node_status, "get_stations", function () return iwinfo.mocks.get_stations end)
-
+    stub(node_status, "get_stations", function () return iwinfo.mocks.get_stations end)
+    stub(iwinfo.nl80211,"frequency",function (iface) return 2400 end)
     stub(network, "get_mac", function (iface)
         if string.match(iface, "wlan0") then
             return iwinfo.mocks.wlan0_mesh_mac
@@ -28,6 +29,7 @@ it('a simple test to get links info and assert requiered fields are present', fu
     assert.is.same({-17,-18}, links_info[1].chains)
     assert.is.equal(-14, links_info[1].signal)
     assert.is.equal(13000, links_info[1].rx_rate)
+    assert.is.equal(2400, links_info[1].freq)
     assert.is.equal("C0:00:00:00:00:00", links_info[1].src_mac)
 end)
 


### PR DESCRIPTION
This pull request addresses the lack of frequency information in wifi links info module 
The module has been tested with two very close tplinks 
and this is the output 

{"primero":{"bleachTTL":30,"data":[{"tx_rate":135000,"dst_mac":"A0:F3:C1:46:28:97","signal":-61,"chains":[-63,-64],"freq":5240,"rx_rate":216000,"src_mac":"a8:40:41:1d:f9:35"},{"tx_rate":135000,"dst_mac":"14:CC:20:DA:4E:AC","signal":-50,"chains":[-50,-62],"freq":5240,"rx_rate":180000,"src_mac":"a8:40:41:1d:f9:35"}],"author":"primero"},"LiMe-da4eaa":{"bleachTTL":30,"data":[{"tx_rate":86700,"dst_mac":"A0:F3:C1:46:28:96","signal":-23,"chains":[-23,-45],"freq":2462,"rx_rate":72200,"src_mac":"14:cc:20:da:4e:ab"},{"tx_rate":270000,"dst_mac":"A0:F3:C1:46:28:97","signal":-49,"chains":[-59,-49],"freq":5240,"rx_rate":300000,"src_mac":"14:cc:20:da:4e:ac"},{"tx_rate":150000,"dst_mac":"A8:40:41:1D:F9:35","signal":-64,"chains":[-74,-64],"freq":5240,"rx_rate":135000,"src_mac":"14:cc:20:da:4e:ac"}],"author":"LiMe-da4eaa"},"LiMe-462895":{"bleachTTL":28,"data":[{"tx_rate":72200,"dst_mac":"14:CC:20:DA:4E:AB","signal":5,"chains":[5,-32],"freq":2462,"rx_rate":65000,"src_mac":"a0:f3:c1:46:28:96"},{"tx_rate":240000,"dst_mac":"A8:40:41:1D:F9:35","signal":-66,"chains":[-74,-67],"freq":5240,"rx_rate":135000,"src_mac":"a0:f3:c1:46:28:97"},{"tx_rate":300000,"dst_mac":"14:CC:20:DA:4E:AC","signal":-42,"chains":[-53,-42],"freq":5240,"rx_rate":270000,"src_mac":"a0:f3:c1:46:28:97"}],"author":"LiMe-462895"}}