### PR TITLE
Stop using random-numgen, not needed in recent OpenWrt

### DIFF
--- a/packages/bmx7-auto-gw-bw-mode/files/usr/sbin/bmx7-auto-bw-test
+++ b/packages/bmx7-auto-gw-bw-mode/files/usr/sbin/bmx7-auto-bw-test
@@ -7,7 +7,7 @@ bw_test() {
   while [ -z "$bw" -a $try -lt $TRIES ]; do
     test=$({ wget -T5 -q $1 -O- | pv -n -b -t >/dev/null; } 2>&1)
     bw=$(echo $test | awk '{printf "%.0f",$NF/$(NF-1)*8}')
-    try=$(($try+1))
+    try=$((try+1))
   done
   echo $bw
 }

--- a/packages/check-date-http/Makefile
+++ b/packages/check-date-http/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+libuci-lua +lua +random-numgen \
+	DEPENDS:=+libuci-lua +lua \
 		+luci-lib-httpclient
 	PKGARCH:=all
 endef

--- a/packages/check-date-http/files/etc/uci-defaults/check-date-http-cron
+++ b/packages/check-date-http/files/etc/uci-defaults/check-date-http-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/20 * * * * ((sleep $(($RANDOM % 600)); check-date-http &> /dev/null)&)'\
+	'*/20 * * * * ((sleep $((RANDOM % 600)); check-date-http &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/check-date-http/files/etc/uci-defaults/check-date-http-cron
+++ b/packages/check-date-http/files/etc/uci-defaults/check-date-http-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/20 * * * * ((sleep $(($(random-numgen) % 600)); check-date-http &> /dev/null)&)'\
+	'*/20 * * * * ((sleep $(($RANDOM % 600)); check-date-http &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/eupgrade/Makefile
+++ b/packages/eupgrade/Makefile
@@ -11,7 +11,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=Utilities
   TITLE:=$(PKG_NAME) provides semi automated firmware upgrades
   MAINTAINER:=Santiago Piccinini <spiccinini@altermundi.net>
-  DEPENDS:=+lua +lime-system +luci-lib-jsonc +luci-lib-nixio +libubus-lua +libuci-lua +random-numgen
+  DEPENDS:=+lua +lime-system +luci-lib-jsonc +luci-lib-nixio +libubus-lua +libuci-lua
   PKGARCH:=all
 endef
 

--- a/packages/eupgrade/files/etc/uci-defaults/99-eupgrades-cron
+++ b/packages/eupgrade/files/etc/uci-defaults/99-eupgrades-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'0 */6 * * * ((sleep $(($(random-numgen) % 120)); eupgrade-check &> /dev/null)&)'\
+	'0 */6 * * * ((sleep $(($RANDOM % 120)); eupgrade-check &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/eupgrade/files/etc/uci-defaults/99-eupgrades-cron
+++ b/packages/eupgrade/files/etc/uci-defaults/99-eupgrades-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'0 */6 * * * ((sleep $(($RANDOM % 120)); eupgrade-check &> /dev/null)&)'\
+	'0 */6 * * * ((sleep $((RANDOM % 120)); eupgrade-check &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/hotplug-initd-services/Makefile
+++ b/packages/hotplug-initd-services/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+libubox-lua +libubus-lua +random-numgen \
+	DEPENDS:=+libubox-lua +libubus-lua \
 		+lua +luci-lib-nixio
 	PKGARCH:=all
 endef

--- a/packages/lime-app/files/etc/uci-defaults/shared-state-reference_state_nodes_info_cron
+++ b/packages/lime-app/files/etc/uci-defaults/shared-state-reference_state_nodes_info_cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state-multiwriter sync reference_state_nodes_info &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $((RANDOM % 120)); shared-state-multiwriter sync reference_state_nodes_info &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/lime-app/files/etc/uci-defaults/shared-state-reference_state_wifi_links_info_cron
+++ b/packages/lime-app/files/etc/uci-defaults/shared-state-reference_state_wifi_links_info_cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state-multiwriter sync reference_state_wifi_links_info &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $((RANDOM % 120)); shared-state-multiwriter sync reference_state_wifi_links_info &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-async/files/etc/uci-defaults/shared-state-net_stats-cron
+++ b/packages/shared-state-async/files/etc/uci-defaults/shared-state-net_stats-cron
@@ -15,5 +15,5 @@ uci set shared-state.${mSc}.update_interval='120'
 uci commit shared-state
 
 unique_append \
-	'*/3 * * * * ((sleep $(($RANDOM % 120)); shared-state-async insert net-stats < /tmp/shared-state/network_statistics.json &> /dev/null)&)' \
+	'*/3 * * * * ((sleep $((RANDOM % 120)); shared-state-async insert net-stats < /tmp/shared-state/network_statistics.json &> /dev/null)&)' \
 	/etc/crontabs/root

--- a/packages/shared-state-async/files/etc/uci-defaults/shared-state-publish-all-cron
+++ b/packages/shared-state-async/files/etc/uci-defaults/shared-state-publish-all-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/30 * * * * ((sleep $(($RANDOM % 120)); shared-state-async-publish-all &> /dev/null)&)' \
+	'*/30 * * * * ((sleep $((RANDOM % 120)); shared-state-async-publish-all &> /dev/null)&)' \
 	/etc/crontabs/root

--- a/packages/shared-state-babel_links_info/Makefile
+++ b/packages/shared-state-babel_links_info/Makefile
@@ -12,7 +12,7 @@ define Package/$(PKG_NAME)
 	TITLE:=Babel links module for shared-state
 	MAINTAINER:=Asociación Civil Altermundi <info@altermundi.net>
 	DEPENDS:=+lua +luci-lib-jsonc +ubus-lime-utils \
-		+libubus-lua +random-numgen shared-state-async   
+		+libubus-lua shared-state-async
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-babeld_hosts/Makefile
+++ b/packages/shared-state-babeld_hosts/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+hotplug-initd-services +random-numgen \
+	DEPENDS:=+hotplug-initd-services \
 		+lua +luci-lib-jsonc shared-state
 	PKGARCH:=all
 endef

--- a/packages/shared-state-babeld_hosts/files/etc/uci-defaults/shared-state-babeld_hosts-cron
+++ b/packages/shared-state-babeld_hosts/files/etc/uci-defaults/shared-state-babeld_hosts-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync babeld-hosts &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $((RANDOM % 120)); shared-state sync babeld-hosts &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-babeld_hosts/files/etc/uci-defaults/shared-state-babeld_hosts-cron
+++ b/packages/shared-state-babeld_hosts/files/etc/uci-defaults/shared-state-babeld_hosts-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state sync babeld-hosts &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync babeld-hosts &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-dnsmasq_hosts/Makefile
+++ b/packages/shared-state-dnsmasq_hosts/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc +random-numgen \
+	DEPENDS:=+lua +luci-lib-jsonc \
 		shared-state
 	PKGARCH:=all
 endef

--- a/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
+++ b/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state sync dnsmasq-hosts &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-hosts &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
+++ b/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-hosts &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $((RANDOM % 120)); shared-state sync dnsmasq-hosts &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-dnsmasq_leases/Makefile
+++ b/packages/shared-state-dnsmasq_leases/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+libuci-lua +lua +random-numgen \
+	DEPENDS:=+libuci-lua +lua \
 		+luci-lib-jsonc shared-state +shared-state-dnsmasq_hosts \
 		+luci-lib-nixio
 	PKGARCH:=all

--- a/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
+++ b/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
@@ -12,7 +12,7 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-leases &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $((RANDOM % 120)); shared-state sync dnsmasq-leases &> /dev/null)&)'\
 	/etc/crontabs/root
 
 exit 0

--- a/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
+++ b/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
@@ -12,7 +12,7 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state sync dnsmasq-leases &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-leases &> /dev/null)&)'\
 	/etc/crontabs/root
 
 exit 0

