### PR TITLE
network: Do not configure protocols on DSA switch port network devices by default.

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -397,10 +397,18 @@ function network.configure()
 
 		for _,protoParams in pairs(deviceProtos) do
 			local args = utils.split(protoParams, network.protoParamsSeparator)
-			if args[1] == "manual" then break end -- If manual is specified do not configure interface
-			local protoModule = "lime.proto."..args[1]
-			for k,v in pairs(flags) do args[k] = v end
-			if utils.isModuleAvailable(protoModule) then
+			local protoName = args[1]
+			if protoName == "manual" then break end -- If manual is specified do not configure interface
+			local protoModule = "lime.proto."..protoName
+			local needsConfig = utils.isModuleAvailable(protoModule)
+			if protoName ~= 'lan' and not flags["specific"] then
+				--! Work around issue 1121. Do not configure any other
+				--! protocols than lime.proto.lan on dsa devices unless there
+				--! is a config net section for the device.
+				needsConfig = needsConfig and not utils.is_dsa(device)
+			end
+			if needsConfig then
+				for k,v in pairs(flags) do args[k] = v end
 				local proto = require(protoModule)
 				xpcall(function() proto.configure(args) ; proto.setup_interface(device, args) end,
 					   function(errmsg) print(errmsg) ; print(debug.traceback()) end)

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -593,13 +593,10 @@ function utils.deepcompare(t1,t2)
     return true
 end
 
-function utils.is_dsa()
+function utils.is_dsa(port)
     --! Code adapted from Jow https://forum.openwrt.org/t/how-to-detect-dsa/111868/4
-    local shell_output = utils.unsafe_shell("grep -s DEVTYPE=dsa /sys/class/net/*/uevent")
-    if shell_output ~= "" and shell_output ~= nil then
-        return true
-    end
-    return false
+    port = port or "*"
+    return 0 == os.execute("grep -sq DEVTYPE=dsa /sys/class/net/"..port.."/uevent")
 end
 
 return utils


### PR DESCRIPTION
work around issue #1121

This adds an optional parameter 'port' to util.is_dsa(), to allow checking if a specific network device is a DSA switch port and prevents such network devices to be configured with protocols other than 'lime-proto-lan', unless there is a 'config net' section for that network device.