### PR TITLE
ci: rebuild packages via sdk only when a package changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
     tags:
       - v*
       - '!v2020*'
+    paths:
+      - ".github/workflows/*"
+      - "libremesh.mk"
+      - "packages/**"
 
 jobs:
   build:


### PR DESCRIPTION
This prevents all packages from being recompiled when not needed (changes to readme, changelog, other not related files)