### PR TITLE
Add uhttpd as dependency to shared-state

### DIFF
--- a/packages/shared-state/Makefile
+++ b/packages/shared-state/Makefile
@@ -10,7 +10,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=+libuci-lua +lime-system +lua +luci-lib-jsonc +luci-lib-nixio \
-		+iputils-ping +uclient-fetch
+		+iputils-ping +uclient-fetch +uhttpd
 	PKGARCH:=all
 endef
 


### PR DESCRIPTION
Address #952 
shared-state indeed share some stuff over http and none of its dependencies pull in uhttpd.
So adding it to the dependency list is a good idea i think!