### PR TITLE
Adds shared-state rpcd data,error output format and shared-state-async rpcd reimplementation 

### DIFF
--- a/packages/shared-state-async/files/usr/libexec/rpcd/shared-state-async
+++ b/packages/shared-state-async/files/usr/libexec/rpcd/shared-state-async
@@ -1,13 +1,11 @@
 #!/bin/sh
-# --[[
-# Shared State Async
 
+# Shared State Async
 # Copyright (c) 2024 Javier Jorge <jjorge@inti.gob.ar>
 # Copyright (c) 2024 Instituto Nacional de Tecnologia Industrial
 # Copyright (C) 2024 Asociacion Civil Altermundi <info@altermundi.net>
-
 # SPDX-License-Identifier: AGPL-3.0-only
-# ]]
+
 
 sinc_args=""
  
@@ -18,8 +16,8 @@ case "$1" in
     call)
         # source jshn shell library
         . /usr/share/libubox/jshn.sh
-        read nmsg
-        json_load $nmsg
+        read msg
+        json_load $msg
         json_get_vars data_type 
         json_get_vars peers_ip
         case "$2" in 

--- a/packages/shared-state-async/files/usr/libexec/rpcd/shared-state-async
+++ b/packages/shared-state-async/files/usr/libexec/rpcd/shared-state-async
@@ -1,63 +1,43 @@
-#!/usr/bin/env lua
+#!/bin/sh
+# --[[
+# Shared State Async
 
