### PR TITLE
draft: fix bridge device section confusion

### DIFF
--- a/packages/lime-system/tests/test_lime_network.lua
+++ b/packages/lime-system/tests/test_lime_network.lua
@@ -93,6 +93,11 @@ describe('LiMe Network tests', function()
         stub(utils, "getBoardAsTable", function () return BOARD end)
         stub(network, "assert_interface_exists", function () return true end)
 
+        bridge_section = uci:add("network", "device")
+        uci:set("network", bridge_section, "type", "bridge")
+        uci:set("network", bridge_section, "name", "br-lan")
+        uci:commit("network")
+
         network.configure()
 
         assert.is.equal("1500", uci:get("network", "lan", "mtu"))


### PR DESCRIPTION
Bridge ports are added to the first device section, which may be the wrong one. This changes the behaviour follwing @ilario s [suggestion](https://github.com/libremesh/lime-packages/issues/1060#issuecomment-1767832137). Now, the first device section that has type `bridge` and the name `br-lan` will be used.
After reading the `/bin/config_generate` script in OpenWrt base-files I am confident that there will always be such a device section on first boot.

fixes #1060
