### PR TITLE
hotplug-initd-observer: Avoid format error when evData.service is empty

### DIFF
--- a/packages/hotplug-initd-services/files/usr/bin/hotplug-initd-observer
+++ b/packages/hotplug-initd-services/files/usr/bin/hotplug-initd-observer
@@ -11,7 +11,7 @@ local function notifyHooks(evData, evName)
 	for hook in fs.dir(hooksDir) do
 		os.execute(
 			string.format( 'ACTION="%s" SERVICE="%s" %s/%s',
-			               evName, evData.service, hooksDir, hook ) )
+			               evName, evData.service or '', hooksDir, hook ) )
 	end
 end
 


### PR DESCRIPTION
Fix #1064 (see also #1068)

Please, @LaneaLucy or @pony1k, can you test if this fixes?

Unexpectedly, running a similar code on my laptop with Lua 5.4.7 does not result in an error. Maybe it is related to the older versions of Lua?