### PR TITLE
fix: ci build packages failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build packages
-        uses: openwrt/gh-action-sdk@v5
+        uses: openwrt/gh-action-sdk@v7
         env:
-          ARCH: "x86_64"
+          ARCH: "x86_64-openwrt-23.05"
           FEEDNAME: "libremesh"
           IGNORE_ERRORS: "n m y"
           KEY_BUILD: "${{ secrets.KEY_BUILD }}"


### PR DESCRIPTION
this is intended to postpone #1139 while restoring the automatic build of packages