### PR TITLE
Removing Babel VLAN on ethernet interfaces inside br-lan

### DIFF
--- a/packages/lime-proto-babeld/Makefile
+++ b/packages/lime-proto-babeld/Makefile
@@ -4,7 +4,7 @@ define Package/$(PKG_NAME)
   SECTION:=lime
   CATEGORY:=LibreMesh
   TITLE:=LiMe babeld proto support
-  DEPENDS:=+babeld +lime-system +luci-lib-nixio 
+  DEPENDS:=+babeld +lime-system +luci-lib-nixio
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   VERSION:=$(if $(PKG_VERSION),$(PKG_VERSION),$(PKG_SRC_VERSION))
   PKGARCH:=all


### PR DESCRIPTION
This is a replace of #631 

This PR removes the legacy "VLAN-on-wlan" approach in `lime-proto-babeld` and runs Babel directly on the **base interfaces** and on the LAN bridge **`br-lan`** (marked as `type=wired`) for modern DSA devices. 

During validation, a side-effect (*ghost neighbor*) caused by bridging `bat0` into `br-lan` appeared; the PR also ships a **nftables netdev/ingress guard** on `bat0` to prevent L2 flooding of Babel traffic.

* **Simplicity & predictability:** Base interface names remain stable; no hidden VLAN layers for each radio/mesh.
* **Better defaults on DSA:** Running on `br-lan` with `type=wired` gives wired links the expected low metric and behavior.
* **Safety net for bridged meshes:** If `bat0` is bridged into `br-lan`, L2 multicast flooding of Babel (UDP/6696) can trick peers into thinking a remote node is a direct wired neighbor. The **netdev/ingress** guard drops those frames at `bat0` before the bridge floods them.

### Two nodes, **no cable** (Wi‑Fi only)

Node **LiMe-d5d63f**:

```
root@LiMe-d5d63f:~# echo dump | nc ::1 30003
BABEL 1.0
version babeld-1.13.1-ubus-mod
host LiMe-d5d63f
my-id ea:9f:80:ff:fe:d5:d6:3f
ok
add interface br-lan up true ipv6 fe80::ea9f:80ff:fed5:d63f ipv4 10.13.214.63
add interface wlan0-mesh up true ipv6 fe80::ec9f:80ff:fed5:d640
add interface wlan1-mesh up true ipv6 fe80::ec9f:80ff:fed5:d641
add interface wan up false
add neighbour 7f89028030 address fe80::c041:1eff:fef8:9fac if wlan0-mesh reach 8040 ureach 0000 rxcost 1015 txcost 461 cost 1828
add neighbour 7f88f9f480 address fe80::c041:1eff:fef8:9fad if wlan1-mesh reach ffff ureach 0000 rxcost 256 txcost 256 cost 256
add xroute fd0d:fe46:8ce8::/64-::/0 prefix fd0d:fe46:8ce8::/64 from ::/0 metric 0
add xroute 10.13.0.0/16-0.0.0.0/0 prefix 10.13.0.0/16 from 0.0.0.0/0 metric 0
add route 7f88f9f780 prefix 10.13.0.0/16 from 0.0.0.0/0 installed no id c6:41:1e:ff:fe:f8:9f:ab metric 256 refmetric 0 via fe80::c041:1eff:fef8:9fad if wlan1-mesh
add route 7f89028230 prefix 10.13.0.0/16 from 0.0.0.0/0 installed no id c6:41:1e:ff:fe:f8:9f:ab metric 1828 refmetric 0 via fe80::c041:1eff:fef8:9fac if wlan0-mesh
add route 7f88f9f6c0 prefix fd0d:fe46:8ce8::/64 from ::/0 installed no id c6:41:1e:ff:fe:f8:9f:ab metric 256 refmetric 0 via fe80::c041:1eff:fef8:9fad if wlan1-mesh
add route 7f88f9f7e0 prefix fd0d:fe46:8ce8::/64 from ::/0 installed no id c6:41:1e:ff:fe:f8:9f:ab metric 1828 refmetric 0 via fe80::c041:1eff:fef8:9fac if wlan0-mesh
ok
```

*No wired neighbor; costs reflect Wi‑Fi links only.*

