### PR TITLE
lime-unstuck-wa: Fix module path

### DIFF
--- a/packages/wifi-unstuck-wa/files/usr/bin/wifi-unstuck
+++ b/packages/wifi-unstuck-wa/files/usr/bin/wifi-unstuck
@@ -1,5 +1,5 @@
 #!/usr/bin/env lua
 
-local unstuck_wa = require 'wifi_unstuck_wa'
+local unstuck_wa = require 'lime.wifi_unstuck_wa'
 
 unstuck_wa.do_workaround()


### PR DESCRIPTION
This updates the module path to its new location, because else `/usr/bin/wifi-unstuck-wa` throws an error and does not work.