### PR TITLE
ci: multi-arch-build: use a different output path

### DIFF
--- a/.github/workflows/multi-arch-build.yml
+++ b/.github/workflows/multi-arch-build.yml
@@ -83,5 +83,5 @@ jobs:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: libremesh/lime-feed
           publish_dir: bin/packages/${{ matrix.arch }}/libremesh/
-          destination_dir: ${{ env.DEST_DIR }}/packages/${{ matrix.arch }}
+          destination_dir: arch_packages/${{ env.DEST_DIR }}/${{ matrix.arch }}
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Within the container, add the `lime-packages` feeds:
 
 ```shell
 echo "src/gz libremesh https://feed.libremesh.org/master" >> repositories.conf
-echo "src/gz libremesh_arch_packages https://feed.libremesh.org/master/packages/mips_24kc" >> repositories.conf
+echo "src/gz libremesh_arch_packages https://feed.libremesh.org/arch_packages/master/mips_24kc" >> repositories.conf
 echo  "untrusted comment: signed by libremesh.org key a71b3c8285abd28b" > keys/a71b3c8285abd28b
 echo "RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8" >> keys/a71b3c8285abd28b
 ```
 
-If your device is not part of ath79-generic replace `mips_24kc` with the architecture of the selected &lt;target&gt;-&lt;subtarget&gt;.
+If your device is not part of ath79-generic replace `mips_24kc` with the architecture of the selected &lt;target&gt;/&lt;subtarget&gt;.
 
 Ideally add your own `lime-community` files within the container in the folder
 `./files/etc/config/`. To find possible options consult the
@@ -95,10 +95,11 @@ Go to <https://firmware-selector.openwrt.org/>. Find your device. Click on the f
 
 ```shell
 echo "src/gz libremesh https://feed.libremesh.org/master" >> repositories.conf
-echo "src/gz libremesh_arch_packages https://feed.libremesh.org/master/packages/mips_24kc" >> repositories.conf
+echo "src/gz libremesh_arch_packages https://feed.libremesh.org/arch_packages/master/mips_24kc" >> repositories.conf
 echo  "untrusted comment: signed by libremesh.org key a71b3c8285abd28b" > keys/a71b3c8285abd28b
 echo "RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8" >> keys/a71b3c8285abd28b
 ```
+If your device is not part of ath79-generic replace `mips_24kc` with the architecture of the selected &lt;target&gt;/&lt;subtarget&gt;.
 
 Create an image with
 ```shell

--- a/packages/lime-system/files/etc/uci-defaults/92_add-lime-repos
+++ b/packages/lime-system/files/etc/uci-defaults/92_add-lime-repos
@@ -12,14 +12,14 @@ feeds_file="/etc/opkg/limefeeds.conf"
   exit 0
 }
 
-arch_packages="$(cat /etc/os-release | grep OPENWRT_ARCH | sed 's/OPENWRT_ARCH=\"\(.*\)\"/\1/')"
+arch_packages="$(grep OPENWRT_ARCH /etc/os-release | sed 's/OPENWRT_ARCH=\"\(.*\)\"/\1/')"
 
 [ "$LIME_CODENAME" == "development" ] && {
 	packages_url="http://feed.libremesh.org/master";
-	arch_packages_url="http://feed.libremesh.org/master/packages/$arch_packages";
+	arch_packages_url="http://feed.libremesh.org/arch_packages/master/$arch_packages";
 } || {
 	packages_url="http://feed.libremesh.org/$LIME_RELEASE"
-	arch_packages_url="http://feed.libremesh.org/$LIME_RELEASE/packages/$arch_packages";
+	arch_packages_url="http://feed.libremesh.org/arch_packages/$LIME_RELEASE/$arch_packages";
 }
 
 profiles_url="http://feed.libremesh.org/profiles"


### PR DESCRIPTION
I apologize for bothering again on this topic, but compiling via imagebuilder once again turns out to be broken.

I did not calculate that a subsequent compilation from the build.yml workflow would delete the subdirectory previously created by the multi-arch-build.yml workflow (e.g. now missing https://github.com/libremesh/lime-feed/tree/gh-pages/master/packages).

This fixes it, telling the multi-arch-build.yml workflow to use a different path for output packages to avoid overwriting.
This updates also `packages/lime-system/files/etc/uci-defaults/92_add-lime-repos` and `README.md` accordingly.

This also removes the feeds added by default by buildroot for each feed declared in feeds.conf and resulting in a known opkg error such as the one below:
```
root@ninux-598775:~# opkg update
[...]
Collected errors:
 * opkg_download: Failed to download http://downloads.openwrt.org/releases/19.07.10/packages/mips_24kc/libremesh/Packages.gz, wget returned 8.
 * opkg_download: Failed to download http://downloads.openwrt.org/releases/19.07.10/packages/mips_24kc/profiles/Packages.gz, wget returned 8.
 ```

