### PR TITLE
lime-system: wireless: add option distance_use_auto_if_available

### DIFF
--- a/packages/lime-docs/files/www/docs/lime-example.txt
+++ b/packages/lime-docs/files/www/docs/lime-example.txt
@@ -154,6 +154,7 @@ config lime wifi
                                                         # that rescan all available frequencies in active radios.
 
     option unstuck_timeout '300'                        # Timeout in seconds that defines how long the mentioned above workaround should go.
+    option distance_use_auto_if_available true
 
 #########################################################
 ### WiFi specific band options

--- a/packages/lime-system/files/etc/config/lime-defaults
+++ b/packages/lime-system/files/etc/config/lime-defaults
@@ -64,6 +64,7 @@ config lime wifi
 	option ieee80211s_mesh_id 'LiMe'
 	option unstuck_interval '10'
 	option unstuck_timeout '300'
+	option distance_use_auto_if_available true
 
 config lime-wifi-band '2ghz'
 	option channel '11'


### PR DESCRIPTION
lime-system: wireless: add option distance_use_auto_if_available

Closes #932

Introduce the wifi option `distance_use_auto_if_available` by default true
to enforce the value "auto" as distance for radio drivers that supports it
like kmod-ath9k when compiled with CONFIG_PACKAGE_ATH_DYNACK=y

Implement a check if driver supports auto setting.
At firstboot run 'iw phyX set distance auto' relying on the iw error
  i.e. 'command failed: Not supported (-95)' if unsupported
Save the result in lime-node in a format like `lime-node.radio0.dynack=0`
Re run the iw command on the same phy when the macaddress has changed
in case of powering off and plugging a different usb wireless adapter

Implement a check if distance 'auto' is requested for a driver that does not support it.
Use the lime-defaults value as safer option than allowing to set "auto", which could lead
to the minimum being applied at next reboot, potentially compromising long distance wireless links.

If auto is requested for a driver that doesn't support it
iw will fail with 'command failed: Not supported (-95)',
the value auto is not applied and the previous valid value i.e. '1000' is kept
However at next reboot if the value auto was saved in /etc/config/wireless
the coverage will be set to 0 on tested hardware.

To verify the applied coverage on a given phyX:
  iw phy phyX info | grep Coverage
In ath9k check the ack timeout in uS, followed by A for auto-determined or S set:
  cat /sys/kernel/debug/ieee80211/phy0/ath9k/ack_to

Further resources and links
- "[RFC] API for setting ACK timeout" thread on ml linux wireless
  https://www.spinics.net/lists/linux-wireless/msg43572.html
- Introduction in linux of setting coverage class for long distance wireless links:
  https://linux-wireless.vger.kernel.narkive.com/qo3X9KdF/patch-0-4-setting-coverage-class-and-ack-timeout-and-slot-time
- Introduction in iw of dynack:
  https://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git/commit/?id=e642142d68850b7eb161489a984ec6817b10c51b
- Support of dynack in openwrt:
  https://git.openwrt.org/?p=openwrt%2Fopenwrt.git&a=search&s=dynack
- Comments from communities using dynack:
  https://www.arednmesh.org/content/auto-distance-setting-0

Due to different driver implementations, producing a list of wireless drivers
that support different distance/coverage optimizations for outdoor usage could be complex.
Looking at the source code a starting point could be to check drivers that handle NL80211_ATTR_WIPHY_COVERAGE_CLASS
  i.e. grep -rl 'distance\|coverage' <linux>/drivers/net/wireless/
Among those, currently dynack is supported just by ath9k

Tested on these devices running lime master and openwrt 24.10.x or snapshot:
- ubnt_litebeam-m5-xw
- gemtek_wvrtm-127acn
- gemtek_wvrtm-130acn
- cudy_wr3000s-v1
- openwrt_one (usb adapter rtl8192cu)