--- a/packages/shared-state-dnsmasq_servers/Makefile
+++ b/packages/shared-state-dnsmasq_servers/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gui iribarren <gui@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc +random-numgen \
+	DEPENDS:=+lua +luci-lib-jsonc \
 		shared-state
 	PKGARCH:=all
 endef

--- a/packages/shared-state-dnsmasq_servers/files/etc/uci-defaults/shared-state-dnsmasq_servers
+++ b/packages/shared-state-dnsmasq_servers/files/etc/uci-defaults/shared-state-dnsmasq_servers
@@ -10,5 +10,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state sync dnsmasq-servers &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-servers &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-dnsmasq_servers/files/etc/uci-defaults/shared-state-dnsmasq_servers
+++ b/packages/shared-state-dnsmasq_servers/files/etc/uci-defaults/shared-state-dnsmasq_servers
@@ -10,5 +10,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync dnsmasq-servers &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $((RANDOM % 120)); shared-state sync dnsmasq-servers &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-network_nodes/Makefile
+++ b/packages/shared-state-network_nodes/Makefile
@@ -11,7 +11,7 @@ define Package/$(PKG_NAME)
   TITLE:=$(PKG_NAME) provides data-type for network nodes marked as reliable by user
   MAINTAINER:=Asociacion Civil Altermundi <info@altermundi.net>
   DEPENDS:=+shared-state +shared-state-nodes_and_links +lime-system +luci-lib-jsonc \
