### PR TITLE
Scrape device names from board.json

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/proto/lan.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/proto/lan.lua
@@ -61,7 +61,6 @@ function lan.configure(args)
 end
 
 function lan.setup_interface(ifname, args)
-	if args and args["nobridge"] then return end
 	if ifname:match("^wlan") then return end
 	if ifname:match(network.protoVlanSeparator.."%d+$") then return end
 

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -593,13 +593,10 @@ function utils.deepcompare(t1,t2)
     return true
 end
 
-function utils.is_dsa()
+function utils.is_dsa(port)
     --! Code adapted from Jow https://forum.openwrt.org/t/how-to-detect-dsa/111868/4
-    local shell_output = utils.unsafe_shell("grep -s DEVTYPE=dsa /sys/class/net/*/uevent")
-    if shell_output ~= "" and shell_output ~= nil then
-        return true
-    end
-    return false
+    port = port or "*"
+    return 0 == os.execute("grep -sq DEVTYPE=dsa /sys/class/net/"..port.."/uevent")
 end
 
 return utils


### PR DESCRIPTION
- Scrape configurable network devices from /etc/board.json.
- Avoid configuration on DSA conduit devices.
- Allow device specific configuration for network devices with
  arbitrary names. This is more intuitive from a users perpective. Before, devices whose names don't match certain patterns were ignored. This could be helpful for network devices with unforseen names.
- Remove 'nobridge' tag, as this seems no longer be needed.
- Add optional parameter 'port' to utils.is_dsa().
- Add 'dsa' tag for DSA user ports. This could be used to fi_x #1121 like suggested by @ilario in [this comment](https://github.com/libremesh/lime-packages/issues/1121#issuecomment-2525078108).

fixes #1132