### PR TITLE
shared-state-async: add publisher call interface

### DIFF
--- a/packages/shared-state-async/files/usr/libexec/rpcd/shared-state-async
+++ b/packages/shared-state-async/files/usr/libexec/rpcd/shared-state-async
@@ -11,7 +11,7 @@ sinc_args=""
  
 case "$1" in 
     list) 
-        echo '{ "sync": { "data_type": "str", "peers_ip": "str" }, "get": { "data_type": "str" },  "publish": { "data_type": "str" } }'
+        echo '{ "sync": { "data_type": "str", "peers_ip": "str" }, "get": { "data_type": "str" },  "publish": { "data_type": "str" }, "publish_all": { } }'
     ;; 
     call)
         # source jshn shell library
@@ -36,6 +36,10 @@ case "$1" in
             publish) 
                 /usr/share/shared-state/publishers/shared-state-publish_$data_type > /dev/null 2>&1
                 echo {\"data\": {} , \"error\": $? } 
+            ;;
+            publish_all)
+                shared-state-async-publish-all > /dev/null 2>&1
+                echo {\"data\": {} , \"error\": $? }
             ;;
             *)
                  echo '{\"data\" {} ,\"error\" = "Method not found"}' 

--- a/packages/shared-state-async/files/usr/libexec/rpcd/shared-state-async
+++ b/packages/shared-state-async/files/usr/libexec/rpcd/shared-state-async
@@ -11,7 +11,7 @@ sinc_args=""
  
 case "$1" in 
     list) 
-        echo '{ "sync": { "data_type": "str", "peers_ip": "str" }, "get": { "data_type": "str" } }'
+        echo '{ "sync": { "data_type": "str", "peers_ip": "str" }, "get": { "data_type": "str" },  "publish": { "data_type": "str" } }'
     ;; 
     call)
         # source jshn shell library
@@ -33,6 +33,10 @@ case "$1" in
                 shared-state-async sync $data_type ${peers_ip//,/ } > /dev/null 2>&1
                 echo {\"data\": {} , \"error\": $? } 
             ;; 
+            publish) 
+                /usr/share/shared-state/publishers/shared-state-publish_$data_type > /dev/null 2>&1
+                echo {\"data\": {} , \"error\": $? } 
+            ;;
             *)
                  echo '{\"data\" {} ,\"error\" = "Method not found"}' 
             ;; 


### PR DESCRIPTION
This pull request enables rpcd publisher call, so a publish followed by a sync deliver accurate and updated data. 

Node A should rpcd call to Node B publish and then 
Node A should call its own rpcd sync using its datatype and the IP of node B
Bat hosts publisher name has to be updated before closing this pull request