### PR TITLE
Replacing deferrable reboot with watchcat

### DIFF
--- a/packages/lime-docs/files/www/docs/lime-example.txt
+++ b/packages/lime-docs/files/www/docs/lime-example.txt
@@ -265,3 +265,15 @@ config net
 #config bgp_peer peer2
 #	option remoteIP '2001:db8::c001'
 #	option remoteAS '65549'
+
+#########################################################
+### Watchcat specific sections
+### One section for each ping-watchdog rule you want to define.
+
+# Ping-reboot the device if gateway (or any IP) is unreachable
+config hwd_watchcat default
+    option mode       'ping_reboot'
+    option pinghosts  '4.2.2.2'    # default Level3 resolver
+    option pingperiod '30s'        # send one ping every 30 seconds
+    option period     '6h'         # reboot if 6h continuously failing
+    option forcedelay '1m'         # wait up to 1m for a soft-reboot

--- a/packages/lime-hwd-watchcat/Makefile
+++ b/packages/lime-hwd-watchcat/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+LIME_BUILDDATE:=$(shell date +%Y%m%d_%H%M)
+
+GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
+GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+
+PKG_NAME:=lime-hwd-watchcat
+PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  TITLE:=Watchcat integration and default configuration for LibreMesh
+  CATEGORY:=LibreMesh
+  URL:=https://libremesh.org
+  DEPENDS:=+lime-system +lua +libuci-lua +watchcat
+  PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/description
+	This package integrates OpenWrt's watchcat into LibreMesh,
+  providing sensible defaults to replace deferrable-reboot functionality.
+endef
+
+define Build/Compile
+	@rm -rf ./build || true
+	@mkdir ./build
+	$(CP) ./files ./build
+	$(FIND) ./build -name '*.sh' -exec sed -i '/^\s*#\[Doc\]/d' {} +
+	$(FIND) ./build -name '*.lua' -exec sed -i '/^\s*--!.*/d' {} +
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(CP) ./build/files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/lime-hwd-watchcat/Makefile
+++ b/packages/lime-hwd-watchcat/Makefile
@@ -1,12 +1,10 @@
-include $(TOPDIR)/libremesh.mk
-
-PKG_NAME:=lime-hwd-watchcat
+include ../../libremesh.mk
 
 define Package/$(PKG_NAME)
-  SECTION:=LibreMesh
+  SECTION:=lime
   CATEGORY:=LibreMesh
-  TITLE:=Watchcat HWD defaults 
-  DEPENDS:=+lime-system +lua +libuci-lua +watchcat
+  TITLE:=Watchcat LibreMesh configurer 
+  DEPENDS:=+lime-system +lua +watchcat
   PKGARCH:=all
 endef
 
@@ -17,4 +15,3 @@ and generating the real /etc/config/watchcat entries.
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))
-

--- a/packages/lime-hwd-watchcat/Makefile
+++ b/packages/lime-hwd-watchcat/Makefile
@@ -1,45 +1,20 @@
-#
-# Copyright (C) 2006-2014 OpenWrt.org
-#
-# This is free software, licensed under the GNU General Public License v3.
-#
-
-include $(TOPDIR)/rules.mk
-
-LIME_BUILDDATE:=$(shell date +%Y%m%d_%H%M)
-
-GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . )
-GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
+include $(TOPDIR)/libremesh.mk
 
 PKG_NAME:=lime-hwd-watchcat
-PKG_VERSION=$(GIT_COMMIT_DATE)-$(GIT_COMMIT_TSTAMP)
-
-include $(INCLUDE_DIR)/package.mk
 
 define Package/$(PKG_NAME)
-  TITLE:=Watchcat integration and default configuration for LibreMesh
+  SECTION:=LibreMesh
   CATEGORY:=LibreMesh
-  URL:=https://libremesh.org
+  TITLE:=Watchcat HWD defaults 
   DEPENDS:=+lime-system +lua +libuci-lua +watchcat
   PKGARCH:=all
 endef
 
 define Package/$(PKG_NAME)/description