-	   +libubus-lua +random-numgen
+	   +libubus-lua
   PKGARCH:=all
 endef
 

--- a/packages/shared-state-network_nodes/files/etc/uci-defaults/shared-state-network_nodes-cron
+++ b/packages/shared-state-network_nodes/files/etc/uci-defaults/shared-state-network_nodes-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state-multiwriter sync network_nodes &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $((RANDOM % 120)); shared-state-multiwriter sync network_nodes &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-network_nodes/files/etc/uci-defaults/shared-state-network_nodes-cron
+++ b/packages/shared-state-network_nodes/files/etc/uci-defaults/shared-state-network_nodes-cron
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state-multiwriter sync network_nodes &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state-multiwriter sync network_nodes &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-node_info/files/etc/uci-defaults/shared-state_node_info_cron
+++ b/packages/shared-state-node_info/files/etc/uci-defaults/shared-state_node_info_cron
@@ -5,5 +5,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync node_info &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $((RANDOM % 120)); shared-state sync node_info &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-nodes_and_links/Makefile
+++ b/packages/shared-state-nodes_and_links/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Nicolas Pace <nico@libre.ws>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc +random-numgen \
+	DEPENDS:=+lua +luci-lib-jsonc \
 		shared-state +ubus-lime-location
 	PKGARCH:=all
 endef

--- a/packages/shared-state-nodes_and_links/files/etc/uci-defaults/shared-state-bat_nodes_and_links
+++ b/packages/shared-state-nodes_and_links/files/etc/uci-defaults/shared-state-bat_nodes_and_links
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($(random-numgen) % 120)); shared-state sync nodes_and_links &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync nodes_and_links &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-nodes_and_links/files/etc/uci-defaults/shared-state-bat_nodes_and_links
+++ b/packages/shared-state-nodes_and_links/files/etc/uci-defaults/shared-state-bat_nodes_and_links
@@ -6,5 +6,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync nodes_and_links &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $((RANDOM % 120)); shared-state sync nodes_and_links &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state-pirania/Makefile
+++ b/packages/shared-state-pirania/Makefile
@@ -19,7 +19,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Asociación Civil AlterMundi <info@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc +random-numgen shared-state
+	DEPENDS:=+lua +luci-lib-jsonc shared-state
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-pirania/files/etc/uci-defaults/90-pirania-cron
+++ b/packages/shared-state-pirania/files/etc/uci-defaults/90-pirania-cron
@@ -6,7 +6,7 @@ unique_append()
 }
 
 unique_append \
-	'*/2 * * * * ((sleep $(($RANDOM % 30)); /etc/shared-state/publishers/shared-state-publish_vouchers && shared-state sync pirania-vouchers &> /dev/null)&)'\
+	'*/2 * * * * ((sleep $((RANDOM % 30)); /etc/shared-state/publishers/shared-state-publish_vouchers && shared-state sync pirania-vouchers &> /dev/null)&)'\
 	/etc/crontabs/root
 
 exit 0

