### PR TITLE
Update lime-docs for downloading docs from the new website

### DIFF
--- a/packages/lime-docs/Makefile
+++ b/packages/lime-docs/Makefile
@@ -20,17 +20,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/$(PKG_NAME)
   CATEGORY:=LibreMesh
-  TITLE:=LibreMesh English documentation
-  DEPENDS:=+$(PKG_NAME)-minimal
-  MAINTAINER:=Ilario Gelmetti <iochesonome@gmail.com>
-  URL:=https://libremesh.org/docs/
-  SUBMENU:=Offline Documentation
-  PKGARCH:=all
-endef
-
-define Package/$(PKG_NAME)-it
-  CATEGORY:=LibreMesh
-  TITLE:=LibreMesh Italian documentation
+  TITLE:=LibreMesh documentation
   DEPENDS:=+$(PKG_NAME)-minimal
   MAINTAINER:=Ilario Gelmetti <iochesonome@gmail.com>
   URL:=https://libremesh.org/docs/
@@ -48,15 +38,11 @@ define Package/$(PKG_NAME)-minimal
 endef
 
 define Package/$(PKG_NAME)/description
-Offline English documentation for LibreMesh firmware
-endef
-
-define Package/$(PKG_NAME)-it/description
-Offline Italian documentation for LibreMesh firmware
+Offline documentation for LibreMesh firmware
 endef
 
 define Package/$(PKG_NAME)-minimal/description
-Minimal offline English documentation for LibreMesh firmware containing
+Minimal offline documentation for LibreMesh firmware containing
 just a commented example of the main config file.
 endef
 
@@ -69,12 +55,6 @@ define Package/$(PKG_NAME)/install
 	@ln -s /www/docs $(1)/docs
 endef
 
-define Package/$(PKG_NAME)-it/install
-	$(INSTALL_DIR) $(1)/www/docs/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/docs/it_*.txt $(1)/www/docs/
-	@ln -s /www/docs $(1)/docs
-endef
-
 define Package/$(PKG_NAME)-minimal/install
 	$(INSTALL_DIR) $(1)/
 	$(CP) ./files/* $(1)/
@@ -82,6 +62,5 @@ define Package/$(PKG_NAME)-minimal/install
 endef
 
 $(eval $(call BuildPackage,lime-docs))
-$(eval $(call BuildPackage,lime-docs-it))
 $(eval $(call BuildPackage,lime-docs-minimal))
 

--- a/packages/lime-docs/Makefile
+++ b/packages/lime-docs/Makefile
@@ -51,7 +51,8 @@ endef
 
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/www/docs/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/docs/en_*.txt $(1)/www/docs/
+	$(CP) $(PKG_BUILD_DIR)/docs/reference $(1)/www/docs/
+	$(CP) $(PKG_BUILD_DIR)/docs/guide $(1)/www/docs/
 	@ln -s /www/docs $(1)/docs
 endef
 

--- a/packages/lime-docs/Makefile
+++ b/packages/lime-docs/Makefile
@@ -51,8 +51,8 @@ endef
 
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/www/docs/
-	$(CP) $(PKG_BUILD_DIR)/docs/reference $(1)/www/docs/
-	$(CP) $(PKG_BUILD_DIR)/docs/guide $(1)/www/docs/
+	$(FIND) $(PKG_BUILD_DIR)/docs/reference -name "*md" -print0 -printf '$(1)/www/docs/%f.txt\000' | $(XARGS) -0 -n 2 $(INSTALL_DATA)
+	$(FIND) $(PKG_BUILD_DIR)/docs/guide -name "*md" -print0 -printf '$(1)/www/docs/%f.txt\000' | $(XARGS) -0 -n 2 $(INSTALL_DATA)
 	@ln -s /www/docs $(1)/docs
 endef
 


### PR DESCRIPTION
As approved in a meeting on the 7th of March, the website has been completely restructured by @a-gave and now it looks much better :D
As a result, the files fetched by the `lime-docs` package moved and it needs to be updated for avoiding compilation errors.
Also, I removed the `lime-docs-it` with the Italian documentation, as it was pretty much abandoned.