### PR TITLE
ci: tests: remove on pull_request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,6 @@ name: tests
 on:
   push:
     branches: [ '**' ]
-  pull_request:
-    branches: [ '**' ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Following the discussion in [#1139](https://github.com/libremesh/lime-packages/pull/1139#issuecomment-3012596719)

Let's remove the on pull_request from tests
As a tool unittests can be runned locally via `./run_tests`
Unittests executed by the ci can eventually be manually triggered during a review.