### PR TITLE
ci: update openwrt/gh-action-sdk

### DIFF
--- a/.github/workflows/build_2020.yml
+++ b/.github/workflows/build_2020.yml
@@ -1,13 +1,9 @@
 name: Build packages
 
 on:
-  release:
-    types: [published]
   push:
-    branches: [master]
     tags:
-      - v*
-      - '!v2020*'
+      - v2020*
 
 jobs:
   build:
@@ -20,7 +16,7 @@ jobs:
       - name: Build packages
         uses: openwrt/gh-action-sdk@v5
         env:
-          ARCH: "x86_64"
+          ARCH: "x86_64-19.07.10"
           FEEDNAME: "libremesh"
           IGNORE_ERRORS: "n m y"
           KEY_BUILD: "${{ secrets.KEY_BUILD }}"


### PR DESCRIPTION
This is an attempt to enable the build of lime-packages via ci also for versions based on openwrt-22.03.5.

This create a distinct workflow file for older release , linking them with the sdk related to openwrt-19.07.10.

This update also the default workflow build.yml to fix the error `/entrypoint.sh: line 8: cd: /home/build/openwrt/: No such file or directory`. This seems due to an update in the directory structure in https://github.com/openwrt/gh-action-sdk