### PR TITLE
Update testing.md

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -4,7 +4,7 @@ LibreMesh has unit tests that help us add new features while keeping maintenance
 
 We encourage contributors to write tests when adding new functionality and also while fixing regressions.
 
-LibreMesh unit testing is based in the powerful [busted](https://olivinelabs.com/busted/) library which has a very good documentation.
+LibreMesh unit testing is based in the powerful [busted](https://lunarmodules.github.io/busted/) library which has a very good documentation.
 
 Tests are run inside a x86_64 Docker image with some lua and openwrt libraries avaible.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -171,8 +171,8 @@ You will need a rootfs and ramfs LibreMesh files. To generate one you can use a 
 and select x86_64 target and select the option to generate an initramfs.
 
 Prebuilt development images can be downloaded from here:
-* http://repo.libremesh.org/tmp/openwrt-18.06-x86-64-generic-rootfs.tar.gz
-* http://repo.libremesh.org/tmp/openwrt-18.06-x86-64-ramfs.bzImage
+* https://firmware-libremesh.antennine.org/releases/2024.1-ow23.05.5/targets/x86/64/default/libremesh-2024.1-ow23.05.5-default-x86-64-generic-squashfs-rootfs.img.gz
+* https://firmware-libremesh.antennine.org/releases/2024.1-ow23.05.5/targets/x86/64/default/libremesh-2024.1-ow23.05.5-default-x86-64-generic-initramfs-kernel.bin
 
 Install the package `qemu-system-x86_64` if you don't have already installed.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -191,7 +191,7 @@ $ sudo ./tools/qemu_dev_start  path/to/openwrt-x86-64-generic-rootfs.tar.gz path
 #### Stop it
 
 ```
-$ ./tools/qemu_dev_stop
+$ ./tools/qemu_dev_stop [NODE_ID]
 ```
 
 #### Run 12 nodes simultaneously, with arbitrary complex topology of clouds and links

--- a/tools/qemu_dev_stop
+++ b/tools/qemu_dev_stop
@@ -1,4 +1,4 @@
 NODE_ID=${1:-0}
 [ ${#NODE_ID} = 1 ] && NODE_ID=0${NODE_ID} # Pad with leading zero
-echo system_powerdown | nc -N 127.0.0.1 "454${NODE_ID}"
+echo system_powerdown | nc 127.0.0.1 "454${NODE_ID}" -w 1
 ip link del lime_br0


### PR DESCRIPTION
Update TESTING.md in order to provide more up-to-date firmware links for testing in QEMU. 

Also clarify the usage of qemu-dev-stop script, and a possible issue encountered (netcat with -N parameter support).