### PR TITLE
add suport for static linked library

### DIFF
--- a/packages/shared-state-async/Makefile
+++ b/packages/shared-state-async/Makefile
@@ -39,7 +39,6 @@ define Package/shared-state-async
   TITLE+= (dynamic linking)
   DEPENDS:=+libstdcpp
   VARIANT:=dynamic
-  DEFAULT_VARIANT:=1
   CONFLICTS:=shared-state-async-static
 endef
 

--- a/packages/shared-state-async/Makefile
+++ b/packages/shared-state-async/Makefile
@@ -10,19 +10,12 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=shared-state-async
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/libremesh/shared-state-async.git
-PKG_SOURCE_DATE:=2024-05-13
-PKG_SOURCE_VERSION:=db58e3d16e8658417956f9bb42e7e87f6aadcd4d
+PKG_SOURCE_URL:=https://github.com/javierbrk/shared-state-async.git
+PKG_SOURCE_VERSION:=use-statically-linked-stdlib
 PKG_MAINTAINER:=Asociación Civil Altermundi <info@altermundi.net>
 PKG_LICENSE:=AGPL-3.0-only
 
-# tar.xz or tar.zst
-PKG_XZ=$(shell top="$(TOPDIR)" && grep -q openwrt-23.05 $${top}/feeds.conf.default && echo true)
-ifeq ($(PKG_XZ),true)
-PKG_MIRROR_HASH:=35884a57e26058c6534b25c50b9aef14df81da501be1d153a9bb7923a47154dd
-else
-PKG_MIRROR_HASH:=649c977e5d32fe232c8d0cb617ec04c6e4bd767dfac40ebcdb1630ab990fcd8f
-endif
+
 
 GIT_COMMIT_DATE:=$(shell psd="$(PKG_SOURCE_DATE)" && echo $${psd} | sed 's|-|.|g' )
 GIT_COMMIT_SHORTHASH:=$(shell psv="$(PKG_SOURCE_VERSION)" && echo $${psv:0:7} )
@@ -41,7 +34,7 @@ define Package/$(PKG_NAME)
 	# TODO: Statically linking libstdcpp instead of depending on it and then
 	# stripping unused symbols might reduce space usage, until this is the
 	# only package to use it
-	DEPENDS:=+libstdcpp
+	# DEPENDS:=+libstdcpp
 endef
 
 define Package/$(PKG_NAME)/description
@@ -59,7 +52,9 @@ CMAKE_OPTIONS += -DCMAKE_VERBOSE_MAKEFILE=ON
 # #0 0x00000000
 # #1 0x00000000
 # #2 0x00000000
-CMAKE_OPTIONS += -DSS_CPPTRACE_STACKTRACE=OFF
+CMAKE_OPTIONS += -DSS_CPPTRACE_STACKTRACE=OFF 
+CMAKE_OPTIONS += -DSS_STATIC_LIBSTDCPP=ON 
+CMAKE_OPTIONS += -DSS_STRIP_SYMBOLS=ON
 
 
 define Package/$(PKG_NAME)/install

--- a/packages/shared-state-async/Makefile
+++ b/packages/shared-state-async/Makefile
@@ -28,17 +28,36 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 include $(INCLUDE_DIR)/host-build.mk
 
-define Package/$(PKG_NAME)
-	TITLE:=shared-state C++ async re-implementation
-	CATEGORY:=LibreMesh
-	# TODO: Statically linking libstdcpp instead of depending on it and then
-	# stripping unused symbols might reduce space usage, until this is the
-	# only package to use it
-	# DEPENDS:=+libstdcpp
+define Package/shared-state-async/Default
+  TITLE:=shared-state C++ async 
+  CATEGORY:=LibreMesh
+  URL:=https://github.com/libremesh/shared-state-async
 endef
 
-define Package/$(PKG_NAME)/description
-	shared-state re-written in C++20 and corotuines to handle information exchange between network nodes more efficiently.
+define Package/shared-state-async
+  $(call Package/shared-state-async/Default)
+  TITLE+= (dynamic linking)
+  DEPENDS:=+libstdcpp
+  VARIANT:=dynamic
+  DEFAULT_VARIANT:=1
+  CONFLICTS:=shared-state-async-static
+endef
+
+define Package/shared-state-async-static
+  $(call Package/shared-state-async/Default)
+  TITLE+= (static linking)
+  VARIANT:=static
+  PROVIDES:=shared-state-async
+  CONFLICTS:=shared-state-async
+endef
+
+define Package/shared-state-async/description
+	shared-state re-written in C++20 and coroutines to handle information exchange between network nodes more efficiently.
+endef
+
+define Package/shared-state-async-static/description
+	shared-state re-written in C++20 and coroutines to handle information exchange between network nodes more efficiently.
+	This variant is statically linked against the C++ standard library.
 endef
 
 # Otherwise OpenWrt's CPPFLAGS are ignored
@@ -53,11 +72,17 @@ CMAKE_OPTIONS += -DCMAKE_VERBOSE_MAKEFILE=ON
 # #1 0x00000000
 # #2 0x00000000
 CMAKE_OPTIONS += -DSS_CPPTRACE_STACKTRACE=OFF 
-CMAKE_OPTIONS += -DSS_STATIC_LIBSTDCPP=ON 
-CMAKE_OPTIONS += -DSS_STRIP_SYMBOLS=ON
 
+# Build configuration según variante
+ifeq ($(BUILD_VARIANT),static)
+  CMAKE_OPTIONS += -DSS_STATIC_LIBSTDCPP=ON
+  CMAKE_OPTIONS += -DSS_STRIP_SYMBOLS=ON
+else
+  CMAKE_OPTIONS += -DSS_STATIC_LIBSTDCPP=OFF
+  CMAKE_OPTIONS += -DSS_STRIP_SYMBOLS=OFF
+endif
 
-define Package/$(PKG_NAME)/install
+define Package/shared-state-async/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/shared-state-async $(1)/usr/bin/
 	$(CP) ./files/* $(1)/
@@ -66,4 +91,7 @@ define Package/$(PKG_NAME)/install
 	$(CP) ../shared-state/files/usr/bin/shared-state-get_candidates_neigh $(1)/usr/bin/shared-state-async-discover
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+Package/shared-state-async-static/install = $(Package/shared-state-async/install)
+
+$(eval $(call BuildPackage,shared-state-async))
+$(eval $(call BuildPackage,shared-state-async-static))

--- a/packages/shared-state-async/Makefile
+++ b/packages/shared-state-async/Makefile
@@ -11,7 +11,7 @@ PKG_NAME:=shared-state-async
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/javierbrk/shared-state-async.git
-PKG_SOURCE_VERSION:=use-statically-linked-stdlib
+PKG_SOURCE_VERSION:=useStaticallyLinkedStdlib
 PKG_MAINTAINER:=Asociación Civil Altermundi <info@altermundi.net>
 PKG_LICENSE:=AGPL-3.0-only
 


### PR DESCRIPTION
#1191 this makefile change enables the use of a statically linked shared state version

https://github.com/libremesh/shared-state-async/pull/2

It can be tested by compiling an image using this repos in the feeds 

src-git libremesh https://github.com/javierbrk/lime-packages.git;shared-state-async-static

This is just a draft and still requires further testing.