### Plug Ethernet between the nodes

Same node **LiMe-d5d63f**:

```
root@LiMe-d5d63f:~# echo dump | nc ::1 30003
BABEL 1.0
version babeld-1.13.1-ubus-mod
host LiMe-d5d63f
my-id ea:9f:80:ff:fe:d5:d6:3f
ok
add interface br-lan up true ipv6 fe80::ea9f:80ff:fed5:d63f ipv4 10.13.214.63
add interface wlan0-mesh up true ipv6 fe80::ec9f:80ff:fed5:d640
add interface wlan1-mesh up true ipv6 fe80::ec9f:80ff:fed5:d641
add interface wan up false
add neighbour 7f890251b0 address fe80::c041:1eff:fef8:9fac if wlan0-mesh reach 7df0 ureach 0000 rxcost 348 txcost 3733 cost 5075
add neighbour 7f89025020 address fe80::c641:1eff:fef8:9fab if br-lan reach ffff ureach 0000 rxcost 96 txcost 96 cost 96
add neighbour 7f88f9f480 address fe80::c041:1eff:fef8:9fad if wlan1-mesh reach ffff ureach 0000 rxcost 256 txcost 256 cost 256
add xroute fd0d:fe46:8ce8::/64-::/0 prefix fd0d:fe46:8ce8::/64 from ::/0 metric 0
add xroute 10.13.0.0/16-0.0.0.0/0 prefix 10.13.0.0/16 from 0.0.0.0/0 metric 0
add route 7f88f9f780 prefix 10.13.0.0/16 from 0.0.0.0/0 installed no id c6:41:1e:ff:fe:f8:9f:ab metric 256 refmetric 0 via fe80::c041:1eff:fef8:9fad if wlan1-mesh
add route 7f890282f0 prefix 10.13.0.0/16 from 0.0.0.0/0 installed no id c6:41:1e:ff:fe:f8:9f:ab metric 96 refmetric 0 via fe80::c641:1eff:fef8:9fab if br-lan
add route 7f890283b0 prefix 10.13.0.0/16 from 0.0.0.0/0 installed no id c6:41:1e:ff:fe:f8:9f:ab metric 5075 refmetric 0 via fe80::c041:1eff:fef8:9fac if wlan0-mesh
add route 7f88f9f6c0 prefix fd0d:fe46:8ce8::/64 from ::/0 installed no id c6:41:1e:ff:fe:f8:9f:ab metric 256 refmetric 0 via fe80::c041:1eff:fef8:9fad if wlan1-mesh
add route 7f89028290 prefix fd0d:fe46:8ce8::/64 from ::/0 installed no id c6:41:1e:ff:fe:f8:9f:ab metric 96 refmetric 0 via fe80::c641:1eff:fef8:9fab if br-lan
add route 7f89028350 prefix fd0d:fe46:8ce8::/64 from ::/0 installed no id c6:41:1e:ff:fe:f8:9f:ab metric 5075 refmetric 0 via fe80::c041:1eff:fef8:9fac if wlan0-mesh
ok
```

*Wired neighbor appears on `br-lan` with canonical cost 96 and becomes preferred.*

### Guard counters

```
root@LiMe-d5d63f:~# nft -a list chain netdev lime_babel_filter prevent_babel_leak_from_bat0
  ip6 nexthdr udp udp dport 6696 counter packets 46 bytes 3500 drop # handle 4
  ip  protocol udp udp dport 6696 counter packets 0 bytes 0 drop   # handle 5
```

*The guard actively drops Babel over `bat0` before the bridge floods it.*


To activate the **`babeld` proto** in LibreMesh (so the new behavior takes effect), add `babeld:0` to the protocol list in `lime-node` like: 

```
config lime network
	list protocols ieee80211s
	list protocols lan
	list protocols anygw
	list protocols batadv:%N1
	list protocols bmx6:13
	list protocols olsr:14
	list protocols olsr6:15
	list protocols olsr2:16
	list protocols babeld:0
	list protocols bmx7:18
```

**IMPORTANT**: This new changes does not support `swconfig`, only routers with `DSA`, I can't test the first one, so you're invited to implement that part :)

