### PR TITLE
bat_hosts: fixes rpcd error

### DIFF
--- a/packages/shared-state-bat_hosts/files/usr/lib/lua/bat-hosts.lua
+++ b/packages/shared-state-bat_hosts/files/usr/lib/lua/bat-hosts.lua
@@ -1,4 +1,3 @@
-local shared_state = require("shared-state")
 local JSON = require("luci.jsonc")
 local utils = require("lime.utils")
 
@@ -10,7 +9,7 @@ function bat_hosts.bathost_deserialize(hostname_plus_iface)
     for _, ifname in ipairs(utils.get_ifnames()) do
         local serialized_ifname = string.gsub(ifname, "%W", "_")
         serialized_ifname = utils.literalize(serialized_ifname)
-        local replaced_hostname = hostname_plus_iface:gsub("_"..serialized_ifname, "")
+        local replaced_hostname = hostname_plus_iface:gsub("_" .. serialized_ifname, "")
         -- hostname don't have underscores see utils.is_valid_hostname
         replaced_hostname = replaced_hostname:gsub("_", "-")
         if #replaced_hostname < #partial_hostname then
@@ -21,13 +20,17 @@ function bat_hosts.bathost_deserialize(hostname_plus_iface)
     return partial_hostname, iface
 end
 
+function bat_hosts.get_bat_hosts_from_shared_state()
+    return JSON.parse(
+        io.popen("shared-state-async get bat-hosts 2> /dev/null", "r"):read("*all"))
+end
+
 function bat_hosts.get_bathost(mac, outgoing_iface)
-	local bathosts = JSON.stringify(
-		io.popen("shared-state-async get bat-hosts", "r"):read("*all") )
-	local bathost = bathosts[mac:lower()]
-	if bathost == nil then return end
-	local hostname, iface = bat_hosts.bathost_deserialize(bathost.data)
-	return { hostname = hostname, iface = iface }
+    local bathosts = bat_hosts.get_bat_hosts_from_shared_state()
+    local bathost = bathosts[mac:lower()]
+    if bathost == nil then return end
+    local hostname, iface = bat_hosts.bathost_deserialize(bathost)
+    return { hostname = hostname, iface = iface }
 end
 
 return bat_hosts

--- a/packages/shared-state-bat_hosts/tests/test_bat_hosts.lua
+++ b/packages/shared-state-bat_hosts/tests/test_bat_hosts.lua
@@ -1,39 +1,26 @@
---! This test uses legasy shared-state Lua implementation, need complete
---! rethinking to work
+local bat_hosts = require('bat-hosts')
+local utils = require('lime.utils')
+local test_utils = require('tests.utils')
+local shared_state = require('shared-state')
 
