### PR TITLE
add wifi interface name in shared state wifi information module 

### DIFF
--- a/packages/shared-state-wifi_links_info/files/usr/bin/shared-state-publish_wifi_links_info
+++ b/packages/shared-state-wifi_links_info/files/usr/bin/shared-state-publish_wifi_links_info
@@ -32,7 +32,7 @@ function get_wifi_links_info()
 		local station_stats = node_status.get_station_stats(station)
 		local freq = iwinfo.nl80211.frequency(station.iface)
 		table.insert(links, {src_mac=src_macaddr ,dst_mac=station.station_mac,
-		signal=station_stats.signal,chains=station_stats.chains,
+		signal=station_stats.signal,chains=station_stats.chains,iface=station.iface,
 		rx_rate=station_stats.rx_rate,tx_rate=station_stats.tx_rate,freq=freq } )
 	end
 	return links

--- a/packages/shared-state-wifi_links_info/tests/test_shared-state_wifi_links_info.lua
+++ b/packages/shared-state-wifi_links_info/tests/test_shared-state_wifi_links_info.lua
@@ -28,6 +28,7 @@ it('a simple test to get links info and assert requiered fields are present', fu
     assert.is.equal("C0:4A:00:BE:7B:09", links_info[1].dst_mac)
     assert.is.same({-17,-18}, links_info[1].chains)
     assert.is.equal(-14, links_info[1].signal)
+    assert.is.equal("wlan0-mesh", links_info[1].iface)
     assert.is.equal(13000, links_info[1].rx_rate)
     assert.is.equal(2400, links_info[1].freq)
     assert.is.equal("C0:00:00:00:00:00", links_info[1].src_mac)


### PR DESCRIPTION
This pull request is a very small improvement witch adds the interface name for each link in shared state's wifi_information module