### PR TITLE
Add rpcd dependency in lime-system

### DIFF
--- a/packages/lime-system/Makefile
+++ b/packages/lime-system/Makefile
@@ -26,7 +26,8 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Gioacchino Mazzurco <gio@eigenlab.org>
   URL:=http://libremesh.org
   DEPENDS:=+firewall4 +libiwinfo-lua +lua +libuci-lua \
-    +luci-lib-ip +luci-lib-nixio +luci-lib-jsonc +jq +rpcd-mod-rpcsys
+    +luci-lib-ip +luci-lib-nixio +luci-lib-jsonc +jq +rpcd-mod-rpcsys \
+    +rpcd
   PKGARCH:=all
 endef
 

--- a/packages/ubus-lime-utils/Makefile
+++ b/packages/ubus-lime-utils/Makefile
@@ -7,7 +7,7 @@ define Package/$(PKG_NAME)
   SUBMENU:=3. Applications
   TITLE:=LIbremesh ubus utils module
   DEPENDS:= +lua +libubox-lua +libubus-lua +libuci +lime-system +libiwinfo-lua +cgi-io +rpcd-mod-file \
-	    +luci-lib-jsonc
+	    +luci-lib-jsonc +rpcd
 
   PKGARCH:=all
 endef


### PR DESCRIPTION
As reported here https://github.com/libremesh/lime-packages/pull/1245#issuecomment-4119550080 and also reported by @rah2501 on the Matrix chat, when compiling using the BuildRoot method, `lime-system` does not appear in menuconfig unless Base system > `rpcd` gets selected first.
This happens because without selecting rpcd, rpcd-mod-rpcsys cannot be selected, and lime-system depends on the latter since #1245.