--- local bat_hosts = require('bat-hosts')
--- local utils = require('lime.utils')
--- local test_utils = require('tests.utils')
--- local shared_state = require('shared-state')
---
--- it('test get_bathost #bathost', function()
---     shared_state.DATA_DIR = test_utils.setup_test_dir()
---     local sharedState = shared_state.SharedState:new('bat-hosts')
---     sharedState:insert({
---         ["02:95:39:ab:cd:00"] = "LiMe_abcd00_wlan1_mesh",
---         ["52:00:00:ab:cd:a0"] = "LiMe_abcd01_wlan2_mesh_17",
---         ["d6:67:58:8e:cd:92"] = "LiMe_abcd02_wlan0_adhoc_29",
---         ["12:00:00:00:00:00"] = "LiMe_abcd03_wlan1_adhoc"
---     })
---     local ifaces = {'wlan1-mesh', 'wlan2-mesh', 'wlan2-mesh_17', 'wlan0-adhoc_29', 'wlan1-adhoc'}
---     stub(utils, "get_ifnames", function () return ifaces end)
---     assert.is.same({hostname='LiMe-abcd00', iface='wlan1-mesh'}, bat_hosts.get_bathost('02:95:39:ab:cd:00'))
---     assert.is.same({hostname='LiMe-abcd01', iface='wlan2-mesh_17'}, bat_hosts.get_bathost('52:00:00:ab:cd:a0'))
---     assert.is.same({hostname='LiMe-abcd02', iface='wlan0-adhoc_29'}, bat_hosts.get_bathost('d6:67:58:8e:cd:92'))
---     assert.is.same({hostname='LiMe-abcd03', iface='wlan1-adhoc'}, bat_hosts.get_bathost('12:00:00:00:00:00'))
---     local ipv6ll = utils.mac2ipv6linklocal('52:00:00:ab:cd:00') .. '%wlan1-mesh'
---     local dataTypeOfSync = nil
---     local urlsOfSync = nil
---     local function syncMock (self, urls)
---         dataTypeOfSync = self.dataType
---         urlsOfSync = urls
---         self:insert({['52:00:00:ab:cd:00'] = "Lime_abcd04_wlan1_mesh"})
---     end
---     stub(shared_state.SharedState, "sync", syncMock)
---     local bathost = bat_hosts.get_bathost('52:00:00:ab:cd:00', 'wlan1-mesh')
---     assert.is.same(urlsOfSync, { ipv6ll })
---     assert.is.equal(dataTypeOfSync, 'bat-hosts')
---     assert.is.same({hostname='Lime-abcd04', iface='wlan1-mesh'}, bathost)
---     assert.is_nil(bat_hosts.get_bathost('00:aa:bb:cc:dd:00', 'wlan1'))
---     assert.is_nil(bat_hosts.get_bathost('00:aa:bb:cc:dd:00'))
--- end)
+it('test get_bathost #bathost', function()
+    shared_state.DATA_DIR = test_utils.setup_test_dir()
+    stub (bat_hosts,"get_bat_hosts_from_shared_state", function ()
+        return {
+        ["02:95:39:ab:cd:00"] = "LiMe_abcd00_wlan1_mesh",
+        ["52:00:00:ab:cd:a0"] = "LiMe_abcd01_wlan2_mesh_17",
+        ["d6:67:58:8e:cd:92"] = "LiMe_abcd02_wlan0_adhoc_29",
+        ["12:00:00:00:00:00"] = "LiMe_abcd03_wlan1_adhoc",
+        ["52:01:00:ab:cd:00"] = "Lime_abcd04_wlan1_mesh"
+    }
+    end)
+    local ifaces = {'wlan1-mesh', 'wlan2-mesh', 'wlan2-mesh_17', 'wlan0-adhoc_29', 'wlan1-adhoc'}
+    stub(utils, "get_ifnames", function () return ifaces end)
+    assert.is.same({hostname='LiMe-abcd00', iface='wlan1-mesh'}, bat_hosts.get_bathost('02:95:39:ab:cd:00'))
+    assert.is.same({hostname='LiMe-abcd01', iface='wlan2-mesh_17'}, bat_hosts.get_bathost('52:00:00:ab:cd:a0'))
+    assert.is.same({hostname='LiMe-abcd02', iface='wlan0-adhoc_29'}, bat_hosts.get_bathost('d6:67:58:8e:cd:92'))
+    assert.is.same({hostname='LiMe-abcd03', iface='wlan1-adhoc'}, bat_hosts.get_bathost('12:00:00:00:00:00'))
+    assert.is.same({hostname='Lime-abcd04', iface='wlan1-mesh'}, bat_hosts.get_bathost('52:01:00:ab:cd:00', 'wlan1-mesh'))
+    assert.is_nil(bat_hosts.get_bathost('00:aa:bb:cc:dd:00', 'wlan1'))
+    assert.is_nil(bat_hosts.get_bathost('00:aa:bb:cc:dd:00'))
+end)


### PR DESCRIPTION
Rpcd get bat hosts call was not working causing lime app UI to fail when trying to retrieve host names. 

This pull request fixes the rpc call. 

the function "bat_hosts.get_bat_hosts_from_shared_state()" was created for testing purposes. 

```bash
 ubus call bat-hosts get_bathost '{"mac":"AE:40:41:1C:85:16"}'
{
        "status": "ok",
        "bathost": {
                "iface": "wlan1-mesh_17",
                "hostname": "LiMe-8037b1"
        }
}
``` 