### PR TITLE
packages: prometheus...-wifi-stations-extra: use babeld if available

### DIFF
--- a/packages/prometheus-node-exporter-lua-wifi-stations-extra/files/usr/lib/lua/prometheus-collectors/wifi_stations_extra.lua
+++ b/packages/prometheus-node-exporter-lua-wifi-stations-extra/files/usr/lib/lua/prometheus-collectors/wifi_stations_extra.lua
@@ -3,15 +3,31 @@ local iwinfo = require "iwinfo"
 
 local function mac2name_init()
   local mac2name = {}
+  local f = ""
+
   filename = "/etc/bat-hosts"
-  for line in io.lines(filename) do
-    local mac, name = line:match("(..:..:..:..:..:..)%s+([^%s]+)")
-    if mac then mac2name[mac:lower()] = name end
+  f = io.open(filename, "r")
+  if(f == nil) then
+    filename = "/etc/babeld-hosts"
+    f = io.open(filename, "r")
   end
+  if(f ~= nil) then
+    for line in io.lines(filename) do
+      if (string.match(filename, "babeld")) then
+        line = string.gsub(line, "ff:fe:", "")
+      end
+      local mac, name = line:match("(..:..:..:..:..:..)%s+([^%s]+)")
+      if mac then mac2name[mac:lower()] = name end
+    end
+  end
+
   filename = "/tmp/dhcp.leases"
-  for line in io.lines(filename) do
-    local mac, ip, name = line:match("(..:..:..:..:..:..)%s+([^%s]+)%s+([^%s]+)")
-    if mac then mac2name[mac:lower()] = name end
+  f = io.open(filename, "r")
+  if(f ~= nil) then
+    for line in io.lines(filename) do
+      local mac, ip, name = line:match("(..:..:..:..:..:..)%s+([^%s]+)%s+([^%s]+)")
+      if mac then mac2name[mac:lower()] = name end
+    end
   end
   return mac2name
 end


### PR DESCRIPTION
This collector currently doesn't work with profile-libremesh-suggested-packages-tiny
due to the lack of shared-state-bat_hosts (since this is based on shared-state-async which is too big for 8-64 devices)

This commit allows the collector to print hostnames taking the info from /etc/babeld-hosts
It also introduces a check to verify the existence of /tmp/dhcp.leases,
this in case of a setup without anygw or another dhcp server.