### PR TITLE
ci: multi-arch-build: enable the build of package index + various fixes

### DIFF
--- a/.github/workflows/multi-arch-build.yml
+++ b/.github/workflows/multi-arch-build.yml
@@ -10,12 +10,16 @@ on:
       - '!v2020*'
     paths:
       - 'packages/shared-state-async/**'
-      
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   build:
     name: build ${{ matrix.arch }} ${{ github.ref }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         arch:
           - aarch64_cortex-a53
@@ -51,16 +55,20 @@ jobs:
           - x86_64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build packages ${{ matrix.arch }}
-        uses: openwrt/gh-action-sdk@v5
+        uses: openwrt/gh-action-sdk@v7
         env:
           ARCH: "${{ matrix.arch }}"
           FEEDNAME: "libremesh"
           IGNORE_ERRORS: "n m y"
           KEY_BUILD: "${{ secrets.KEY_BUILD }}"
           PACKAGES: "shared-state-bat_hosts"
+          INDEX: 1
+          NO_DEFAULT_FEEDS: 1
+          NO_REFRESH_CHECK: 1
+          NO_SHFMT_CHECK: 1
 
       - name: Set package destination
         run: |


### PR DESCRIPTION
update gh-action-sdk from v5 to v7
prevent that entire workflow fail if a single arch fails 
allow to run the workflow manually
disable unnecessary options: default_feed, patches refresh_check, '*.init' files formatting