### PR TITLE
lime-owut: init the package

### DIFF
--- a/packages/lime-owut/Makefile
+++ b/packages/lime-owut/Makefile
@@ -1,0 +1,41 @@
+include ../../libremesh.mk
+
+# owut is available since openwrt-24.10
+PKG_AVAILABLE:=1
+OW_BRANCH:=$(shell echo $$(grep -m1 -o "releases/.*" \
+	$(TOPDIR)/include/version.mk || echo "main") | \
+	cut -d"/" -f2 | cut -d"." -f1,2 )
+
+ifneq ($(OW_BRANCH),main)
+  ifeq ($(shell test $$(echo $(OW_BRANCH) | cut -d"." -f1) -lt 24; echo $$?),0)
+    PKG_AVAILABLE:=0
+  endif
+endif
+
+ifeq ($(PKG_AVAILABLE),1)
+
+	define Package/$(PKG_NAME)
+		TITLE:=$(PKG_NAME) allows to use owut OpenWrt Upgrade Tool in LibreMesh
+		CATEGORY:=LibreMesh
+		URL:=http://libremesh.org
+		DEPENDS:=+owut
+		PKGARCH:=all
+	endef
+
+	define Package/$(PKG_NAME)/postinst
+#!/bin/sh
+# Preserve the complete opkg status if CONFIG_CLEAN_IPKG=y
+grep -q CONFIG_CLEAN_IPKG=y $${TOPDIR}/.config || exit 0
+[ -f $${IPKG_INSTROOT}/usr/lib/opkg/status ] || exit 0
+
+cp $${IPKG_INSTROOT}/usr/lib/opkg/status $${IPKG_INSTROOT}/etc/opkg/
+cat << EOF > $${IPKG_INSTROOT}/etc/uci-defaults/99_owut-packagelist
+#!/bin/sh
+rm /usr/lib/opkg/status
+ln -s /etc/opkg/status /usr/lib/opkg/status
+EOF
+	endef
+
+	$(eval $(call BuildPackage,$(PKG_NAME)))
+
+endif

--- a/packages/lime-owut/README.md
+++ b/packages/lime-owut/README.md
@@ -1,0 +1,60 @@
+# lime-owut
+
+A script to add LibreMesh package repositories to owut build requests (available since openwrt-24.10).
+
+## Description
+To request a firmware build, owut asks it to an asu server (online imagebuilder) [0].
+This package by default instructs owut to use an asu instance [1] which allows adding feeds from libremesh.
+A source code with these changes to allow libremesh repositories within asu can be found at note [2].
+
+**owut**, OpenWrt Upgrade Tool, [3] _"is command line tool that upgrades your router's firmware. It creates custom images of OpenWrt using the sysupgrade server and installs them, retaining all of your currently installed packages and configuration."_
+
+In LibreMesh, it can be used to update the libremesh and openwrt packages:
+- while remaining with the same version of openwrt (like in the example below)
+- when updating to a newer version of openwrt, whether it is a minor update (e.g., 24.10.2 -> 24.10.3) or a major update (24.10.2 -> 25.xx.xx).
+
+**Note**: updating between major releases of OpenWrt is generally only “officially supported” between one major release and the next (i.e., 24.10.2 -> 26.xx.xx may work but is not officially supported). 
+
+## Example output running `owut download`
+
+```
+root@LiMe-870f23:~# owut download
+ASU-Server     https://sysupgrade.antennine.org
+Upstream       https://downloads.openwrt.org
+Target         mediatek/filogic
+Profile        cudy_wr3000s-v1
+Package-arch   aarch64_cortex-a53
+Version-from   24.10.2 r28739-d9340319c6 (kernel 6.6.93)
+Version-to     24.10.2 r28739-d9340319c6 (kernel 6.6.93)
+55 packages are out-of-date
+WARNING: There are 3 missing default packages, confirm this is expected before proceeding
+Request hash:
+  37c114d672897c322b6ef12ef6f91e809052a032272544e711c891045037c270
+--
+Status:   queued - 0 ahead of you
+Progress:   0s total =   0s in queue +   0s in build
+--
+Status:   init
+Progress:   1s total =   0s in queue +   1s in build
+--
+Status:   validate_manifest
+Progress:  49s total =   0s in queue +  49s in build
+--
+Status:   building_image
+Progress:  86s total =   0s in queue +  86s in build
+--
+Status:   done
+Progress:  89s total =   0s in queue +  89s in build
+
+Build succeeded in  89s total =   0s in queue +  89s to build:
+Image saved : /tmp/firmware.bin
+```
+
+## Notes
+This package may be deprecated in the future, since it adds repo_feeds and repo_keys from libremesh
+And the ability to use additional feeds, within /etc/(opkg|apk), could perhaps be added to the core of owut itself.
+
+[0] https://github.com/openwrt/asu    
+[1] https://sysupgrade.antennine.org    
+[2] https://github.com/a-gave/asu-libremesh    
+[3] https://github.com/efahl/owut    

