### PR TITLE
Readme.md: improve imagebuilder instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ As explained above, in the instuctions on the website you will find where to spe
 
 The ImageBuiler **will download pre-compiled parts of the OpenWrt releases**, and add the pre-compiled LibreMesh packages, so it is **much faster** than the BuildRoot method (but less practical if you want to develop some new features modifying LibreMesh source code).
 
+##### With Docker
+
 Start an ImageBuilder of your choice, for example ath79-generic if your device is supported within it, use containers for an easier setup:
 
 ```shell
@@ -57,7 +59,7 @@ mkdir ./images/
 docker run -it -v $(pwd)/images:/images/ ghcr.io/openwrt/imagebuilder:ath79-generic-v22.03.5
 ```
 
-If your device is not part of ath79-generic profiles, you can replace it with another <target>-<subtarget> combination. For knowing which target and subtarget is best suited for your router, check out the page about it in the [OpenWrt's Table of Hardware][OpenWrt-ToH].
+If your device is not part of ath79-generic profiles, you can replace it with another &lt;target&gt;-&lt;subtarget&gt; combination. For knowing which target and subtarget is best suited for your router, check out the page about it in the [OpenWrt's Table of Hardware][OpenWrt-ToH].
 
 Within the container, add the `lime-packages` feed:
 
@@ -70,17 +72,31 @@ echo "RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8" >> keys/a71b3c82
 Ideally add your own `lime-community` files within the container in the folder
 `./files/etc/config/`. To find possible options consult the
 [lime-example.txt][lime-example] file. It is also possible to mount an existing
-`lime-community` file directly via `-v
-$(pwd)/lime-community:/builder/files/etc/config/lime-community`.
+`lime-community` file directly. For example, when the `lime-community` file is in the current directory, append `-v
+$(pwd)/lime-community:/builder/files/etc/config/lime-community` to the `docker run` command.
 
 Now create an image of your choice, to see the names of supported profiles run
 `make info` first.
 
 ```shell
-make image PROFILE=ubnt_unifi PACKAGES="lime-system lime-proto-babeld lime-proto-batadv lime-proto-anygw lime-hwd-openwrt-wan -dnsmasq" BIN_DIR=/images FILES=files
+make image PROFILE=ubnt_unifi PACKAGES="lime-system lime-proto-babeld lime-proto-batadv lime-proto-anygw lime-hwd-openwrt-wan lime-hwd-ground-routing lime-app lime-debug lime-docs lime-docs-minimal shared-state-babeld_hosts shared-state-bat_hosts shared-state-dnsmasq_hosts shared-state-nodes_and_links babeld-auto-gw-mode check-date-http batctl-default -dnsmasq -odhcpd-ipv6only" BIN_DIR=/images FILES=files
 ```
 
-Your images should be available outside of the container in the `./images/` folder
+For more information about which packages to select, refer to section [package-selection](#package-selection).
+
+Your images should be available outside of the container in the `./images/` folder.
+
+##### Without Docker
+
+Go to <https://firmware-selector.openwrt.org/>. Find your device. Click on the folder symbol right after "Links: ". Alternatively, find your device in [OpenWrt's Table of Hardware][OpenWrt-ToH], find the image download link, remove the filename from the right side of the link and put the result in your browsers address bar. Scroll down and download openwrt-imagebuilder-*. Unpack the file and open a terminal inside the directory. Create an image with
+```shell
+make image PROFILE=ubnt_unifi FILES=path-to-root-dir PACKAGES="lime-system lime-proto-babeld lime-proto-batadv lime-proto-anygw lime-hwd-openwrt-wan lime-hwd-ground-routing lime-app lime-debug lime-docs lime-docs-minimal shared-state-babeld_hosts shared-state-bat_hosts shared-state-dnsmasq_hosts shared-state-nodes_and_links babeld-auto-gw-mode check-date-http batctl-default -dnsmasq -odhcpd-ipv6only"
+```
+where `path-to-root-dir` is the path to a directory where your `lime-community` file is located, like so: `path-to-root-dir/etc/config/lime-community`. `ubnt_unifi` needs to be replaced with the profile that fits your device. Run `make info` to see the names of supported profiles. You find the resulting image files in `./bin/target/*/*/`.
+
+For more information about which packages to select, refer to section [package-selection](#package-selection).
+
+For more information about commands and parameters of imagebuilder, run `make help`.
 
 ##### Possible errors from the ImageBuilder
 
@@ -88,6 +104,25 @@ If you get a `docker: Cannot connect to the Docker daemon at unix:///var/run/doc
 
 If you get a `opkg_download: Check your network settings and connectivity.` error, both check the connectivity and make sure that the firewall rules of your computer allow the container to reach the internet.
 
+##### Package selection
+
+With the `PACKAGES=` argument, you can specify which packages should be preinstalled inside the image. All packages and packages they depend on will be included in the image. This list of packes will produce an image close to the official ones:
+```shell
+PACKAGES="lime-system lime-proto-babeld lime-proto-batadv lime-proto-anygw lime-hwd-openwrt-wan lime-hwd-ground-routing lime-app lime-debug lime-docs lime-docs-minimal shared-state-babeld_hosts shared-state-bat_hosts shared-state-dnsmasq_hosts shared-state-nodes_and_links babeld-auto-gw-mode check-date-http batctl-default -dnsmasq -odhcpd-ipv6only"
+```
+There are some target and profile specific packages that are included by default. They can be excluded by prepending them with a minus sign. Note that when there is a package in the selection that depends on another package, that package will always be included. You can find out which packages depend on another package using `package_whatdepends`, for example:
+```
+make package_whatdepends PACKAGE=lime-system
+```
+If you have a device that uses an atk10k wireless driver, you need to make sure to use the one that isn't suffixed with `-ct`. With the `-ct`-version, 802.11s meshing does not work. After building an image, open the `.manifest`-file that is created within the same folder as the image with a text editor. Check if there are any packages ending with `-ct`. If this is the case, exclude them from the image. Include the packages with the same name but without the `-ct`. For example, append
+```
+-kmod-ath10k-ct kmod-ath10k -ath10k-firmware-qca988x-ct ath10k-firmware-qca988x
+```
+If you planning to use encrypted mesh, you need to make sure to have the `wpad-mesh-*`, not `wpad-basic-*` package, where `*` is `mbedtls`, `openssl` or `wolfssl`. OpenWrt 23 by default uses `mbedtls`. For example, append
+```
+-wpad-basic-mbedtls wpad-mesh-mbedtls
+```
+If you want to save some space on the devices flash, there are some packages that can savely be excluded. For example, you can remove `lime-debug` from the above example and save about 540KB. Append `-ppp -ppp-mod-pppoe` to save another 140KB (if you don't need pppoe).
 
 ## Testing
 


### PR DESCRIPTION
Building LibreMesh with imagebuilder is difficult. Especially selecting the right packages is not trivial. With these changes and additions I intend to make it easier to build a working image for someone not so familiar with LibreMesh and imagebuilder.