--- a/packages/shared-state-pirania/files/etc/uci-defaults/90-pirania-cron
+++ b/packages/shared-state-pirania/files/etc/uci-defaults/90-pirania-cron
@@ -6,7 +6,7 @@ unique_append()
 }
 
 unique_append \
-	'*/2 * * * * ((sleep $(($(random-numgen) % 30)); /etc/shared-state/publishers/shared-state-publish_vouchers && shared-state sync pirania-vouchers &> /dev/null)&)'\
+	'*/2 * * * * ((sleep $(($RANDOM % 30)); /etc/shared-state/publishers/shared-state-publish_vouchers && shared-state sync pirania-vouchers &> /dev/null)&)'\
 	/etc/crontabs/root
 
 exit 0

--- a/packages/shared-state-wifi_links_info/files/etc/uci-defaults/shared-state_wifi_links_info
+++ b/packages/shared-state-wifi_links_info/files/etc/uci-defaults/shared-state_wifi_links_info
@@ -5,5 +5,5 @@ unique_append()
 }
 
 unique_append \
-	'*/5 * * * * ((sleep $(($RANDOM % 120)); shared-state sync wifi_links_info &> /dev/null)&)'\
+	'*/5 * * * * ((sleep $((RANDOM % 120)); shared-state sync wifi_links_info &> /dev/null)&)'\
 	/etc/crontabs/root

--- a/packages/shared-state/Makefile
+++ b/packages/shared-state/Makefile
@@ -20,7 +20,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=+libuci-lua +lime-system +lua +luci-lib-jsonc +luci-lib-nixio \
-		+iputils-ping +uclient-fetch +random-numgen
+		+iputils-ping +uclient-fetch
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state/files/etc/uci-defaults/shared-state-publishers-cron
+++ b/packages/shared-state/files/etc/uci-defaults/shared-state-publishers-cron
@@ -6,7 +6,7 @@ unique_append()
 }
 
 unique_append \
-	'*/30 * * * * ((sleep $(($RANDOM % 1000)); shared-state-publish-all &> /dev/null)&)'\
+	'*/30 * * * * ((sleep $((RANDOM % 1000)); shared-state-publish-all &> /dev/null)&)'\
 	/etc/crontabs/root
 
 unique_append \

--- a/packages/shared-state/files/etc/uci-defaults/shared-state-publishers-cron
+++ b/packages/shared-state/files/etc/uci-defaults/shared-state-publishers-cron
@@ -6,7 +6,7 @@ unique_append()
 }
 
 unique_append \
-	'*/30 * * * * ((sleep $(($(random-numgen) % 1000)); shared-state-publish-all &> /dev/null)&)'\
+	'*/30 * * * * ((sleep $(($RANDOM % 1000)); shared-state-publish-all &> /dev/null)&)'\
 	/etc/crontabs/root
 
 unique_append \

--- a/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
+++ b/packages/shared-state/files/usr/bin/shared-state-get_candidates_neigh
@@ -20,7 +20,7 @@ lastRunFile="/tmp/shared-state-get_candidates_neigh.lastrun"
 lastRun=$(if [ -s $lastRunFile ]; then echo $(cat $lastRunFile); else  echo -9999; fi)
 currUptime="$(get_uptime)"
 
-[ "$(($currUptime - $lastRun))" -lt "30" ] &&
+[ "$((currUptime - lastRun))" -lt "30" ] &&
 {
 	cat "$cacheFile"
 	exit 0


### PR DESCRIPTION
The random-numgen package was created in #991 as in OpenWrt 21 BusyBox did not have $RANDOM enabled by default (so it was not present in the official ImageBuilder), see #800.

But since OpenWrt 22 it is present by default, see https://github.com/openwrt/packages/pull/20728 so there is no need to use it.

Maybe we can keep the random-numgen package for a few more years and then delete it.

This commit should be picked also in the 2024.1 branch.

Fix #1075