### PR TITLE
fix broken profiles

### DIFF
--- a/packages/shared-state-bat_hosts/Makefile
+++ b/packages/shared-state-bat_hosts/Makefile
@@ -20,7 +20,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Asociación Civil Altermundi <info@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=+libubus-lua +lime-system +lua +luci-lib-jsonc +luci-lib-nixio \
-	         shared-state-async
+	         +shared-state-async
 	PKGARCH:=all
 endef
 


### PR DESCRIPTION
Following the official instructions on the libremesh development project page but using the owrt v23.05.3 branch, the profiles are broken because sharede-state-bat-hosts depend on shared-state-async and without the "+" it doesn't select the package.