### PR TITLE
fix: anygw not working via cable in dsa devices

### DIFF
--- a/packages/lime-proto-anygw/Makefile
+++ b/packages/lime-proto-anygw/Makefile
@@ -12,7 +12,7 @@ define Package/$(PKG_NAME)
 	DEPENDS:=+dnsmasq-dhcpv6 +kmod-nft-bridge +libuci-lua \
 		+lime-system +lua +kmod-macvlan \
 		+shared-state +shared-state-dnsmasq_leases \
-		+luci-lib-nixio +firewall4
+		+luci-lib-nixio +firewall4 +ip-bridge
   PKGARCH:=all
 endef
 

--- a/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
+++ b/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
@@ -32,7 +32,7 @@ function anygw.configure(args)
 	local anygw_ipv4 = ipv4:minhost()
 	anygw_ipv6:prefix(64) -- SLAAC only works with a /64, per RFC
 	anygw_ipv4:prefix(ipv4:prefix())
-	local baseIfname = "br-lan"
+	local baseIfname = config.uci:get('network', 'lan', 'device')
 	local argsDev = { macaddr = anygw_mac }
 	local argsIf = {
 		proto = "static",

--- a/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
+++ b/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
@@ -126,6 +126,41 @@ function anygw.configure(args)
 	fs.writefile("/etc/dnsmasq.d/lime-proto-anygw-20-ipv6.conf", table.concat(content, "\n").."\n")
 
 	utils.unsafe_shell("/etc/init.d/dnsmasq enable || true")
+
+	if utils.is_dsa then
+		local nftDsaGuardFileName = includeDir.."lime-proto-anygw_dsa-mac-rules.nft"
+		local nftDsaGuard = "#!/usr/sbin/nft -f\
+define dsa_user_ports = {}\
+add table inet filter_anygw_ingress\
+add chain inet filter_anygw_ingress ingress_dsa\
+delete chain inet filter_anygw_ingress ingress_dsa\
+\
+table inet filter_anygw_ingress {\
+	chain ingress_dsa {\
+		type filter hook ingress devices = $dsa_user_ports priority 0; policy accept\
+		ether saddr $anygw_macs counter drop\
+	}\
+}\n"
+		fs.writefile(nftDsaGuardFileName, nftDsaGuard)
+
+		local br_lan_cfgid = utils.find_br_lan()
+		local dsaPortsList = "#!/bin/sh\
+ports=$(uci get network."..br_lan_cfgid..".ports)\
+dsa_ports={\
+for i in $ports; do\
+	echo $i | grep -qv bat && dsa_ports=$dsa_ports$i,\
+done\
+dsa_ports=${dsa_ports::-1}}\
+sed -i \"s|\\(define dsa_user_ports = \\).*|\\1$dsa_ports|\" "..nftDsaGuardFileName.."\
+nft flush ruleset; fw4 reload\n"
+		fs.writefile("/etc/hotplug.d/lime-config/10-anygw-mac-dsa", dsaPortsList)
+		utils.unsafe_shell("chmod +x /etc/hotplug.d/lime-config/10-anygw-mac-dsa")
+
+		local bridgeFdbFixes = "#!/bin/sh\
+bridge fdb flush dev br-lan\
+bridge fdb add " .. anygw_mac .. " dev br-lan\n"
+		fs.writefile("/etc/hotplug.d/net/10-anygw-mac-dsa", bridgeFdbFixes)
+	end
 end
 
 function anygw.setup_interface(ifname, args) end

--- a/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
+++ b/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
@@ -145,6 +145,7 @@ table inet filter_anygw_ingress {\
 
 		local br_lan_cfgid = utils.find_br_lan()
 		local dsaPortsList = "#!/bin/sh\
+[ \"$ACTION\" = \"post\" ] || exit 0\
 ports=$(uci get network."..br_lan_cfgid..".ports)\
 dsa_ports={\
 for i in $ports; do\

--- a/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
+++ b/packages/lime-proto-anygw/files/usr/lib/lua/lime/proto/anygw.lua
@@ -127,7 +127,7 @@ function anygw.configure(args)
 
 	utils.unsafe_shell("/etc/init.d/dnsmasq enable || true")
 
-	if utils.is_dsa then
+	if utils.is_dsa() then
 		local nftDsaGuardFileName = includeDir.."lime-proto-anygw_dsa-mac-rules.nft"
 		local nftDsaGuard = "#!/usr/sbin/nft -f\
 define dsa_user_ports = {}\

--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -385,12 +385,6 @@ function network.configure()
 			if protoName == "manual" then break end -- If manual is specified do not configure interface
 			local protoModule = "lime.proto."..protoName
 			local needsConfig = utils.isModuleAvailable(protoModule)
-			if protoName ~= 'lan' and not flags["specific"] then
-				--! Work around issue 1121. Do not configure any other
-				--! protocols than lime.proto.lan on dsa devices unless there
-				--! is a config net section for the device.
-				needsConfig = needsConfig and not utils.is_dsa(device)
-			end
 			if needsConfig then
 				for k,v in pairs(flags) do args[k] = v end
 				local proto = require(protoModule)

--- a/packages/lime-system/files/usr/lib/lua/lime/proto/lan.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/proto/lan.lua
@@ -8,24 +8,6 @@ local utils = require("lime.utils")
 
 lan.configured = false
 
---! Find a device section in network with
---! option name 'br-lan'
---! option type 'bridge'
-local function find_br_lan(uci)
-	local br_lan_section = nil
-	uci:foreach("network", "device",
-		function(s)
-			if br_lan_section then return end
-			local dev_type = uci:get("network", s[".name"], "type")
-			local dev_name = uci:get("network", s[".name"], "name")
-			if not (dev_type == 'bridge') then return end
-			if not (dev_name == 'br-lan') then return end
-			br_lan_section = s[".name"]
-		end
-	)
-	return br_lan_section
-end
-
 function lan.configure(args)
 	if lan.configured then return end
 	lan.configured = true
@@ -38,7 +20,7 @@ function lan.configure(args)
 	uci:set("network", "lan", "netmask", ipv4:mask():string())
 	uci:set("network", "lan", "proto", "static")
 	uci:set("network", "lan", "mtu", "1500")
-	local br_lan_section = find_br_lan(uci)
+	local br_lan_section = utils.find_br_lan()
 	if br_lan_section then uci:delete("network", br_lan_section, "ports") end
 	uci:save("network")
 
@@ -66,7 +48,7 @@ function lan.setup_interface(ifname, args)
 
 	local uci = config.get_uci_cursor()
 	local bridgedIfs = {}
-	local br_lan_section = find_br_lan(uci)
+	local br_lan_section = utils.find_br_lan()
 	if not br_lan_section then return end
 	local oldIfs = uci:get("network", br_lan_section, "ports") or {}
 	--! it should be a table, it was a string in old OpenWrt releases

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -616,4 +616,27 @@ function utils.dumptable(table, nesting)
   end
 end
 
+--! Find a device section in network with i.e.
+--! option name 'br-lan'
+--! option type 'bridge'
+function utils.find_bridge_cfgid(bridge_name)
+    local uci = config.get_uci_cursor()
+	local br_section = nil
+	uci:foreach("network", "device",
+		function(s)
+			if br_section then return end
+			local dev_type = uci:get("network", s[".name"], "type")
+			local dev_name = uci:get("network", s[".name"], "name")
+			if not (dev_type == 'bridge') then return end
+			if not (dev_name == bridge_name) then return end
+			br_section = s[".name"]
+		end
+	)
+	return br_section
+end
+
+function utils.find_br_lan()
+    return utils.find_bridge_cfgid("br-lan")
+end
+
 return utils

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -636,7 +636,9 @@ function utils.find_bridge_cfgid(bridge_name)
 end
 
 function utils.find_br_lan()
-    return utils.find_bridge_cfgid("br-lan")
+    local dev = config.uci:get('network', 'lan_vlan', 'device')
+    if dev == nil then dev = 'br-lan' end
+    return utils.find_bridge_cfgid(dev)
 end
 
 return utils


### PR DESCRIPTION
Fix #1192. In dsa devices if another libremesh node is connected via cable
anygw starts working intermittently for hosts connected via cable

Manually adjust the bridge fdb, as suggested here [0], with an /etc/hotplug.d/net trigger
adding an entry that states that the anygw mac address can be found locally on device br-lan

Then add a nftables guard rule that drop packets with ether source address equal to the anygw_mac
on every dsa user ports that is member of br-lan to prevent icmp6 broadcast loops.

To use the command bridge it is necessary to add the package ip-bridge ~30KB.
This wouldn't be required in swconfig devices but an easy way to distinguish between dsa and swconfig devices
at compile time doesn't exists at the moment.

[0] https://www.kernel.org/doc/html/latest/networking/dsa/configuration.html#forwarding-database-fdb-management