-	This package integrates OpenWrt's watchcat into LibreMesh,
-  providing sensible defaults to replace deferrable-reboot functionality.
-endef
-
-define Build/Compile
-	@rm -rf ./build || true
-	@mkdir ./build
-	$(CP) ./files ./build
-	$(FIND) ./build -name '*.sh' -exec sed -i '/^\s*#\[Doc\]/d' {} +
-	$(FIND) ./build -name '*.lua' -exec sed -i '/^\s*--!.*/d' {} +
-endef
-
-define Package/$(PKG_NAME)/install
-	$(INSTALL_DIR) $(1)/
-	$(CP) ./build/files/* $(1)/
+Integrates OpenWrt’s watchcat into LibreMesh as a hardware-detection
+module (HWD), reading ‘config hwd_watchcat’ from the LibreMesh UCI
+and generating the real /etc/config/watchcat entries.
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))
+

--- a/packages/lime-hwd-watchcat/files/usr/lib/lua/lime/hwd/watchcat.lua
+++ b/packages/lime-hwd-watchcat/files/usr/lib/lua/lime/hwd/watchcat.lua
@@ -8,10 +8,13 @@ local watchcat = {}
 
 watchcat.sectionNamePrefix = hardware_detection.sectionNamePrefix.."watchcat_"
 
-
+local function reload_watchcat()
+        os.execute("/etc/init.d/watchcat reload")
+end
 
 function watchcat.clean()
         local uci = config.get_uci_cursor()
+        local modified = false
 
         local function clear_watchcat_section(section)
                 local is_ours = utils.stringStarts(section[".name"], watchcat.sectionNamePrefix)
@@ -20,11 +23,15 @@ function watchcat.clean()
 
                 if is_ours or is_anon then
                         uci:delete("watchcat", section[".name"])
+                        modified = true
                 end
         end
 
         uci:foreach("watchcat", "watchcat", clear_watchcat_section)
-        uci:save("watchcat")
+        if modified then
+                uci:save("watchcat")
+                reload_watchcat()
+        end
 end
 
 function watchcat.detect_hardware()
@@ -48,6 +55,7 @@ function watchcat.detect_hardware()
         -- only saved if we actually aplied any user section
         if user_defined then
                 uci:save("watchcat")
+                reload_watchcat()
         end
 end
 

--- a/packages/lime-hwd-watchcat/files/usr/lib/lua/lime/hwd/watchcat.lua
+++ b/packages/lime-hwd-watchcat/files/usr/lib/lua/lime/hwd/watchcat.lua
@@ -1,0 +1,36 @@
+local hardware_detection = require("lime.hardware_detection")
+local config = require("lime.config")
+local utils = require("lime.utils")
+
+local watchcat = {}
+
+watchcat.sectionNamePrefix = hardware_detection.sectionNamePrefix.."watchcat_"
+
+local function clear_watchcat_section(section)
+        if utils.stringStarts(section[".name"], watchcat.sectionNamePrefix) then
+            uci:delete("watchcat", section[".name"])
+        end
+end
+
+function watchcat.clean()
+        local uci = config.get_uci_cursor()   
+        
+        uci:foreach("watchcat", "watchcat", clear_watchcat_section)
+        uci:save("watchcat")
+end
+
+function watchcat.detect_hardware()
+        local uci = config.get_uci_cursor()
+        local sec = watchcat.sectionNamePrefix.."ping_reboot"
+        
+        uci:set("watchcat", sec, "watchcat")
+        uci:set("watchcat", sec, "mode", "ping_reboot")
+        uci:set("watchcat", sec, "pinghosts", "8.8.8.8")
+        uci:set("watchcat", sec, "period", "6h")
+        uci:set("watchcat", sec, "pingperiod", "30s")
+        uci:set("watchcat", sec, "forcedelay", "1m")
+        
+        uci:save("watchcat")
+end
+
+return watchcat

--- a/packages/lime-hwd-watchcat/files/usr/lib/lua/lime/hwd/watchcat.lua
+++ b/packages/lime-hwd-watchcat/files/usr/lib/lua/lime/hwd/watchcat.lua
@@ -14,7 +14,11 @@ function watchcat.clean()
         local uci = config.get_uci_cursor()
 
         local function clear_watchcat_section(section)
-                if utils.stringStarts(section[".name"], watchcat.sectionNamePrefix) then
+                local is_ours = utils.stringStarts(section[".name"], watchcat.sectionNamePrefix)
+                
+                local is_anon = section[".anonymous"]
+
+                if is_ours or is_anon then
                         uci:delete("watchcat", section[".name"])
                 end
         end


### PR DESCRIPTION
This implementation covers the suggestion made [here](https://github.com/libremesh/lime-packages/issues/1177). The code configures watchcat every time `lime-config` is run. 

For the moment `deferrable-reboot` has not been removed.
Please review and let me know if you think it is safe to remove `deferrable-reboot` entirely, or if further adjustments are needed.