### PR TITLE
lime-example: specify that the gateway line in the static proto is optional

### DIFF
--- a/packages/lime-docs/files/www/docs/lime-example.txt
+++ b/packages/lime-docs/files/www/docs/lime-example.txt
@@ -224,9 +224,9 @@ config net wirelessclientbackbone
 #	list protocols 'wan'				# Some of these protocols require the relative package "lime-proto-..."
 #	list protocols 'static'				# Set up a static IP (both IPv4 and IPv6 supported)
 #	option static_ipv4 '192.168.1.2/24'
-#	option static_gateway_ipv4 '192.168.1.1'
+#	option static_gateway_ipv4 '192.168.1.1'	# in static protocol, specifying an IP for the gateway is optional. Skip this line if no default route should be added on this interface.
 #	option static_ipv6 '2a00:1508:0a00::1234/64'
-#	option static_gateway_ipv6 'fe80::1'
+#	option static_gateway_ipv6 'fe80::1'		# in static protocol, specifying an IP for the gateway is optional. Skip this line if no default route should be added on this interface.
 
 ## (optional) configure lan1 for connection to other nodes, not for users connection:
 config net


### PR DESCRIPTION
In the lime-example.txt file, the static configuration of an IP was shown with a line configuring the gateway for that interface.
Here I just added a comment for stating that the gateway configuration can be skipped if no default route is needed on that interface.