---[[
-Shared State Async
+# Copyright (c) 2024 Javier Jorge <jjorge@inti.gob.ar>
+# Copyright (c) 2024 Instituto Nacional de Tecnologia Industrial
+# Copyright (C) 2024 Asociacion Civil Altermundi <info@altermundi.net>
 
-Copyright (c) 2024  Javier Jorge <jjorge@inti.gob.ar>
-Copyright (c) 2024  Instituto Nacional de Tecnolog..a Industrial
-Copyright (C) 2024  Asociacion Civil Altermundi <info@altermundi.net>
+# SPDX-License-Identifier: AGPL-3.0-only
+# ]]
 
-This is free software, licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3
-]]
---
-local utils = require('lime.utils')
-local json = require 'luci.jsonc'
-
-local function get(msg)
-    local error = os.execute("shared-state-async get " ..
-        msg.data_type .. " 2>/dev/null ")
-        -- if os.execute dont fail will print the output and rpcd wont execute
-        -- the following lines. If there is an error the above code wont print
-        -- anything and this code will return the error code.
-    utils.printJson({
-        error = error
-    })
-end
-
-local function sync(msg)
-    local error = os.execute("shared-state-async sync " ..
-            msg.data_type .. " " .. table.concat(msg.peers_ip or {}, " ") .. " 2>/dev/null ")
-    utils.printJson({
-      error = error
-    })
-end
-
---{"data_type":"data","peers_ip":["10.0.0.1","10.0.0.2"]}
---{"data_type":"data","peers_ip":["10.0.0.1"]}
-local methods = {
-    get = {
-        data_type = 'value'
-    },
-    sync = {
-        data_type = 'value',
-        peers_ip = 'value'
-    }
-}
-
-if arg[1] == 'list' then
-    utils.printJson(methods)
-end
-
-if arg[1] == 'call' then
-    local msg = utils.rpcd_readline()
-    msg = json.parse(msg)
-    if arg[2] == 'get' then
-        get(msg)
-    elseif arg[2] == 'sync' then
-        sync(msg)
-    else
-        utils.printJson({
-            error = "Method not found"
-        })
-    end
-end
+sinc_args=""
+ 
+case "$1" in 
+    list) 
+        echo '{ "sync": { "data_type": "str", "peers_ip": "str" }, "get": { "data_type": "str" } }'
+    ;; 
+    call)
+        # source jshn shell library
+        . /usr/share/libubox/jshn.sh
+        read nmsg
+        json_load $nmsg
+        json_get_vars data_type 
+        json_get_vars peers_ip
+        case "$2" in 
+            get) 
+                if output=$(shared-state-async get $data_type 2>/dev/null) 
+                then 
+                    echo {\"data\": $output , \"error\" :$?}
+                else 
+                    echo {\"data\": {} , \"error\": $? } 
+                fi 
+            ;; 
+            sync) 
+                shared-state-async sync $data_type ${peers_ip//,/ } > /dev/null 2>&1
+                echo {\"data\": {} , \"error\": $? } 
+            ;; 
+            *)
+                 echo '{\"data\" {} ,\"error\" = "Method not found"}' 
+            ;; 
+        esac 
+    ;; 
+esac 

--- a/packages/shared-state-async/tests/test_rpcd_shared-state-async.lua
+++ b/packages/shared-state-async/tests/test_rpcd_shared-state-async.lua
@@ -3,10 +3,10 @@ local sharedState = require("shared-state")
 local json = require("luci.jsonc")
 
 local testFileName = "packages/shared-state-async/files/usr/libexec/rpcd/shared-state-async"
-local sharedStateRpc = testUtils.load_lua_file_as_function(testFileName)
-local rpcdCall = testUtils.rpcd_call
+
 
 --since there is no Shared State async binary, testing possiblities are reduced
+--also testing the full 
 --manual testing can be done on a router with bat-hosts package using this commands:
 --ubus -S call shared-state-async get "{'data_type': 'bat-hosts'}"
 --ubus -S call shared-state-async sync "{'data_type': 'bat-hosts'}"
@@ -14,21 +14,12 @@ local rpcdCall = testUtils.rpcd_call
 
 
 describe('ubus-shared-state tests #ubus-shared-state', function()
-    before_each('', function()
-        testDir = testUtils.setup_test_dir()
-        sharedState.DATA_DIR = testDir
-        sharedState.PERSISTENT_DATA_DIR = testDir
-    end)
-
-    after_each('', function()
-        testUtils.teardown_test_dir()
-    end)
 
     it('test list methods', function()
-        local response = rpcdCall(sharedStateRpc, {'list'})
-        assert.is.equal("value", response.get.data_type)
-        assert.is.equal("value", response.sync.data_type)
-        assert.is.equal("value", response.sync.peers_ip)
-
+        local response = utils.unsafe_shell(testFileName.." list")
+        response = json.parse(response)
+        assert.is.equal("str", response.get.data_type)
+        assert.is.equal("str", response.sync.data_type)
+        assert.is.equal("str", response.sync.peers_ip)
     end)
 end)

--- a/packages/shared-state/files/usr/libexec/rpcd/shared-state
+++ b/packages/shared-state/files/usr/libexec/rpcd/shared-state
@@ -1,14 +1,11 @@
 #!/usr/bin/env lua
---[[
-Shared State
 
-Copyright (c) 2023  Javier Jorge <jjorge@inti.gob.ar>
-Copyright (c) 2023  Instituto Nacional de Tecnología Industrial
-Copyright (C) 2023  Asociación Civil Altermundi <info@altermundi.net>
+--! Shared State
+--! Copyright (c) 2023  Javier Jorge <jjorge@inti.gob.ar>
+--! Copyright (c) 2023  Instituto Nacional de Tecnología Industrial
+--! Copyright (C) 2023  Asociación Civil Altermundi <info@altermundi.net>
+--! SPDX-License-Identifier: AGPL-3.0-only
 
-This is free software, licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3
-]]
-   --
 local ubus = require "ubus"
 local utils = require('lime.utils')
 local shared_state = require("shared-state")

--- a/packages/shared-state/files/usr/libexec/rpcd/shared-state
+++ b/packages/shared-state/files/usr/libexec/rpcd/shared-state
@@ -1,5 +1,5 @@
-#!/usr/bin/env lua                     
---[[                                                                                 
+#!/usr/bin/env lua
+--[[
 Shared State
 
 Copyright (c) 2023  Javier Jorge <jjorge@inti.gob.ar>
@@ -7,7 +7,8 @@ Copyright (c) 2023  Instituto Nacional de Tecnología Industrial
 Copyright (C) 2023  Asociación Civil Altermundi <info@altermundi.net>
 
 This is free software, licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3
-]] --                                                                                 
+]]
+   --
 local ubus = require "ubus"
 local utils = require('lime.utils')
 local shared_state = require("shared-state")
@@ -15,31 +16,36 @@ local json = require 'luci.jsonc'
 
 require("nixio.util")
 
-local function getFromSharedState(msg)
-    local sharedState = shared_state.SharedState:new(msg.data_type, 
-		nixio.syslog)
+local response_template = {data = {}, error = 500}
+
+local function showData(sharedState)
     local resultTable = sharedState:get()
-    local response ={}
-    for k,v in pairs(resultTable) do
-        response[k]=v.data
+    if next(resultTable) == nill then
+        response_template.error = 404
+    else
+        for k, v in pairs(resultTable) do
+            response_template.data[k] = v.data
+        end
+        response_template.error = 0
     end
-    utils.printJson(response)
+    utils.printJson(response_template)
+end
+
+local function getFromSharedState(msg)
+    local sharedState = shared_state.SharedState:new(msg.data_type,
+        nixio.syslog)
+    showData(sharedState)
 end
 
 local function getFromSharedStateMultiWriter(msg)
-    local sharedState = shared_state.SharedStateMultiWriter:new(msg.data_type, 
-		nixio.syslog)
-    local resultTable = sharedState:get()
-    local response ={}
-    for k,v in pairs(resultTable) do
-        response[k]=v.data
-    end
-    utils.printJson(response)
+    local sharedState = shared_state.SharedStateMultiWriter:new(msg.data_type,
+        nixio.syslog)
+    showData(sharedState)
 end
 
 local function insertIntoSharedStateMultiWriter(msg)
-    local sharedState = shared_state.SharedStateMultiWriter:new(msg.data_type, 
-		nixio.syslog)
+    local sharedState = shared_state.SharedStateMultiWriter:new(msg.data_type,
+        nixio.syslog)
     local inputTable = msg.json or {}
     sharedState:insert(inputTable)
 end

--- a/packages/shared-state/tests/test_rpcd_shared-state.lua
+++ b/packages/shared-state/tests/test_rpcd_shared-state.lua
@@ -38,10 +38,20 @@ describe('ubus-shared-state tests #ubus-shared-state', function()
         assert.is.equal(dbA.zig.data, 'zag')
         local response = rpcdCall(sharedStateRpc, {'call', 'getFromSharedState'},
             '{"data_type": "wifi_links_info"}')
-        assert.is.equal(response.bar, 'foo')
-        assert.is.equal(response.baz, 'qux')
-        assert.is.equal(response.zig, 'zag')
+        assert.is.equal(response.data.bar, 'foo')
+        assert.is.equal(response.data.baz, 'qux')
+        assert.is.equal(response.data.zig, 'zag')
     end)
+
+    it('test get multiwriter data from empty data_type ', function()
+        local sharedStateA = sharedState.SharedStateMultiWriter:new('EMPTY')
+        
+        local response = rpcdCall(sharedStateRpc, {'call', 
+            'getFromSharedStateMultiWriter'}, '{"data_type": "EMPTY"}')
+        assert.is.equal(response.error, 404)
+        assert.is.equal(next(response.data), next({}))
+    end)
+
 
     it('test get multiwriter data ', function()
         local sharedStateA = sharedState.SharedStateMultiWriter:new('A')
@@ -55,9 +65,9 @@ describe('ubus-shared-state tests #ubus-shared-state', function()
         assert.is.equal('zag', dbA.zig.data)
         local response = rpcdCall(sharedStateRpc, {'call', 
             'getFromSharedStateMultiWriter'}, '{"data_type": "A"}')
-        assert.is.equal(response.bar, 'foo')
-        assert.is.equal(response.baz, 'qux')
-        assert.is.equal(response.zig, 'zag')
+        assert.is.equal(response.data.bar, 'foo')
+        assert.is.equal(response.data.baz, 'qux')
+        assert.is.equal(response.data.zig, 'zag')
     end)
 
     it('test insert multiwriter data ', function()
@@ -87,8 +97,8 @@ describe('ubus-shared-state tests #ubus-shared-state', function()
         })
         local response = rpcdCall(sharedStateRpc, {'call', 
             'getFromSharedStateMultiWriter'}, '{"data_type": "A"}')
-        assert.is.equal('foo', response.bar)
-        assert.is.equal('zag', response.zig)
+        assert.is.equal('foo', response.data.bar)
+        assert.is.equal('zag', response.data.zig)
         response.zig="newzag"
         callargs =  '{"data_type": "A", "json": '..json.stringify(response)..'}'
         local response = rpcdCall(sharedStateRpc, {'call', 
@@ -143,7 +153,7 @@ describe('ubus-shared-state tests #ubus-shared-state', function()
             '{"data_type": "A", "json": {"zig": "zag"}}')
         response = rpcdCall(sharedStateRpc, {'call', 
             'getFromSharedStateMultiWriter'}, '{"data_type": "A"}')
-        assert.is.equal(response.zig, 'zag')
+        assert.is.equal(response.data.zig, 'zag')
 
         response = rpcdCall(sharedStateRpc, {'call', 
             'insertIntoSharedStateMultiWriter'},
@@ -151,8 +161,8 @@ describe('ubus-shared-state tests #ubus-shared-state', function()
         response = rpcdCall(sharedStateRpc, {'call', 
             'getFromSharedStateMultiWriter'},
             '{"data_type": "ref_state_wifilinks"}')
-        assert.is.equal(response.primero.bleachTTL, 23)
-        assert.is.equal(response.primero.author, "primero")
+        assert.is.equal(response.data.primero.bleachTTL, 23)
+        assert.is.equal(response.data.primero.author, "primero")
 
         response = rpcdCall(sharedStateRpc, {'call', 
         'insertIntoSharedStateMultiWriter'},wifiStatusJsonsample27)
@@ -161,8 +171,8 @@ describe('ubus-shared-state tests #ubus-shared-state', function()
             'getFromSharedStateMultiWriter'},
             '{"data_type": "ref_state_wifilinks"}')
 
-        assert.is.equal(response.primero.bleachTTL, 27)
-        assert.is.equal(response.primero.author, "primero")
+        assert.is.equal(response.data.primero.bleachTTL, 27)
+        assert.is.equal(response.data.primero.author, "primero")
 
         response = rpcdCall(sharedStateRpc, {'call', 
             'insertIntoSharedStateMultiWriter'},
@@ -170,7 +180,7 @@ describe('ubus-shared-state tests #ubus-shared-state', function()
         response = rpcdCall(sharedStateRpc, {'call', 
             'getFromSharedStateMultiWriter'},
             '{"data_type": "ref_state_wifilinks"}')
-        assert.is.equal(response.primero.bleachTTL, 23)
-        assert.is.equal(response.primero.author, "primero")
+        assert.is.equal(response.data.primero.bleachTTL, 23)
+        assert.is.equal(response.data.primero.author, "primero")
     end)
 end)


### PR DESCRIPTION
# Ubus interface for shared state 

current implementations of rpcd for shared-state are inconsistent this new implementation adds a consistent format across the three implementations (shared-state, shared-state-async, shared-state-multiwriter ) 
In every case calls to shared state get or sync will return a json object wit this format 

```JSON 
{"data":{},"error":0}
```

Also this new implementation for shared-state-async uses a shell script to simplify the implementation 

## Ubus interface for shared state async

ubus -S call shared-state-async get '{"data_type": "bat-hosts"}'
```JSON 
{
  "data": {
    "02:29:0f:a5:1e:d1": "LiMe_a51ed1_eth1_2_29",
    "02:58:47:a5:1e:d1": "LiMe_a51ed1_wlan0_mesh_29",
    "02:95:39:a5:1e:d1": "LiMe_a51ed1_eth0_29",
    "02:ab:46:a5:1e:d1": "LiMe_a51ed1_wlan1_mesh_29",
    "02:bb:ed:a5:1e:d1": "LiMe_a51ed1_eth1_29",
    "02:cc:4e:a5:1e:d1": "LiMe_a51ed1_wlan2_mesh_29",
    "02:db:d6:a5:1e:d1": "LiMe_a51ed1_eth0_1_29",
    "06:ef:f4:3d:4d:75": "LiMe_a51ed1_bat0",
    "a8:40:41:1c:85:16": "LiMe_a51ed1_wlan1_ap",
    "a8:40:41:1c:85:c3": "LiMe_a51ed1_wlan2_ap",
    "a8:40:41:1f:73:a8": "LiMe_a51ed1_wlan0_ap",
    "a8:40:41:1f:73:aa": "LiMe_a51ed1_eth0_1_17",
    "a8:40:41:1f:73:ab": "LiMe_a51ed1_eth1_17",
    "aa:40:41:1c:85:16": "LiMe_a51ed1_wlan1_apname",
    "aa:40:41:1c:85:c3": "LiMe_a51ed1_wlan2_apname",
    "aa:40:41:1f:73:a8": "LiMe_a51ed1_wlan0_apname",
    "ae:40:41:1c:85:16": "LiMe_a51ed1_wlan1_mesh",
    "ae:40:41:1c:85:c3": "LiMe_a51ed1_wlan2_mesh",
    "ae:40:41:1f:73:a8": "LiMe_a51ed1_wlan0_mesh"
  },
  "error": 0
}
```

ubus -S call shared-state-async get '{"data_type": "bat-hosss"}'
```JSON 
{"data":{},"error":208}
```
ubus -S call shared-state-async sync '{"data_type": "bat-hosts"}'
```JSON 
{"data":{},"error":146}
```
ubus -S call shared-state-async sync '{"data_type": "bat-hosss"}'
```JSON 
{"data":{},"error":208}
 ```
ubus -S call shared-state-async sync '{"data_type": "bat-hostss", "peers_ip":"10.13.30.20"}'
```JSON 
{"data":{},"error":208}
```
ubus -S call shared-state-async sync '{"data_type": "bat-hosts", "peers_ip":"10.13.30.20"}'
```JSON 
{"data":{},"error":148}
```
ubus -S call shared-state-async sync '{"data_type": "bat-hosts", "peers_ip":"127.0.0.1"}'
```JSON 
{"data":{},"error":0}

```
## Ubus interface for shared state and shared state Multiwriter


Get the list of available methods using:

ubus -v list shared-state

Get wifi links information: 

ubus -S call shared-state getFromSharedState '{"data_type": "wifi_links_info" }'

Write information that is common to every all the network:

ubus -S call shared-state insertIntoSharedStateMultiWriter '{"data_type": "ref_state_wifi_links", "json": {"primero":{"bleachTTL":27}}}'

Get the information in the same node:

ubus -S call shared-state getFromSharedStateMultiWriter '{"data_type": "ref_state_wifi_links"}'
```JSON 
{"data":{"primero":{"bleachTTL":27}},"error":0}
```

Get the info in another node, before getting the information the others need to sync on the same topic.
This has to be done before reading and data types usually do it in a cron job. 

shared-state-multiwriter sync ref_state_wifi_links

ubus -S call shared-state getFromSharedStateMultiWriter '{"data_type": "ref_state_wifi_links" }'
