### PR TITLE
lime-docs: update PKG_SOURCE_URL

### DIFF
--- a/packages/lime-docs/Makefile
+++ b/packages/lime-docs/Makefile
@@ -13,8 +13,8 @@ PKG_NAME:=lime-docs
 PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/libremesh/lime-web/trunk/docs
-PKG_SOURCE_PROTO:=svn
+PKG_SOURCE_URL:=https://github.com/libremesh/libremesh.github.io/
+PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=HEAD
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 
@@ -67,13 +67,13 @@ endef
 
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/www/docs/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/en_*.txt $(1)/www/docs/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/docs/en_*.txt $(1)/www/docs/
 	@ln -s /www/docs $(1)/docs
 endef
 
 define Package/$(PKG_NAME)-it/install
 	$(INSTALL_DIR) $(1)/www/docs/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/it_*.txt $(1)/www/docs/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/docs/it_*.txt $(1)/www/docs/
 	@ln -s /www/docs $(1)/docs
 endef
 


### PR DESCRIPTION
This update the PKG_SOURCE_URL and PKG_SOURCE_PROTO of lime-docs.
It seems something is changed from github.com's side: 
- the 'svn' proto is not accepted anymore (see logs) 
- while it is still present an http redirect from `https://github.com/libremesh/lime-web/trunk/docs` to `https://github.com/libremesh/libremesh.github.io/`

The bug is preventing v2023.1-rc2 to be build.
I made sure that this is the only bug that cause a build failure as now the build for v2023.1-rc2 is going on.

<details><summary>Error Details</summary>
<pre>
SHELL= flock /home/antennine/openwrt_build/stable/libremesh_2023.1-rc2-ow22/openwrt_buildroot_22.03.5/tmp/.lime-docs-2023-09-17-1694972618.tar.xz.flock -c '  	 echo "Checking out files from the svn repository..."; mkdir -p /home/antennine/openwrt_build/stable/libremesh_2023.1-rc2-ow22/openwrt_buildroot_22.03.5/tmp/dl && cd /home/antennine/openwrt_build/stable/libremesh_2023.1-rc2-ow22/openwrt_buildroot_22.03.5/tmp/dl && rm -rf lime-docs-2023-09-17-1694972618 && [ \! -d lime-docs-2023-09-17-1694972618 ] && ( svn help export | grep -q trust-server-cert && svn export --non-interactive --trust-server-cert -rHEAD https://github.com/libremesh/lime-web/trunk/docs lime-docs-2023-09-17-1694972618 || svn export --non-interactive -rHEAD https://github.com/libremesh/lime-web/trunk/docs lime-docs-2023-09-17-1694972618 ) && echo "Packing checkout..." && export TAR_TIMESTAMP="" && tar --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name ${TAR_TIMESTAMP:+--mtime="$TAR_TIMESTAMP"} -c lime-docs-2023-09-17-1694972618 | 	xz -zc -7e > /home/antennine/openwrt_build/stable/libremesh_2023.1-rc2-ow22/openwrt_buildroot_22.03.5/tmp/dl/lime-docs-2023-09-17-1694972618.tar.xz && mv /home/antennine/openwrt_build/stable/libremesh_2023.1-rc2-ow22/openwrt_buildroot_22.03.5/tmp/dl/lime-docs-2023-09-17-1694972618.tar.xz /home/antennine/openwrt_build/stable/libremesh_2023.1-rc2-ow22/openwrt_buildroot_22.03.5/dl/ && rm -rf lime-docs-2023-09-17-1694972618;     '
Checking out files from the svn repository...
/bin/sh: 1: svn: not found
/bin/sh: 1: svn: not found
make[3]: *** [Makefile:87: /home/antennine/openwrt_build/stable/libremesh_2023.1-rc2-ow22/openwrt_buildroot_22.03.5/dl/lime-docs-2023-09-17-1694972618.tar.xz] Error 127
make[3]: Leaving directory '/home/antennine/openwrt_build/stable/libremesh_2023.1-rc2-ow22/openwrt_buildroot_22.03.5/feeds/libremesh/packages/lime-docs'
time: package/feeds/libremesh/lime-docs/compile#0.12#0.03#0.13
    ERROR: package/feeds/libremesh/lime-docs failed to build.

</pre>
</details> 