### PR TITLE
Fix lime-config fail when there is no lower iface

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -216,7 +216,8 @@ end
 function network._get_lower(dev)
     local lower_if_path = utils.unsafe_shell("ls -d /sys/class/net/" .. dev .. "/lower*")
     local lower_if_table = utils.split(lower_if_path, "_")
-    return lower_if_table[#lower_if_table]:gsub("\n", "")
+    local lower_if = lower_if_table[#lower_if_table]
+    return lower_if and lower_if:gsub("\n", "")
 end
 
 function network.scandevices()
@@ -248,19 +249,23 @@ function network.scandevices()
 		--! or just lan.
 		if dev:match("^lan%d*$") then
 			local lower_if = network._get_lower(dev)
-			devices[lower_if] = { nobridge = true }
-			devices[dev] = {}
-			utils.log( "network.scandevices.dev_parser found LAN port %s " ..
-			           "and marking %s as nobridge", dev, lower_if )
+			if lower_if then
+				devices[lower_if] = { nobridge = true }
+				devices[dev] = {}
+				utils.log( "network.scandevices.dev_parser found LAN port %s " ..
+				           "and marking %s as nobridge", dev, lower_if )
+			end
 		end
 
 		--! With DSA, the WAN is named wan. Copying the code from the lan case.
 		if dev:match("^wan$") then
 			local lower_if = network._get_lower(dev)
-			devices[lower_if] = { nobridge = true }
-			devices[dev] = {}
-			utils.log( "network.scandevices.dev_parser found WAN port %s " ..
-			           "and marking %s as nobridge", dev, lower_if )
+			if lower_if then
+				devices[lower_if] = { nobridge = true }
+				devices[dev] = {}
+				utils.log( "network.scandevices.dev_parser found WAN port %s " ..
+				           "and marking %s as nobridge", dev, lower_if )
+			end
 		end
 
 		if dev:match("^wlan%d+"..wireless.wifiModeSeparator.."%w+$") then


### PR DESCRIPTION
On a mercusys mr70x, lime-config does not work. It throws the following error:
```
network.scandevices.owrt_network_interface_parser found ifname wan
ls: /sys/class/net/wan/lower*: No such file or directory
/usr/lib/lua/lime/network.lua:223: attempt to index field '?' (a nil value)
stack traceback:
        /usr/lib/lua/lime/config.lua:221: in function </usr/lib/lua/lime/config.lua:221>
        [C]: in function 'foreach'
        /usr/lib/lua/lime/network.lua:339: in function 'scandevices'
        /usr/lib/lua/lime/network.lua:373: in function </usr/lib/lua/lime/network.lua:364>
        [C]: in function 'xpcall'
        /usr/lib/lua/lime/config.lua:221: in function 'main'
        /usr/bin/lime-config:55: in main chunk
        [C]: ?
```
It seems that an interface that is called "wan" does not always have link to a lower interface in /sys/class/net. This is how I would like to fix it. I've tested it already on a mercusys mr70x and it is working fine.