### PR TITLE
Adding "iw phy" to lime-report

### DIFF
--- a/packages/lime-report/files/lime-report.sh
+++ b/packages/lime-report/files/lime-report.sh
@@ -56,6 +56,7 @@ generate_status() {
     paste_cmd df
     paste_cmd logread -l 20
     paste_cmd "logread | grep err"
+    paste_cmd iw phy
     paste_cmd iw dev wlan0-mesh station dump
     paste_cmd iw dev wlan1-mesh station dump
     paste_cmd iw dev wlan2-mesh station dump


### PR DESCRIPTION
`iw phy` includes some useful information like the supported interfaces' combinations.

For example, for a TP-Link Archer A7 v5:

```
valid interface combinations:
	* #{ managed } <= 2048, #{ AP, mesh point } <= 8, #{ P2P-client, P2P-GO } <= 1, #{ IBSS } <= 1,
	  total <= 2048, #channels <= 1, STA/AP BI must match, radar detect widths: { 20 MHz (no HT), 20 MHz, 40 MHz }
```

And what is interesting for us is that there can be maximum 8 AP or mesh interfaces on each radio.
