### PR TITLE
Consolidate module handling code into a new script

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/config.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/config.lua
@@ -8,6 +8,7 @@
 local fs = require("nixio.fs")
 local libuci = require("uci")
 local nixio = require "nixio"
+local modules = require "lime.modules"
 
 config = {}
 
@@ -195,11 +196,14 @@ function config.main()
 	local utils = require("lime.utils")
 
 	--! Check whether this is the first ever run
-	if not utils.file_exists(config.uci:get_confdir() .. "/" .. config.UCI_AUTOGEN_NAME) then
+	local init = not utils.file_exists(config.uci:get_confdir() .. "/" .. config.UCI_AUTOGEN_NAME)
+	if init then
 		config.execute_hooks("init")
+		modules.execute("init")
 	end
 
 	config.execute_hooks("pre")
+	modules.execute("pre")
 
 	--! Get mac address and set mac-based configuration file name
 	config.UCI_MAC_NAME = "lime-" .. table.concat(network.primary_mac(),"")
@@ -217,23 +221,8 @@ function config.main()
 
 	config.execute_hooks("merged")
 
-	local modules_name = { "hardware_detection", "wireless", "network", "firewall", "system",
-                           "generic_config" }
-
-	if utils.isModuleAvailable("lime.wifi_unstuck_wa") then
-		table.insert(modules_name, "wifi_unstuck_wa")
-	end
-
-	local modules = {}
-
-	for i, name in pairs(modules_name) do modules[i] = require("lime."..name) end
-	for _,module in pairs(modules) do
-		xpcall(module.clean, function(errmsg) print(errmsg) ; print(debug.traceback()) end)
-	end
-
-	for _,module in pairs(modules) do
-		xpcall(module.configure, function(errmsg) print(errmsg) ; print(debug.traceback()) end)
-	end
+	modules.execute("clean")
+	modules.execute("configure")
 
 	config.execute_hooks("configured")
 

--- a/packages/lime-system/files/usr/lib/lua/lime/modules.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/modules.lua
@@ -1,0 +1,59 @@
+#!/usr/bin/lua
+
+modules = {}
+
+modules.NAMES = {
+	"hardware_detection",
+	"wireless",
+	"network",
+	"firewall",
+	"system",
+	"generic_config",
+	"wifi_unstuck_wa",
+}
+
+function modules.is_available(name)
+	if package.loaded[name] then
+		return true
+	else
+		for _, searcher in ipairs(package.searchers or package.loaders) do
+			local loader = searcher(name)
+			if type(loader) == 'function' then
+				package.preload[name] = loader
+				return true
+			end
+		end
+		return false
+	end
+end
+
+function modules.ensure_modules()
+	if modules.modules ~= nil then
+		return
+	end
+
+	modules.modules = {}
+	for i, name in pairs(modules.NAMES) do
+		full_name = "lime." .. name
+		if modules.is_available(full_name) then
+			modules.modules[i] = require(full_name)
+		end
+	end
+end
+
+local function module_error(errmsg)
+	print(errmsg)
+	print(debug.traceback())
+end
+
+function modules.execute(func)
+	modules.ensure_modules()
+
+	for _, module in pairs(modules.modules) do
+		if module[func] ~= nil then
+			xpcall(module[func], module_error)
+		end
+	end
+end
+
+return modules

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -9,6 +9,7 @@
 
 utils = {}
 
+local modules = require("lime.modules")
 local config = require("lime.config")
 local json = require("luci.jsonc")
 local fs = require("nixio.fs")
@@ -78,18 +79,7 @@ function utils.literalize(str)
 end
 
 function utils.isModuleAvailable(name)
-	if package.loaded[name] then
-		return true
-	else
-		for _, searcher in ipairs(package.searchers or package.loaders) do
-			local loader = searcher(name)
-			if type(loader) == 'function' then
-				package.preload[name] = loader
-				return true
-			end
-		end
-		return false
-	end
+	return modules.is_available(name)
 end
 
 function utils.applyMacTemplate16(template, mac)


### PR DESCRIPTION
This makes the interface to module functions much more robust and clean and also as a side-effect, makes the config.lua script much cleaner.

While we're at it, an init() function for lime modules called once on first boot (essentially a one-liner with the consolidation).  Note that it is called from /etc/init.d/boot and not uci-defaults so the stock OpenWrt wireless config will be present.