### PR TITLE
fix: lime-config improve the fallback to network.primary_interface

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/network.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/network.lua
@@ -55,20 +55,72 @@ function network.get_own_macs(interface_filter)
 	return result
 end
 
+function network.interface_exists(ifname)
+	return fs.lstat("/sys/class/net/"..ifname) and true or false
+end
+
+--! Extract network.<role>.device or the first network.<role>.ports if found in /etc/board.json
+function network.primary_interface_from_board_by_role(role)
+	local board = utils.getBoardAsTable()
+	local ifname = nil
+	if board["network"] and board["network"][role] then
+		ifname = board["network"][role]["device"]
+		if ifname == nil or ifname == "" then
+			local ports = board["network"][role]["ports"]
+			if ports == nil or ports == "" or next(ports) == nil then
+				print("network.primary_interface() could not determine ifname from "..role.." in /etc/board.json!" )
+			else
+				ifname = ports[1]
+			end
+		end
+	end
+	return ifname
+end
 
 function network.assert_interface_exists(ifname)
 	assert( ifname ~= nil and ifname ~= "",
 	        "network.primary_interface() could not determine ifname!" )
 
-	assert( fs.lstat("/sys/class/net/"..ifname),
+	assert( network.interface_exists(ifname),
 	        "network.primary_interface() "..ifname.." doesn't exists!" )
+end
+
+function network.primary_interface_from_board()
+	--! Scan the role network.lan from /etc/board.json
+	local ifname = network.primary_interface_from_board_by_role("lan")
+
+	--! Scan other roles
+	if ifname == nil or ifname == "" then
+		local board = utils.getBoardAsTable()
+		for role in pairs(board["network"] or {}) do
+			if role ~= "lan" then
+				ifname = network.primary_interface_from_board_by_role(role)
+				if ifname ~= nil and ifname ~= "" then
+					break
+				end
+			end
+		end
+	end
+
+	return ifname
 end
 
 function network.primary_interface()
 	local ifname = config.get("network", "primary_interface", "eth0")
+
+	--! Check if the autogen primary_interface or the fallback 'eth0' exists
+	--! Force a fallback to 'auto' otherwise
+	if ifname ~= "auto" then
+		if not network.interface_exists(ifname) then
+			print("network.primary_interface() "..ifname.." doesn't exists! Fallback to 'auto'.")
+			ifname = "auto"
+			local uci = config.get_uci_cursor()
+			uci:set(config.UCI_AUTOGEN_NAME, "network", "primary_interface", "auto")
+		end
+	end
+
 	if ifname == "auto" then
-		local board = utils.getBoardAsTable()
-		ifname = board['network']['lan']['device']
+		ifname = network.primary_interface_from_board()
 	end
 	network.assert_interface_exists(ifname)
 	return ifname

--- a/packages/lime-system/tests/test_lime_network.lua
+++ b/packages/lime-system/tests/test_lime_network.lua
@@ -35,7 +35,7 @@ describe('LiMe Network tests', function()
         stub(utils, "getBoardAsTable", function () return BOARD end)
         stub(network, "assert_interface_exists", function () return true end)
 
-        assert.is.equal('test0', network.primary_interface())
+        assert.is.equal('lo', network.primary_interface())
     end)
 
     it('test primary_interface auto config', function()


### PR DESCRIPTION
Force a fallback to auto in case the specified primary_interface doesn't exist