### PR TITLE
Default distance setting: increase 10x

### DIFF
--- a/packages/lime-docs/files/www/docs/lime-example.txt
+++ b/packages/lime-docs/files/www/docs/lime-example.txt
@@ -98,7 +98,7 @@ config lime wifi					# Settings in this section applies to all radios.
 config lime-wifi-band '2ghz' 			# Settings in this section applies for all radios in '2ghz' (or '5ghz') band. And take presedence over 'lime wifi' section
 	option channel '11'
 	option htmode 'HT20'			# htmode sets the width of the channel. HT40 should have better performances in non-noisy environments. Check out the documentation in the OpenWrt wiki here: https://openwrt.org/docs/guide-user/network/wifi/basic#htmodewi-fi_channel_width
-	option distance '100'
+	option distance '1000'			# 1 km max distance, farther clients or peers will not be able to connect
 	option adhoc_mcast_rate '24000'
 	option ieee80211s_mcast_rate '24000'
 #	list modes 'ap'				# For networks where only dual band routers are used,
@@ -110,7 +110,7 @@ config lime-wifi-band '5ghz'
 	list channel '157'			# Check for allowed channels on https://en.wikipedia.org/wiki/List_of_WLAN_channels#regulatory_tables5.0ghz
 	option htmode 'HT40'			# htmode sets the width of the channel. VHT80 should have better performances in non-noisy environment. Check out the valid channels list in this comment: https://github.com/libremesh/lime-packages/issues/647#issuecomment-1503968192 and check out the documentation in the OpenWrt wiki here: https://openwrt.org/docs/guide-user/network/wifi/basic#htmodewi-fi_channel_width
 #	list modes 'ieee80211s'			# For networks where only dual band routers are used, the 5 GHz radio can be reserved for the node-to-node connections
-	option distance '1000' 			# Distance between this node/ap and the furthest connected node/client in meters, heavily affects performances. If you are unsure of the right number, better to use a too-large distance here than a too-small one.
+	option distance '10000'			# Distance between this node/ap and the furthest connected node/client in meters, affects performances. If you are unsure of the right number, better to use a too-large distance here than a too-small one. Farther clients or peers will not be able to connect
 	option adhoc_mcast_rate '6000'
 	option ieee80211s_mcast_rate '6000'
 
@@ -167,7 +167,7 @@ config wifi radio99 # you should ensure that the chosen radio name exists, for e
 	option client_ssid 'SomeWiFiNetwork'
 	option client_key 'SomeWPApskPassword'
 	option client_encryption 'psk2'			# psk for WPA or psk2 for WPA2
-	option distance 300				# maximum distance to AP, heavily affects performances
+	option distance 1000				# maximum distance to AP, affects performances
 
 config net wirelessclientWAN
 	option linux_name 'wlan0-sta'			# verify the name, the client interface name could be named differently, like wlan1-sta
@@ -205,7 +205,7 @@ config wifi radio99 # you should ensure that the chosen radio name exists, for e
 	option client_ssid 'backbone/LiMe-ddeeff'	# specify here the name of the specifically configured backbone AP interface you want to connect to
 #	option client_key 'somePassword'
 #	option client_encryption 'psk2'
-	option distance 1000				# maximum distance to AP, heavily affects performances
+	option distance 1000				# maximum distance to AP, affects performances
 
 config net wirelessclientbackbone
 	option linux_name 'wlan0-sta'			# verify the name, the client interface name could be named differently, like wlan1-sta

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -66,7 +66,7 @@ config lime wifi
 config lime-wifi-band '2ghz'
 	option channel '11'
 	option htmode 'HT20'
-	option distance '100'
+	option distance '1000'
 	option adhoc_mcast_rate '24000'
 	option ieee80211s_mcast_rate '24000'
 
@@ -74,7 +74,7 @@ config lime-wifi-band '5ghz'
 	list channel '48'
 	list channel '157'
 	option htmode 'HT40'
-	option distance '1000'
+	option distance '10000'
 	option adhoc_mcast_rate '6000'
 	option ieee80211s_mcast_rate '6000'
 

--- a/tests/test_lime_config_device.lua
+++ b/tests/test_lime_config_device.lua
@@ -69,9 +69,9 @@ describe('LiMe Config tests', function()
 		assert.is.equal('HT40', uci:get('wireless', 'radio1', 'htmode'))
 		assert.is.equal('HT40', uci:get('wireless', 'radio2', 'htmode'))
 
-		assert.is.equal('100', uci:get('wireless', 'radio0', 'distance'))
-		assert.is.equal('1000', uci:get('wireless', 'radio1', 'distance'))
-		assert.is.equal('1000', uci:get('wireless', 'radio2', 'distance'))
+		assert.is.equal('1000', uci:get('wireless', 'radio0', 'distance'))
+		assert.is.equal('10000', uci:get('wireless', 'radio1', 'distance'))
+		assert.is.equal('10000', uci:get('wireless', 'radio2', 'distance'))
     end)
 
 	setup('', function()


### PR DESCRIPTION
Fix #201

Goes against the decisions implemented in #202 and #324

See the discussion on #201 and on this email thread: https://lists.autistici.org/thread/20230815.142621.071b5fc0.en.html#i20230815.142621.071b5fc0

Here, the default distance setting for 5 GHz radios is being increased from 1 km to 10 km.
And the default distance setting for 2.4 GHz from 100 m to 1 km.