### PR TITLE
fix: typo of ubus-lime-groundrouting; fix multi-arch-build

### DIFF
--- a/.github/workflows/multi-arch-build.yml
+++ b/.github/workflows/multi-arch-build.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build packages ${{ matrix.arch }}
         uses: openwrt/gh-action-sdk@v7
         env:
-          ARCH: "${{ matrix.arch }}"
+          ARCH: "${{ matrix.arch }}-openwrt-23.05"
           FEEDNAME: "libremesh"
           IGNORE_ERRORS: "n m y"
           KEY_BUILD: "${{ secrets.KEY_BUILD }}"

--- a/packages/ubus-lime-groundrouting/Makefile
+++ b/packages/ubus-lime-groundrouting/Makefile
@@ -1,6 +1,6 @@
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=ubus-lime-grondrouting
+PKG_NAME:=ubus-lime-groundrouting
 PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
 GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
 GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )


### PR DESCRIPTION
fix typo from #1141 also in package ubus-lime-groundrouting 
copy fix from #1140 also in job multi-arch-build.yml