### PR TITLE
network._get_lower do not cause "ls" error when there is no lower

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -214,7 +214,7 @@ function network.clean()
 end
 
 function network._get_lower(dev)
-    local lower_if_path = utils.unsafe_shell("ls -d /sys/class/net/" .. dev .. "/lower*")
+    local lower_if_path = utils.unsafe_shell("ls /sys/class/net/" .. dev .. "/ | grep ^lower")
     local lower_if_table = utils.split(lower_if_path, "_")
     local lower_if = lower_if_table[#lower_if_table]
     return lower_if and lower_if:gsub("\n", "")


### PR DESCRIPTION
On a YouHua WR1200JS I could observe two error messages from `ls` when running `lime-config`:

```
...
network.scandevices.owrt_network_interface_parser found ifname lo
network.scandevices.owrt_network_interface_parser found ifname br-lan
network.scandevices.owrt_network_interface_parser found ifname wan
ls: /sys/class/net/wan/lower*: No such file or directory
network.scandevices.dev_parser found WAN port wan
network.scandevices.owrt_network_interface_parser found ifname wan
ls: /sys/class/net/wan/lower*: No such file or directory
network.scandevices.dev_parser found WAN port wan
network.scandevices.owrt_device_parser found base interface not_found and derived device br-lan
network.scandevices.dev_parser got nil device
...
```

This happens as `wan` on this router [is the name of the physical interface](https://github.com/openwrt/openwrt/blob/75af6a0d736a696ca726cb44d813791858c29f0c/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts#L161), so it does not have any lower one associated.

With the applied change, the output of lime-config does not show anymore these errors.