### PR TITLE
fixed typo ubus-lime-groundrouting in lime-app's Makefile

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
 	URL:=http://github.com/libremesh/lime-app
 	DEPENDS:=+rpcd +uhttpd +uhttpd-mod-ubus +uhttpd-mod-lua \
 		+ubus-lime-location +ubus-lime-metrics +ubus-lime-utils \
-		+rpcd-mod-iwinfo +ubus-lime-grondrouting
+		+rpcd-mod-iwinfo +ubus-lime-groundrouting
 	PKGARCH:=all
 endef
 


### PR DESCRIPTION
That typo was introduced in January 2019 with this commit https://github.com/libremesh/lime-packages/commit/8fe8d05b3ad126d78f5615d3c8abf74c3e446949 part of https://github.com/libremesh/lime-packages/pull/453

It causes this warning and error messages when building LibreMesh using the [Buildroot method](https://libremesh.org/development.html#compiling_libremesh_from_source_code):

```
WARNING: Makefile 'package/feeds/libremesh/lime-app/Makefile' has a dependency on 'ubus-lime-grondrouting', which does not exist
 * pkg_hash_check_unresolved: cannot find dependency ubus-lime-grondrouting for lime-app
```
