### PR TITLE
ci: multi-arch-build: run one job at a time

### DIFF
--- a/.github/workflows/multi-arch-build.yml
+++ b/.github/workflows/multi-arch-build.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         arch:
           - aarch64_cortex-a53


### PR DESCRIPTION
Quick fix for `Error: Action failed with "The process '/usr/bin/git' failed with exit code 1"` caused by the fact that the next job does checkout before the previous one has pushed.
It could be restructured as described here, but for now there is not much need, just do one at a time.

- https://github.com/peaceiris/actions-gh-pages/issues/608#issuecomment-834186136
- How to share matrix between jobs https://github.com/orgs/community/discussions/26284#discussioncomment-3251198