### PR TITLE
ubus-lime-utils add dependency from ip package

### DIFF
--- a/packages/ubus-lime-utils/Makefile
+++ b/packages/ubus-lime-utils/Makefile
@@ -12,9 +12,9 @@ define Package/$(PKG_NAME)
   CATEGORY:=Ubus
   MAINTAINER:=Santiago Piccinini <spiccinini@altermundi.net>
   SUBMENU:=3. Applications
-  TITLE:=LIbremesh ubus utils module
+  TITLE:=LibreMesh ubus utils module
   DEPENDS:= +lua +libubox-lua +libubus-lua +libuci +lime-system +libiwinfo-lua +cgi-io +rpcd-mod-file \
-	    +luci-lib-jsonc
+	    +luci-lib-jsonc +ip
 
   PKGARCH:=all
 endef


### PR DESCRIPTION
Fix #1137 adding the dependency from the ip package. An alternative solution would be to parse the output of the ip command shipped with Busybox.