### PR TITLE
ci: add multi-arch-build.yml;

### DIFF
--- a/.github/workflows/multi-arch-build.yml
+++ b/.github/workflows/multi-arch-build.yml
@@ -1,0 +1,78 @@
+name: Multi arch build packages
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: [master]
+    tags:
+      - v*
+      - '!v2020*'
+    paths:
+      - 'packages/shared-state-async/**'
+      
+jobs:
+  build:
+    name: build ${{ matrix.arch }} ${{ github.ref }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - aarch64_cortex-a53
+          - aarch64_cortex-a72
+          - aarch64_generic
+          - arm_arm1176jzf-s_vfp
+          - arm_arm926ej-s
+          - arm_cortex-a15_neon-vfpv4
+          - arm_cortex-a5_vfpv4
+          - arm_cortex-a7
+          - arm_cortex-a7_neon-vfpv4
+          - arm_cortex-a7_vfpv4
+          - arm_cortex-a8_vfpv3
+          - arm_cortex-a9
+          - arm_cortex-a9_neon
+          - arm_cortex-a9_vfpv3-d16
+          - arm_fa526
+          - arm_mpcore
+          - arm_xscale
+          - i386_pentium-mmx
+          - i386_pentium4
+          - mips64_octeonplus
+          - mips_24kc
+          - mips_4kec
+          - mips_mips32
+          - mipsel_24kc
+          - mipsel_24kc_24kf
+          - mipsel_74kc
+          - mipsel_mips32
+          - powerpc_464fp
+          - powerpc_8548
+          - riscv64_riscv64
+          - x86_64
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build packages ${{ matrix.arch }}
+        uses: openwrt/gh-action-sdk@v5
+        env:
+          ARCH: "${{ matrix.arch }}"
+          FEEDNAME: "libremesh"
+          IGNORE_ERRORS: "n m y"
+          KEY_BUILD: "${{ secrets.KEY_BUILD }}"
+          PACKAGES: "shared-state-bat_hosts"
+
+      - name: Set package destination
+        run: |
+          export TAG=$(echo "${{ github.ref }}" | cut -d '/' -f 3- | perl -pe 's/v([0-9])/$1/')
+          echo "$TAG"
+          echo "DEST_DIR=$TAG" >> $GITHUB_ENV
+
+      - name: Upload packages to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          external_repository: libremesh/lime-feed
+          publish_dir: bin/packages/${{ matrix.arch }}/libremesh/
+          destination_dir: ${{ env.DEST_DIR }}/packages/${{ matrix.arch }}
+

--- a/README.md
+++ b/README.md
@@ -61,13 +61,16 @@ docker run -it -v $(pwd)/images:/images/ ghcr.io/openwrt/imagebuilder:ath79-gene
 
 If your device is not part of ath79-generic profiles, you can replace it with another &lt;target&gt;-&lt;subtarget&gt; combination. For knowing which target and subtarget is best suited for your router, check out the page about it in the [OpenWrt's Table of Hardware][OpenWrt-ToH].
 
-Within the container, add the `lime-packages` feed:
+Within the container, add the `lime-packages` feeds:
 
 ```shell
 echo "src/gz libremesh https://feed.libremesh.org/master" >> repositories.conf
+echo "src/gz libremesh_arch_packages https://feed.libremesh.org/master/packages/mips_24kc" >> repositories.conf
 echo  "untrusted comment: signed by libremesh.org key a71b3c8285abd28b" > keys/a71b3c8285abd28b
 echo "RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8" >> keys/a71b3c8285abd28b
 ```
+
+If your device is not part of ath79-generic replace `mips_24kc` with the architecture of the selected &lt;target&gt;-&lt;subtarget&gt;.
 
 Ideally add your own `lime-community` files within the container in the folder
 `./files/etc/config/`. To find possible options consult the
@@ -92,6 +95,7 @@ Go to <https://firmware-selector.openwrt.org/>. Find your device. Click on the f
 
 ```shell
 echo "src/gz libremesh https://feed.libremesh.org/master" >> repositories.conf
+echo "src/gz libremesh_arch_packages https://feed.libremesh.org/master/packages/mips_24kc" >> repositories.conf
 echo  "untrusted comment: signed by libremesh.org key a71b3c8285abd28b" > keys/a71b3c8285abd28b
 echo "RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8" >> keys/a71b3c8285abd28b
 ```

--- a/packages/lime-system/files/etc/uci-defaults/92_add-lime-repos
+++ b/packages/lime-system/files/etc/uci-defaults/92_add-lime-repos
@@ -12,10 +12,14 @@ feeds_file="/etc/opkg/limefeeds.conf"
   exit 0
 }
 
+arch_packages="$(cat /etc/os-release | grep OPENWRT_ARCH | sed 's/OPENWRT_ARCH=\"\(.*\)\"/\1/')"
+
 [ "$LIME_CODENAME" == "development" ] && {
 	packages_url="http://feed.libremesh.org/master";
+	arch_packages_url="http://feed.libremesh.org/master/packages/$arch_packages";
 } || {
 	packages_url="http://feed.libremesh.org/$LIME_RELEASE"
+	arch_packages_url="http://feed.libremesh.org/$LIME_RELEASE/packages/$arch_packages";
 }
 
 profiles_url="http://feed.libremesh.org/profiles"
@@ -25,6 +29,7 @@ key_content="RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8"
 
 echo "Configuring official LibreMesh opkg feeds"
 echo "src/gz libremesh $packages_url" > "$feeds_file"
+echo "src/gz libremesh_arch_packages $arch_packages_url" >> "$feeds_file"
 echo "src/gz profiles $profiles_url" >> "$feeds_file"
 echo "untrusted comment: signed by libremesh.org key $key_name" > "/etc/opkg/keys/$key_name"
 echo "$key_content" >> "/etc/opkg/keys/$key_name"


### PR DESCRIPTION
Add a new packages repository at:
- http://github.com/libremesh/lime-feed/tree/gh-pages/master/packages/$ARCH_PACKAGES
- http://feed.libremesh.org/master/packages/$ARCH_PACKAGES 

That includes packages precompiled by openwrt-sdk for each specific architecture

This is currently required only for the package `shared-state-async` 
After this merge https://github.com/libremesh/lime-packages/pull/1067, imagebuilder builds fail, using the default set of packages, unless you are building for x86_64

update the imagebuilder build guide on `README.md`
update `lime-system/files/etc/uci-defaults/92_add-lime-repos` to use also the new repo