### PR TITLE
Ensure that wan interface gets configured on DSA devices, where wan could be the name of the interface

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -259,12 +259,14 @@ function network.scandevices()
 
 		--! With DSA, the WAN is named wan. Copying the code from the lan case.
 		if dev:match("^wan$") then
+			devices[dev] = {}
 			local lower_if = network._get_lower(dev)
 			if lower_if then
 				devices[lower_if] = { nobridge = true }
-				devices[dev] = {}
 				utils.log( "network.scandevices.dev_parser found WAN port %s " ..
 				           "and marking %s as nobridge", dev, lower_if )
+			else
+				utils.log( "network.scandevices.dev_parser found WAN port %s", dev)
 			end
 		end
 


### PR DESCRIPTION
Initially proposed in this comment: https://github.com/libremesh/lime-packages/pull/1080#issuecomment-2351774330

On DSA devices, the "wan" interface could be named just "wan", without having any lower interface.
This ensures that it gets configured by the protocols even if it has no lower interface.

@pony1k @G10h4ck do you think that the same will be needed for LAN?