--- a/packages/lime-owut/files/etc/uci-defaults/99_lime-owut
+++ b/packages/lime-owut/files/etc/uci-defaults/99_lime-owut
@@ -1,0 +1,49 @@
+. /etc/os-release
+
+feed_host="http://feed.libremesh.org"
+asu_url="https://sysupgrade.antennine.org"
+
+ow_branch=$( [ $VERSION == 'SNAPSHOT' ] &&
+	echo "openwrt-main" || echo openwrt-${VERSION:0:5})
+
+feed_packages=$feed_host/master/$ow_branch
+feed_profiles=$feed_host/profiles/$ow_branch
+
+grep -q "let lime" /usr/bin/owut && exit 0
+
+# Add libremesh 'repositories' and 'repository_keys' to owut's build requests
+cat << EOF > /tmp/owut_repos 
+		repositories: {
+			'libremesh': '$feed_packages/x86_64',
+			'libremesh_arch_packages': '$feed_packages/$OPENWRT_ARCH',
+			'profiles': '$feed_profiles/x86_64'},
+		repository_keys: [ 
+			"RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8",
+			"-----BEGIN PUBLIC KEY-----\n\
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdFJZ2qVti49Ol8LJZYuxgOCLowBS\n\
+8bI86a7zqhSbs5yon3JON7Yee7CQOgqwPOX5eMALGOu8iFGAqIRx5YjfYA==\n\
+-----END PUBLIC KEY-----" ],
+EOF
+sed -ie '/target:.*device.target/r /tmp/owut_repos' /usr/bin/owut
+
+# Add libremesh repositories to packages, arch_packages and profiles
+cat << EOF > /tmp/owut_repos 
+	let lime = dl_json("$feed_packages/x86_64/index.json",
+		"/tmp/owut-packages-lime.json", true);
+
+	let lime_arch_packages = dl_json("$feed_packages/$OPENWRT_ARCH/index.json",
+		"/tmp/owut-packages-lime_arch_packages.json", true);
+
+	let profiles = dl_json("$feed_profiles/x86_64/index.json", 
+		"/tmp/owut-packages-profiles.json", true);
+
+	return sort({ ...(arch ?? []), ...(plat?.packages ?? []), 
+		...(lime?.packages ?? []), ...(lime_arch_packages?.packages ?? []),
+		...(profiles?.packages ?? []) });
+EOF
+sed -i -e "/return\ sort({\ ...(arch/r /tmp/owut_repos" -e "//d" /usr/bin/owut
+rm /tmp/owut_repos
+
+# Set a default server
+uci set attendedsysupgrade.server.url="$asu_url"
+uci commit attendedsysupgrade


### PR DESCRIPTION
Add a script to setup a working owut.
Warning about packages missing can be just ignored for now.