### PR TITLE
Fix get node status to work with busybox ip command

### DIFF
--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
@@ -134,22 +134,24 @@ end
 
 function node_status.dsa_get_link_status(ports)
     for _, port in ipairs(ports) do
-        local dsa = utils.unsafe_shell("ip -j -p link show " .. port['num'])
-        local dsa_json = json.parse(dsa)
-
-        port['device'] = port['num']
-        port['num'] = dsa_json[1]['ifindex']
-        port['role'] = dsa_json[1]['link']
-        if dsa_json[1]['link'] == nil then
-            port['role'] = dsa_json[1]['ifname']
-        end
-        port['link'] = dsa_json[1]['operstate']
-        if dsa_json[1]['operstate'] == "LOWERLAYERDOWN" then
-            port['link'] = "DOWN"
-        end
-    end
-    return ports
-end
+        local dsa = utils.unsafe_shell("ip link show " .. port['num'])
+        -- Match ifindex, ifname, link (optional), and operstate                                    
+        local ifindex, ifname, link, operstate = dsa:match("^(%d+): ([^:@]+)@?([^:]*):.-state (%S+)")             
+        if ifindex and ifname and operstate then                                                                              
+            port['device'] = port['num']                             
+            port['num'] = tonumber(ifindex)                                                          
+            port['role'] = link ~= "" and link or nil -- Handle optional link field
+            if port['role'] == nil then                                                             
+                port['role'] = ifname                                                                      
+            end                                                                                                               
+            port['link'] = operstate                                 
+            if operstate == "LOWERLAYERDOWN" then                                            
+                port['link'] = "DOWN"                                              
+            end                                                                                     
+        end                                                                                                       
+    end                                                                                                                       
+    return ports                                                     
+end 
 
 
 function node_status.swconfig_get_link_status(ports)


### PR DESCRIPTION
Fix https://github.com/libremesh/lime-packages/issues/1137 parsing the output of the "ip" command shipped with Busybox (default OpenWrt option)
With this fix, it is no longer necessary to include the ip-tiny package, which has a size of approximately 126 KB depending on the platform. On small hardware platforms where storage is limited, every byte counts.
