### PR TITLE
Fixes on ubus-lime-utils

### DIFF
--- a/packages/ubus-lime-utils/files/etc/udhcpc.user.d/50-client-wwan-watchping
+++ b/packages/ubus-lime-utils/files/etc/udhcpc.user.d/50-client-wwan-watchping
@@ -8,7 +8,7 @@ setup_hotspot_watchping() {
         uci set system.hotspot_watchping.pinghosts=$gw
         uci set system.hotspot_watchping.pinginterval=20s
         uci commit system
-        /etc/init.d/watchping restart
+        [ -e /etc/init.d/watchping ] && /etc/init.d/watchping restart
     fi
 }
 

--- a/packages/ubus-lime-utils/files/etc/udhcpc.user.d/50-client-wwan-watchping
+++ b/packages/ubus-lime-utils/files/etc/udhcpc.user.d/50-client-wwan-watchping
@@ -1,14 +1,17 @@
 setup_hotspot_watchping() {
     ifname="client-wwan"
-    gw=$(ip r show default dev $ifname | while read default via ip rest; do [[ $via == "via" ]] && echo $ip && break; done)
-    if [ -n "$gw" ]; then
-        uci set system.hotspot_watchping=watchping
-        uci set system.hotspot_watchping.interface=$ifname
-        uci set system.hotspot_watchping.timeout=2m
-        uci set system.hotspot_watchping.pinghosts=$gw
-        uci set system.hotspot_watchping.pinginterval=20s
-        uci commit system
-        [ -e /etc/init.d/watchping ] && /etc/init.d/watchping restart
+    # check if interface exists before running the ip command on it
+    if [ -e /sys/class/net/$ifname/type ]; then
+        gw=$(ip r show default dev $ifname | while read default via ip rest; do [[ $via == "via" ]] && echo $ip && break; done)
+        if [ -n "$gw" ]; then
+            uci set system.hotspot_watchping=watchping
+            uci set system.hotspot_watchping.interface=$ifname
+            uci set system.hotspot_watchping.timeout=2m
+            uci set system.hotspot_watchping.pinghosts=$gw
+            uci set system.hotspot_watchping.pinginterval=20s
+            uci commit system
+            [ -e /etc/init.d/watchping ] && /etc/init.d/watchping restart
+        fi
     fi
 }
 

--- a/packages/ubus-lime-utils/files/etc/udhcpc.user.d/50-client-wwan-watchping
+++ b/packages/ubus-lime-utils/files/etc/udhcpc.user.d/50-client-wwan-watchping
@@ -1,7 +1,7 @@
 setup_hotspot_watchping() {
     ifname="client-wwan"
     gw=$(ip r show default dev $ifname | while read default via ip rest; do [[ $via == "via" ]] && echo $ip && break; done)
-    if [ -n gw ]; then
+    if [ -n "$gw" ]; then
         uci set system.hotspot_watchping=watchping
         uci set system.hotspot_watchping.interface=$ifname
         uci set system.hotspot_watchping.timeout=2m


### PR DESCRIPTION
The first and the third commits fix #956 

I considered that the usage of watchping is not a real dependency of this package (this package does things even if watchping is not doing its things). So, rather than adding the dependency, I added a check for the existence of watchping (first commit).

The second commit is fixing a bug undetected since its introduction in https://github.com/libremesh/lime-packages/commit/400ac95448a1f1d5a83496488e40c302cde766f0 within #890

The third commit is checking if the `client-wwan` interface exists before running ip on it.

This could also be merged in the 2024.1 branch for the upcoming release.