### PR TITLE
feat(ci): end-to-end firmware build and hardware test pipeline

### DIFF
--- a/.github/ci/targets.yml
+++ b/.github/ci/targets.yml
@@ -1,0 +1,114 @@
+# CI targets for the build-firmware workflow.
+openwrt_releases:
+  - "24.10.6"
+  - "25.12.2"
+feed_branches:
+  "24.10.6": "openwrt-24.10"
+  "25.12.2": "openwrt-25.12"
+default_physical_releases:
+  - "24.10.6"
+
+packages: >-
+  lime-system lime-proto-babeld lime-proto-batadv lime-proto-anygw
+  lime-hwd-openwrt-wan lime-hwd-ground-routing lime-app
+  lime-debug lime-docs lime-docs-minimal
+  shared-state-babeld_hosts shared-state-bat_hosts
+  shared-state-dnsmasq_hosts shared-state-nodes_and_links
+  babeld-auto-gw-mode check-date-http batctl-default
+  -dnsmasq -odhcpd-ipv6only
+
+targets:
+  - device: linksys_e8450
+    imagebuilder: mediatek-mt7622
+    # The `linksys_e8450-ubi` profile (UBI-on-NAND) defines KERNEL_INITRAMFS
+    # and ships the kernel.bin + DTB build_image.sh needs to repack the FIT;
+    # the plain `linksys_e8450` profile does not.
+    profile: linksys_e8450-ubi
+    arch: aarch64_cortex-a53
+    sdk_arch: aarch64_cortex-a53-openwrt-24.10
+    index_imagebuilder: mediatek-filogic
+    build_initramfs: true
+    fit_arch: arm64
+    fit_kernel_loadaddr: "0x44000000"
+    fit_dts: mt7622-linksys-e8450-ubi
+    test_firmware: true
+    test_places:
+      - belkin_rt3200_1
+      - belkin_rt3200_2
+      - belkin_rt3200_3
+    # MT7622 BL2/BL31 take ~12s before U-Boot starts its 3s autoboot
+    # countdown; bump the interrupt-spam window so it covers both.
+    uboot_interrupt_spam_sec: 25
+    # mt7915e PCIe needs `swiotlb=512` to allocate DMA bounce buffers.
+    fit_bootargs: "console=ttyS0,115200n1 swiotlb=512 pci=pcie_bus_perf"
+    # OEM MAC lives in a UBI factory volume; mtk_eth_soc races UBI attach
+    # and gets stuck on -EPROBE_DEFER. Patch DTBs to inject the MAC.
+    dtb_patch_nvmem_mac: true
+    # Force the legacy 23.05 SPI-NAND layout so the kernel UBI MTD does
+    # not overwrite BL2/BL31/factory on units still on layout 1.0.
+    dtb_force_legacy_partitions: true
+
+  - device: openwrt_one
+    imagebuilder: mediatek-filogic
+    profile: openwrt_one
+    arch: aarch64_cortex-a53
+    sdk_arch: aarch64_cortex-a53-openwrt-24.10
+    index_imagebuilder: mediatek-filogic
+    build_initramfs: true
+    fit_arch: arm64
+    fit_kernel_loadaddr: "0x44000000"
+    fit_dts: mt7981b-openwrt-one
+
+  - device: qemu_x86_64
+    imagebuilder: x86-64
+    profile: generic
+    arch: x86_64
+    sdk_arch: x86_64-openwrt-24.10
+    index_imagebuilder: x86-64
+    build_initramfs: false
+    image_format: x86-combined
+    # vwifi packaging fork pinned by full SHA (smart-HTTP rejects short prefixes).
+    packages: >-
+      {{ packages_default }} kmod-mac80211-hwsim wpad-mesh-mbedtls vwifi
+    extra_feeds:
+      - "src-git|vwifi|https://github.com/fcefyn-testbed/vwifi_cli_package.git^8a57be2622053ca75e7e2c8c592cf62b9fad012f"
+    extra_packages:
+      - "vwifi"
+    test_firmware: false
+    test_qemu: true
+
+  - device: librerouter_v1
+    imagebuilder: ath79-generic
+    profile: librerouter_librerouter-v1
+    arch: mips_24kc
+    sdk_arch: mips_24kc-openwrt-24.10
+    index_imagebuilder: ath79-generic
+    build_initramfs: true
+    image_format: dual-tftp
+    test_firmware: true
+    test_places:
+      - librerouter_1
+
+  - device: bananapi_bpi-r4
+    imagebuilder: mediatek-filogic
+    profile: bananapi_bpi-r4
+    arch: aarch64_cortex-a53
+    sdk_arch: aarch64_cortex-a53-openwrt-24.10
+    index_imagebuilder: mediatek-filogic
+    build_initramfs: true
+    fit_arch: arm64
+    fit_kernel_loadaddr: "0x46000000"
+    fit_dts: mt7988a-bananapi-bpi-r4
+    # mt7996e on 24.10.x panics under hostapd; exclude wifi kmods until the
+    # mt76 backport lands. The board still mesh-routes over the wired DSA
+    # ports. Tracking: https://github.com/openwrt/openwrt/issues/21657
+    packages: >-
+      lime-system lime-proto-babeld lime-proto-batadv lime-proto-anygw
+      lime-hwd-openwrt-wan lime-hwd-ground-routing lime-app
+      lime-debug lime-docs lime-docs-minimal
+      shared-state-babeld_hosts shared-state-bat_hosts
+      shared-state-dnsmasq_hosts shared-state-nodes_and_links
+      babeld-auto-gw-mode check-date-http batctl-default
+      -dnsmasq -odhcpd-ipv6only
+      -kmod-mt7996e -kmod-mt7996-firmware -kmod-mt7996-firmware-common
+      -kmod-mt7996-233-firmware -mt7988-wo-firmware

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -1,0 +1,1169 @@
+name: Build firmware
+
+on:
+  pull_request:
+    branches: [master, main]
+    paths:
+      - ".github/workflows/build-firmware.yml"
+      - ".github/ci/targets.yml"
+      - "tools/ci/**"
+      - "packages/**"
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: "Comma-separated devices from .github/ci/targets.yml or 'all'"
+        required: false
+        default: "all"
+      openwrt_releases:
+        description: "Comma-separated OpenWrt releases (defaults to targets.yml openwrt_releases)"
+        required: false
+        default: ""
+      physical_releases:
+        description: "Comma-separated releases to run on physical lab (defaults to targets.yml default_physical_releases)"
+        required: false
+        default: ""
+      physical_single:
+        description: "Run single-node tests on every physical lab DUT"
+        required: false
+        type: boolean
+        default: false
+      physical_mesh_count:
+        description: "Number of physical DUTs for the mesh test (0 = skip, 2 or 3)"
+        required: false
+        type: choice
+        options:
+          - "0"
+          - "2"
+          - "3"
+        default: "0"
+      physical_mesh_pairs:
+        description: "Run 2-node mesh pairs sweep (same as daily cron)"
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Daily lab sweep at 06:00 UTC (03:00 ART).
+    - cron: "0 6 * * *"
+
+concurrency:
+  # PR/push share a per-ref lane; schedule and workflow_dispatch share a single lab lane so lab-bound runs never race on a labgrid place.
+  group: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'physical-lab-shared' || format('build-firmware-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      targets_matrix: ${{ steps.prepare.outputs.targets_matrix }}
+      test_targets_matrix: ${{ steps.prepare.outputs.test_targets_matrix }}
+      mesh_test_matrix: ${{ steps.prepare.outputs.mesh_test_matrix }}
+      mesh_pairs_matrix: ${{ steps.prepare.outputs.mesh_pairs_matrix }}
+      qemu_single_matrix: ${{ steps.prepare.outputs.qemu_single_matrix }}
+      qemu_mesh_matrix: ${{ steps.prepare.outputs.qemu_mesh_matrix }}
+      archs_matrix: ${{ steps.prepare.outputs.archs_matrix }}
+      lime_packages_list: ${{ steps.prepare.outputs.lime_packages_list }}
+      feed_hash: ${{ steps.prepare.outputs.feed_hash }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install yq
+        run: sudo apt-get update && sudo apt-get install -y yq jq
+
+      - name: Prepare matrices
+        id: prepare
+        env:
+          TARGETS_INPUT: ${{ github.event.inputs.targets || 'all' }}
+          RELEASES_OVERRIDE: ${{ github.event.inputs.openwrt_releases || '' }}
+          PHYSICAL_RELEASES_OVERRIDE: ${{ github.event.inputs.physical_releases || '' }}
+          MESH_COUNT_INPUT: ${{ github.event.inputs.physical_mesh_count || '0' }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: tools/ci/prepare_matrix.sh
+
+  build-feed:
+    runs-on: ubuntu-latest
+    needs: prepare-matrix
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.archs_matrix) }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Free disk
+        run: sudo rm -rf /opt/hostedtoolcache /usr/share/dotnet /usr/local/lib/android
+
+      - name: Restore feed cache
+        id: cache-feed
+        uses: actions/cache@v4
+        with:
+          path: feed-artifact/lime_packages
+          # `extra_hash` is a 12-char sha256 prefix over (extra_feeds,
+          # extra_packages); restore-keys deliberately omits it so a stale
+          # extras pin never falls back to a partial match.
+          key: lime-feed-v3-${{ matrix.arch }}-${{ matrix.openwrt_release }}-${{ needs.prepare-matrix.outputs.feed_hash }}-${{ matrix.extra_hash }}
+          restore-keys: |
+            lime-feed-v3-${{ matrix.arch }}-${{ matrix.openwrt_release }}-${{ needs.prepare-matrix.outputs.feed_hash }}-
+
+      - name: Build packages with openwrt/gh-action-sdk
+        if: steps.cache-feed.outputs.cache-hit != 'true'
+        uses: openwrt/gh-action-sdk@v9
+        env:
+          ARCH: ${{ matrix.sdk_arch }}
+          FEEDNAME: lime_packages
+          PACKAGES: ${{ needs.prepare-matrix.outputs.lime_packages_list }} ${{ matrix.extra_packages }}
+          # Extra src-git feeds, space-separated `<type>|<name>|<url>[^<sha>]`
+          # entries; gh-action-sdk appends each to feeds.conf. Pinning the
+          # full 40-char SHA is required (smart-HTTP rejects short prefixes).
+          EXTRA_FEEDS: ${{ matrix.extra_feeds }}
+          NO_REFRESH_CHECK: "1"
+          NO_SHFMT_CHECK: "1"
+          # SDK-side `make package/index` is unreliable in CI; we index the
+          # feed downstream with ImageBuilder's ipkg-make-index / apk mkndx.
+          INDEX: "0"
+          IGNORE_ERRORS: "n m y"
+
+      - name: Diagnose feed build output
+        if: steps.cache-feed.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          OPENWRT_RELEASE: ${{ matrix.openwrt_release }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          case "${OPENWRT_RELEASE}" in
+            24.10.*) PKG_FORMAT=ipk ;;
+            *)       PKG_FORMAT=apk ;;
+          esac
+          echo "Package format for ${OPENWRT_RELEASE}: ${PKG_FORMAT}"
+          echo "=== bin/packages tree ==="
+          find bin/packages -maxdepth 4 -type d 2>/dev/null | sort || true
+          echo "=== bin/targets tree (where target-binary extras land) ==="
+          find bin/targets -maxdepth 4 -type d 2>/dev/null | sort || true
+          echo "=== bin/packages/${{ matrix.arch }}/lime_packages/ ==="
+          ls -la "bin/packages/${{ matrix.arch }}/lime_packages/" 2>/dev/null || echo "(missing)"
+          echo "=== bin/packages/all/lime_packages/ ==="
+          ls -la "bin/packages/all/lime_packages/" 2>/dev/null || echo "(missing)"
+          arch_files=(
+            "bin/packages/${{ matrix.arch }}/lime_packages/"*.ipk
+            "bin/packages/${{ matrix.arch }}/lime_packages/"*.apk
+          )
+          all_files=(
+            "bin/packages/all/lime_packages/"*.ipk
+            "bin/packages/all/lime_packages/"*.apk
+          )
+          echo "Arch packages: ${#arch_files[@]} | All packages: ${#all_files[@]}"
+          if (( ${#arch_files[@]} == 0 && ${#all_files[@]} == 0 )); then
+            echo "ERROR: feed produced no .ipk or .apk packages" >&2
+            exit 1
+          fi
+          # Best-effort listing of every extra feed output dir; missing
+          # dirs are tolerated since target-binary packages land under
+          # bin/targets/ instead.
+          extra_feeds_str="${{ matrix.extra_feeds }}"
+          if [[ -n "$extra_feeds_str" ]]; then
+            echo "=== Extra src-git feeds output ==="
+            for entry in $extra_feeds_str; do
+              feed_name="$(echo "$entry" | cut -d'|' -f2)"
+              extra_dir="bin/packages/${{ matrix.arch }}/${feed_name}"
+              echo "--- ${extra_dir} ---"
+              ls -la "$extra_dir" 2>/dev/null || echo "(missing - target-binary extras live under bin/targets/)"
+            done
+            echo "=== bin/targets/**/packages/ (target-built packages) ==="
+            find bin/targets \( -name "*.ipk" -o -name "*.apk" \) -path "*/packages/*" 2>/dev/null \
+              | sort || echo "(none)"
+          fi
+
+      - name: Assemble lime_packages feed artifact (index with ImageBuilder)
+        if: steps.cache-feed.outputs.cache-hit != 'true'
+        env:
+          OPENWRT_RELEASE: ${{ matrix.openwrt_release }}
+        run: |
+          set -euo pipefail
+          # 24.10.x emits .ipk indexed by Packages/Packages.gz (opkg);
+          # 25.12.x emits .apk indexed by packages.adb (apk-tools).
+          case "${OPENWRT_RELEASE}" in
+            24.10.*) PKG_FORMAT=ipk ;;
+            *)       PKG_FORMAT=apk ;;
+          esac
+          echo "Assembling feed for ${OPENWRT_RELEASE} (PKG_FORMAT=${PKG_FORMAT})"
+
+          rm -rf feed-artifact
+          mkdir -p feed-artifact/lime_packages
+
+          arch_dir="bin/packages/${{ matrix.arch }}/lime_packages"
+          all_dir="bin/packages/all/lime_packages"
+
+          if [[ -d "$arch_dir" ]]; then
+            cp -a "$arch_dir"/. feed-artifact/lime_packages/
+          fi
+          if [[ -d "$all_dir" ]]; then
+            cp -a "$all_dir"/. feed-artifact/lime_packages/
+          fi
+
+          # Merge per-feed packages from the extra src-git feeds. PKGARCH:=all
+          # entries land under bin/packages/<arch>/<feed>/; target-binary
+          # entries (e.g. vwifi) land under bin/targets/<t>/<st>/packages/.
+          extra_feeds_str="${{ matrix.extra_feeds }}"
+          extra_packages_str="${{ matrix.extra_packages }}"
+          if [[ -n "$extra_feeds_str" ]]; then
+            for entry in $extra_feeds_str; do
+              feed_name="$(echo "$entry" | cut -d'|' -f2)"
+              for src in \
+                "bin/packages/${{ matrix.arch }}/${feed_name}" \
+                "bin/packages/all/${feed_name}"
+              do
+                if [[ -d "$src" ]]; then
+                  echo "Merging $src into feed-artifact/lime_packages/"
+                  shopt -s nullglob
+                  for f in "$src"/*.ipk "$src"/*.apk; do
+                    cp -a "$f" feed-artifact/lime_packages/
+                  done
+                fi
+              done
+            done
+            # Pull each declared extra_packages entry from bin/targets/
+            # if not already present (handles target-binary feeds like
+            # vwifi where the SDK lands the package under bin/targets/).
+            if [[ -n "$extra_packages_str" && -d bin/targets ]]; then
+              for pkg in $extra_packages_str; do
+                shopt -s nullglob
+                already=(
+                  feed-artifact/lime_packages/${pkg}_*.ipk
+                  feed-artifact/lime_packages/${pkg}-*.ipk
+                  feed-artifact/lime_packages/${pkg}-*.apk
+                )
+                if [[ ${#already[@]} -gt 0 ]]; then
+                  continue
+                fi
+                while IFS= read -r -d '' f; do
+                  echo "Merging $f (from bin/targets) into feed-artifact/lime_packages/"
+                  cp -a "$f" feed-artifact/lime_packages/
+                done < <(find bin/targets -path '*/packages/*' \
+                          \( -name "${pkg}_*.ipk" -o -name "${pkg}-*.ipk" -o -name "${pkg}-*.apk" \) \
+                          -print0 2>/dev/null)
+              done
+            fi
+          fi
+
+          # Each declared extra_packages entry must have produced at least
+          # one .ipk/.apk; gh-action-sdk exits 0 when an arch is unsupported.
+          if [[ -n "$extra_packages_str" ]]; then
+            for pkg in $extra_packages_str; do
+              shopt -s nullglob
+              matches=(
+                feed-artifact/lime_packages/${pkg}_*.ipk
+                feed-artifact/lime_packages/${pkg}-*.ipk
+                feed-artifact/lime_packages/${pkg}-*.apk
+              )
+              if [[ ${#matches[@]} -eq 0 ]]; then
+                echo "ERROR: extra_packages entry '${pkg}' produced no .ipk or .apk" >&2
+                echo "Searched feed-artifact/lime_packages/${pkg}{_,-}*.{ipk,apk}" >&2
+                echo "Also searched bin/targets/**/packages/${pkg}*:" >&2
+                find bin/targets -path '*/packages/*' \
+                     \( -name "${pkg}_*.ipk" -o -name "${pkg}-*.ipk" -o -name "${pkg}-*.apk" \) \
+                     2>/dev/null >&2 || true
+                exit 1
+              fi
+            done
+          fi
+
+          shopt -s nullglob
+          all_pkgs=(feed-artifact/lime_packages/*.ipk feed-artifact/lime_packages/*.apk)
+          if [[ ${#all_pkgs[@]} -eq 0 ]]; then
+            echo "ERROR: No .ipk or .apk files found under feed-artifact/lime_packages" >&2
+            echo "Expected sources: $arch_dir and/or $all_dir" >&2
+            exit 1
+          fi
+
+          docker pull "ghcr.io/openwrt/imagebuilder:${{ matrix.index_imagebuilder }}-v${OPENWRT_RELEASE}"
+          chmod -R a+rwX feed-artifact/lime_packages
+
+          if [[ "$PKG_FORMAT" == "ipk" ]]; then
+            # ipkg-make-index puts the path it receives straight into the
+            # `Filename:` field after stripping a leading `./`. Pass `.`
+            # so the index ships bare basenames; `/work` would emit
+            # `Filename: /work/...` which opkg cannot resolve.
+            docker run --rm \
+              --user root \
+              -e MKHASH=/builder/staging_dir/host/bin/mkhash \
+              -e PATH=/builder/staging_dir/host/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+              -v "$(pwd)/feed-artifact/lime_packages:/work" \
+              "ghcr.io/openwrt/imagebuilder:${{ matrix.index_imagebuilder }}-v${OPENWRT_RELEASE}" \
+              sh -lc 'cd /work && /builder/scripts/ipkg-make-index.sh . > Packages && gzip -9nc Packages > Packages.gz'
+
+            echo "=== Final feed-artifact/lime_packages/ contents (ipk) ==="
+            ls -la feed-artifact/lime_packages/
+            echo "=== Packages index summary (first 60 lines + count) ==="
+            head -n 60 feed-artifact/lime_packages/Packages || true
+            pkg_count=$(grep -c '^Package:' feed-artifact/lime_packages/Packages || echo 0)
+            echo "Total Package: entries in index: ${pkg_count}"
+            echo "=== Sanity: Filename fields must be bare basenames ==="
+            bad_fn=$(grep -E '^Filename: (/|\./)' feed-artifact/lime_packages/Packages || true)
+            if [[ -n "$bad_fn" ]]; then
+              echo "ERROR: Packages index has non-basename Filename entries:" >&2
+              echo "$bad_fn" >&2
+              exit 1
+            fi
+            grep -m 3 '^Filename:' feed-artifact/lime_packages/Packages
+          else
+            # apk-tools 3.x quirks: `--allow-untrusted` is a global flag
+            # (must precede the sub-command); `apk <sub> --help` exits 1
+            # even on valid sub-commands, so probe via the global help.
+            # The IB ships `apk` under staging_dir/host{,/usr}/bin/apk.
+            docker run --rm \
+              --user root \
+              -e PATH=/builder/staging_dir/host/usr/bin:/builder/staging_dir/host/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+              -v "$(pwd)/feed-artifact/lime_packages:/work" \
+              "ghcr.io/openwrt/imagebuilder:${{ matrix.index_imagebuilder }}-v${OPENWRT_RELEASE}" \
+              sh -lc '
+                set -e
+                cd /work
+                APK=""
+                for cand in \
+                  /builder/staging_dir/host/usr/bin/apk \
+                  /builder/staging_dir/host/bin/apk \
+                  /builder/staging_dir/hostpkg/usr/bin/apk \
+                  /usr/bin/apk \
+                  $(command -v apk 2>/dev/null || true)
+                do
+                  if [ -n "$cand" ] && [ -x "$cand" ]; then
+                    APK="$cand"; break
+                  fi
+                done
+                if [ -z "$APK" ]; then
+                  echo "ERROR: cannot locate apk binary in the IB" >&2
+                  echo "=== /builder/staging_dir/host listing ===" >&2
+                  find /builder/staging_dir/host -maxdepth 4 -name apk 2>/dev/null >&2 || true
+                  echo "=== /builder layout (top 2 levels) ===" >&2
+                  find /builder -maxdepth 2 -type d 2>/dev/null >&2 || true
+                  exit 1
+                fi
+                echo "=== apk binary: $APK ==="
+                "$APK" --version 2>&1 || true
+                help_text=$("$APK" --help 2>&1 || true)
+                if printf "%s\n" "$help_text" | grep -qw mkndx; then
+                  echo "Using: apk --allow-untrusted mkndx"
+                  "$APK" --allow-untrusted mkndx --output packages.adb -- *.apk
+                elif printf "%s\n" "$help_text" | grep -qw index; then
+                  echo "Using: apk --allow-untrusted index"
+                  "$APK" --allow-untrusted index --output packages.adb *.apk
+                else
+                  echo "WARNING: neither mkndx nor index advertised in apk --help; attempting mkndx anyway" >&2
+                  printf "%s\n" "$help_text" | head -80 >&2 || true
+                  "$APK" --allow-untrusted mkndx --output packages.adb -- *.apk
+                fi
+              '
+
+            echo "=== Final feed-artifact/lime_packages/ contents (apk) ==="
+            ls -la feed-artifact/lime_packages/
+            if [[ ! -f feed-artifact/lime_packages/packages.adb ]]; then
+              echo "ERROR: packages.adb was not generated" >&2
+              exit 1
+            fi
+            adb_size=$(stat -c%s feed-artifact/lime_packages/packages.adb)
+            apk_count=$(find feed-artifact/lime_packages -maxdepth 1 -name "*.apk" | wc -l)
+            echo "packages.adb size: ${adb_size} bytes | .apk count: ${apk_count}"
+          fi
+
+      - name: Diagnose cached feed (cache hit)
+        if: steps.cache-feed.outputs.cache-hit == 'true'
+        env:
+          OPENWRT_RELEASE: ${{ matrix.openwrt_release }}
+        run: |
+          set -euo pipefail
+          case "${OPENWRT_RELEASE}" in
+            24.10.*) PKG_FORMAT=ipk ;;
+            *)       PKG_FORMAT=apk ;;
+          esac
+          echo "=== Cache hit: feed-artifact/lime_packages/ (${PKG_FORMAT}) ==="
+          ls -la feed-artifact/lime_packages/
+          if [[ "$PKG_FORMAT" == "ipk" ]]; then
+            pkg_count=$(grep -c '^Package:' feed-artifact/lime_packages/Packages 2>/dev/null || echo 0)
+            echo "Cached opkg index has ${pkg_count} packages"
+          else
+            apk_count=$(find feed-artifact/lime_packages -maxdepth 1 -name "*.apk" | wc -l)
+            adb_size=$(stat -c%s feed-artifact/lime_packages/packages.adb 2>/dev/null || echo 0)
+            echo "Cached apk feed: ${apk_count} .apk files, packages.adb=${adb_size} bytes"
+          fi
+
+      - name: Upload local feed artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lime-feed-${{ matrix.arch }}-${{ matrix.openwrt_release }}
+          path: feed-artifact/lime_packages/
+          retention-days: 7
+
+      - name: Upload feed debug logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-debug-feed-${{ matrix.arch }}-${{ matrix.openwrt_release }}
+          path: |
+            bin/packages/${{ matrix.arch }}/
+            logs/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  build-image:
+    runs-on: ubuntu-latest
+    needs: [prepare-matrix, build-feed]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.targets_matrix) }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Free disk
+        run: sudo rm -rf /opt/hostedtoolcache /usr/share/dotnet /usr/local/lib/android
+
+      - name: Download matching local feed
+        uses: actions/download-artifact@v5
+        with:
+          name: lime-feed-${{ matrix.arch }}-${{ matrix.openwrt_release }}
+          path: ./feed-in/lime_packages/
+
+      - name: Diagnose downloaded feed
+        run: |
+          set -euo pipefail
+          echo "=== feed-in/lime_packages/ contents ==="
+          ls -la ./feed-in/lime_packages/
+          echo "=== Packages index head ==="
+          head -n 80 ./feed-in/lime_packages/Packages || echo "(no Packages file)"
+          ipk_count=$(find ./feed-in/lime_packages -maxdepth 1 -name '*.ipk' | wc -l)
+          pkg_idx_count=$(grep -c '^Package:' ./feed-in/lime_packages/Packages 2>/dev/null || echo 0)
+          echo "IPK files: ${ipk_count} | Packages index entries: ${pkg_idx_count}"
+
+      - name: Pull ImageBuilder image
+        run: docker pull ghcr.io/openwrt/imagebuilder:${{ matrix.imagebuilder }}-v${{ matrix.openwrt_release }}
+
+      - name: Build firmware image
+        env:
+          DEVICE_NAME: ${{ matrix.device }}
+          ARCH: ${{ matrix.arch }}
+          FEED_BRANCH: ${{ matrix.feed_branch }}
+          PACKAGES: ${{ matrix.packages }}
+          BUILD_INITRAMFS: ${{ matrix.build_initramfs }}
+          IMAGE_FORMAT: ${{ matrix.image_format }}
+          FIT_ARCH: ${{ matrix.fit_arch }}
+          FIT_KERNEL_LOADADDR: ${{ matrix.fit_kernel_loadaddr }}
+          FIT_DTS: ${{ matrix.fit_dts }}
+          FIT_CONFIG: ${{ matrix.fit_config }}
+          FIT_BOOTARGS: ${{ matrix.fit_bootargs }}
+          DTB_PATCH_NVMEM_MAC: ${{ matrix.dtb_patch_nvmem_mac }}
+          DTB_FORCE_LEGACY_PARTITIONS: ${{ matrix.dtb_force_legacy_partitions }}
+        run: |
+          chmod +x tools/ci/build_image.sh
+          tools/ci/build_image.sh \
+            "${{ matrix.imagebuilder }}" \
+            "${{ matrix.profile }}" \
+            "${{ matrix.openwrt_release }}" \
+            "./feed-in" \
+            "./out"
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.device }}-${{ matrix.openwrt_release }}
+          path: ./out/firmware-${{ matrix.device }}.*
+          retention-days: 7
+
+      - name: Upload image debug files
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-debug-image-${{ matrix.device }}-${{ matrix.openwrt_release }}
+          path: |
+            ./out/
+            ./feed-in/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Physical single-node test on the self-hosted lab. Runs on schedule
+  # (full sweep), on workflow_dispatch -f physical_single=true, and on
+  # pull_request (every place; gated by the physical-lab environment).
+  # A single approval here covers test-mesh too (test-mesh needs:
+  # test-firmware, so it waits for this job to finish).
+  test-firmware:
+    name: test-firmware (${{ matrix.place }} / ${{ matrix.openwrt_release }})
+    needs: [prepare-matrix, build-image]
+    if: |
+      (
+        github.event_name == 'schedule'
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.physical_single == 'true')
+        || github.event_name == 'pull_request'
+      )
+      && fromJson(needs.prepare-matrix.outputs.test_targets_matrix).include[0] != null
+    environment:
+      name: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'physical-lab' || '' }}
+    runs-on: [self-hosted, testbed-fcefyn]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.test_targets_matrix) }}
+    env:
+      PYTHONUNBUFFERED: "1"
+      PYTEST_ADDOPTS: "--color=yes"
+      LG_CONSOLE: internal
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: firmware-${{ matrix.device }}-${{ matrix.openwrt_release }}
+          path: fw
+
+      - uses: actions/checkout@v6
+        with:
+          repository: fcefyn-testbed/libremesh-tests
+          ref: main
+          path: libremesh-tests
+
+      - uses: actions/checkout@v6
+        with:
+          repository: aparcar/openwrt-tests
+          ref: main
+          path: openwrt-tests
+
+      - name: Set OPENWRT_TESTS_DIR for pytest
+        run: echo "OPENWRT_TESTS_DIR=$GITHUB_WORKSPACE/openwrt-tests" >> "$GITHUB_ENV"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Sync libremesh-tests environment
+        run: |
+          echo "$(date -u +'%Y-%m-%dT%H:%M:%SZ') uv sync (libremesh-tests) starting"
+          cd libremesh-tests && uv sync
+          echo "$(date -u +'%Y-%m-%dT%H:%M:%SZ') uv sync finished"
+
+      - name: Stage firmware on TFTP
+        env:
+          DEVICE: ${{ matrix.device }}
+          PLACE: ${{ matrix.place }}
+          OPENWRT_RELEASE: ${{ matrix.openwrt_release }}
+          RUN_ID: ${{ github.run_id }}
+        run: tools/ci/lab_stage_firmware.sh
+
+      - name: Lock labgrid place
+        working-directory: libremesh-tests
+        run: |
+          set -euo pipefail
+          echo "LG_PROXY=labgrid-fcefyn" >> "$GITHUB_ENV"
+          PLACE="labgrid-fcefyn-${{ matrix.place }}"
+          LOCK_OUT=$(uv run labgrid-client -v -p "$PLACE" lock 2>&1) || {
+            echo "$LOCK_OUT"
+            echo "::error::labgrid lock failed for $PLACE"
+            exit 1
+          }
+          echo "$LOCK_OUT"
+          echo "LG_PLACE=$PLACE" >> "$GITHUB_ENV"
+          echo "LG_ENV=targets/${{ matrix.device }}.yaml" >> "$GITHUB_ENV"
+          echo "Locked $PLACE for device=${{ matrix.device }}"
+
+      - name: Run single-node LibreMesh tests
+        working-directory: libremesh-tests
+        env:
+          LG_PROXY: labgrid-fcefyn
+          LG_IMAGE: ${{ env.LG_IMAGE }}
+          LG_IMAGE_INITRD: ${{ env.LG_IMAGE_INITRD }}
+          LG_PLACE: ${{ env.LG_PLACE }}
+          LG_ENV: ${{ env.LG_ENV }}
+          LG_MESH_UBOOT_INTERRUPT_SPAM_SEC: ${{ matrix.uboot_interrupt_spam_sec }}
+        run: |
+          set -euo pipefail
+          LOG_DIR="$GITHUB_WORKSPACE/logs/${{ matrix.place }}-${{ matrix.openwrt_release }}"
+          mkdir -p "$LOG_DIR"
+          uv run pytest tests/test_libremesh.py \
+            --lg-log "$LOG_DIR/" \
+            --junitxml="$LOG_DIR/report.xml" \
+            --lg-colored-steps \
+            --log-cli-level=CONSOLE
+
+      - name: Collect lime-report from DUT
+        id: lime-report
+        if: always() && env.LG_PLACE != ''
+        working-directory: libremesh-tests
+        env:
+          LG_PLACE: ${{ env.LG_PLACE }}
+        run: |
+          set +e
+          REPORT=$(uv run labgrid-client -p "$LG_PLACE" ssh -- lime-report -m 2>/dev/null | head -c 50000)
+          if [ -z "$REPORT" ]; then
+            REPORT="_Could not collect lime-report (device unreachable or command not found)._"
+          fi
+          echo "$REPORT" > "$GITHUB_WORKSPACE/lime-report-${{ matrix.place }}.md"
+          echo "collected=true" >> "$GITHUB_OUTPUT"
+
+      - name: Poweroff and unlock device
+        if: always()
+        working-directory: libremesh-tests
+        env:
+          LG_PLACE: ${{ env.LG_PLACE }}
+        run: |
+          set +e
+          if [ -n "${LG_PLACE:-}" ]; then
+            uv run labgrid-client -p "$LG_PLACE" power off || true
+            uv run labgrid-client -p "$LG_PLACE" unlock || true
+          else
+            echo "No labgrid lock acquired by this job; skipping power off / unlock."
+          fi
+          rm -rf "/srv/tftp/firmwares/ci/${{ github.run_id }}/${{ matrix.place }}/${{ matrix.openwrt_release }}" 2>/dev/null || true
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.place }}-${{ matrix.openwrt_release }}
+          path: ${{ github.workspace }}/logs/${{ matrix.place }}-${{ matrix.openwrt_release }}/*
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Open or close issue on test result
+        if: always() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const device = "${{ matrix.device }}";
+            const place = "${{ matrix.place }}";
+            const release = "${{ matrix.openwrt_release }}";
+            const issueTitle = `CI healthcheck: ${place} (${release})`;
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const isSuccess = "${{ job.status }}" === "success";
+
+            let limeReport = "_Not collected._";
+            const reportPath = `${process.env.GITHUB_WORKSPACE}/lime-report-${place}.md`;
+            try { limeReport = fs.readFileSync(reportPath, 'utf8').trim(); } catch {}
+
+            const failureBody = [
+              `### CI healthcheck failed`,
+              ``,
+              `| Field | Value |`,
+              `|-------|-------|`,
+              `| **Place** | \`${place}\` |`,
+              `| **Device** | \`${device}\` |`,
+              `| **OpenWrt release** | \`${release}\` |`,
+              `| **Run** | [#${context.runId}](${runUrl}) |`,
+              `| **Date** | ${new Date().toISOString().slice(0,10)} |`,
+              ``,
+              `### lime-report`,
+              ``,
+              `<details><summary>Click to expand</summary>`,
+              ``,
+              '```',
+              limeReport,
+              '```',
+              `</details>`,
+            ].join('\n');
+
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              labels: 'healthcheck',
+              per_page: 100,
+            });
+
+            let testIssue = issues.data.find(i => i.title === issueTitle);
+
+            if (isSuccess) {
+              if (testIssue && testIssue.state === 'open') {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: testIssue.number,
+                  body: `Healthcheck passed on [run #${context.runId}](${runUrl}). Closing.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: testIssue.number,
+                  state: 'closed',
+                });
+                console.log(`Closed issue #${testIssue.number} (test passed).`);
+              }
+            } else {
+              if (testIssue) {
+                if (testIssue.state === 'closed') {
+                  await github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: testIssue.number,
+                    state: 'open',
+                    body: failureBody,
+                  });
+                  console.log(`Reopened issue #${testIssue.number}.`);
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: testIssue.number,
+                    body: failureBody,
+                  });
+                  console.log(`Commented on open issue #${testIssue.number}.`);
+                }
+              } else {
+                const created = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: issueTitle,
+                  body: failureBody,
+                  labels: ['healthcheck'],
+                });
+                console.log(`Created issue #${created.data.number}.`);
+              }
+            }
+
+  # Physical mesh test (N=2 or N=3 places). Runs on workflow_dispatch
+  # (-f physical_mesh_count=2|3) and on pull_request (forced N=3).
+  # Daily mesh coverage comes from `test-mesh-pairs`.
+  test-mesh:
+    name: test-mesh (N=${{ github.event.inputs.physical_mesh_count || '3 (PR)' }} / ${{ matrix.openwrt_release }})
+    # test-firmware is in `needs` only to serialise lab access (both reserve
+    # the same labgrid places). When test-firmware is skipped via dispatch
+    # inputs we still want this job to run, so `if:` uses `!cancelled()` and
+    # checks needs.test-firmware.result != 'failure' instead of relying on
+    # GitHub's default skip-cascade behaviour.
+    needs: [prepare-matrix, build-image, test-firmware]
+    if: |
+      !cancelled()
+      && needs.prepare-matrix.result == 'success'
+      && needs.build-image.result == 'success'
+      && needs.test-firmware.result != 'failure'
+      && (
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.physical_mesh_count != '0')
+        || github.event_name == 'pull_request'
+      )
+      && fromJson(needs.prepare-matrix.outputs.mesh_test_matrix).include[0] != null
+    runs-on: [self-hosted, testbed-fcefyn]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.mesh_test_matrix) }}
+    env:
+      PYTHONUNBUFFERED: "1"
+      PYTEST_ADDOPTS: "--color=yes"
+      LG_CONSOLE: internal
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/checkout@v6
+        with:
+          repository: fcefyn-testbed/libremesh-tests
+          ref: main
+          path: libremesh-tests
+
+      - uses: actions/checkout@v6
+        with:
+          repository: aparcar/openwrt-tests
+          ref: main
+          path: openwrt-tests
+
+      - name: Set OPENWRT_TESTS_DIR for pytest
+        run: echo "OPENWRT_TESTS_DIR=$GITHUB_WORKSPACE/openwrt-tests" >> "$GITHUB_ENV"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Sync libremesh-tests environment
+        run: cd libremesh-tests && uv sync
+
+      # Static download steps gated by `contains(matrix.devices, ...)`.
+      # N=2 fires only openwrt_one + bananapi_bpi-r4; N=3 also pulls
+      # linksys_e8450 (consumed by belkin_rt3200_2).
+      - name: Download firmware (openwrt_one)
+        if: contains(matrix.devices, 'openwrt_one')
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware-openwrt_one-${{ matrix.openwrt_release }}
+          path: fw-mesh/openwrt_one
+
+      - name: Download firmware (bananapi_bpi-r4)
+        if: contains(matrix.devices, 'bananapi_bpi-r4')
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware-bananapi_bpi-r4-${{ matrix.openwrt_release }}
+          path: fw-mesh/bananapi_bpi-r4
+
+      - name: Download firmware (linksys_e8450)
+        if: contains(matrix.devices, 'linksys_e8450')
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware-linksys_e8450-${{ matrix.openwrt_release }}
+          path: fw-mesh/linksys_e8450
+
+      - name: Stage firmware and run mesh tests
+        env:
+          MODE: full
+          OPENWRT_RELEASE: ${{ matrix.openwrt_release }}
+          RUN_ID: ${{ github.run_id }}
+          MESH_PLACES_JSON: ${{ toJson(matrix.places) }}
+          MESH_DEVICES_JSON: ${{ toJson(matrix.devices) }}
+          SRC_DIR: fw-mesh
+          LOGS_DIR: mesh-logs
+        run: tools/ci/lab_stage_mesh.sh
+
+      - name: Cleanup TFTP on failure
+        if: failure()
+        run: rm -rf "/srv/tftp/firmwares/ci/${{ github.run_id }}/mesh/${{ matrix.openwrt_release }}" || true
+
+      - name: Upload mesh test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-mesh-${{ matrix.openwrt_release }}
+          path: mesh-logs/*
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # Walking-chain mesh smoke. Three sequential 2-node pairs share devices
+  # on purpose; max-parallel:1 serialises lab access. Runs on daily cron
+  # and on workflow_dispatch with physical_mesh_pairs=true.
+  # Place layout is computed in `prepare_matrix.sh::mesh_pairs_matrix`.
+  test-mesh-pairs:
+    name: test-mesh-pairs (#${{ matrix.pair }} ${{ matrix.place_a }}+${{ matrix.place_b }} / ${{ matrix.openwrt_release }})
+    # test-firmware is in `needs` only to serialise lab access (both reserve
+    # the same labgrid places). When test-firmware is skipped via dispatch
+    # inputs we still want this job to run, so `if:` uses `!cancelled()` and
+    # checks needs.test-firmware.result != 'failure' instead of relying on
+    # GitHub's default skip-cascade behaviour.
+    needs: [prepare-matrix, build-image, test-firmware]
+    if: |
+      !cancelled()
+      && needs.prepare-matrix.result == 'success'
+      && needs.build-image.result == 'success'
+      && needs.test-firmware.result != 'failure'
+      && (
+        github.event_name == 'schedule'
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.physical_mesh_pairs == 'true')
+      )
+      && fromJson(needs.prepare-matrix.outputs.mesh_pairs_matrix).include[0] != null
+    runs-on: [self-hosted, testbed-fcefyn]
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.mesh_pairs_matrix) }}
+    env:
+      PYTHONUNBUFFERED: "1"
+      PYTEST_ADDOPTS: "--color=yes"
+      LG_CONSOLE: internal
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/checkout@v6
+        with:
+          repository: fcefyn-testbed/libremesh-tests
+          ref: main
+          path: libremesh-tests
+
+      - uses: actions/checkout@v6
+        with:
+          repository: aparcar/openwrt-tests
+          ref: main
+          path: openwrt-tests
+
+      - name: Set OPENWRT_TESTS_DIR for pytest
+        run: echo "OPENWRT_TESTS_DIR=$GITHUB_WORKSPACE/openwrt-tests" >> "$GITHUB_ENV"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Sync libremesh-tests environment
+        run: cd libremesh-tests && uv sync
+
+      - name: Download firmware (${{ matrix.device_a }})
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware-${{ matrix.device_a }}-${{ matrix.openwrt_release }}
+          path: fw-pair/${{ matrix.device_a }}
+
+      # Skip the second download when both endpoints share the same
+      # device artifact (download-artifact errors on a duplicate path).
+      - name: Download firmware (${{ matrix.device_b }})
+        if: matrix.device_a != matrix.device_b
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware-${{ matrix.device_b }}-${{ matrix.openwrt_release }}
+          path: fw-pair/${{ matrix.device_b }}
+
+      - name: Stage firmware and run mesh tests
+        env:
+          MODE: pair
+          OPENWRT_RELEASE: ${{ matrix.openwrt_release }}
+          RUN_ID: ${{ github.run_id }}
+          PAIR: ${{ matrix.pair }}
+          PLACE_A: ${{ matrix.place_a }}
+          DEVICE_A: ${{ matrix.device_a }}
+          PLACE_B: ${{ matrix.place_b }}
+          DEVICE_B: ${{ matrix.device_b }}
+          SRC_DIR: fw-pair
+          LOGS_DIR: mesh-pairs-logs
+        run: tools/ci/lab_stage_mesh.sh
+
+      - name: Cleanup TFTP on failure
+        if: failure()
+        run: rm -rf "/srv/tftp/firmwares/ci/${{ github.run_id }}/mesh-pairs/${{ matrix.pair }}/${{ matrix.openwrt_release }}" || true
+
+      - name: Upload mesh-pairs test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-mesh-pairs-${{ matrix.pair }}-${{ matrix.openwrt_release }}
+          path: mesh-pairs-logs/*
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # QEMU single-node smoke test on a GitHub-hosted runner. One job per
+  # release, for every target with `test_qemu: true`. Runs in TCG mode
+  # (KVM only available on the multi-node mesh job below).
+  test-firmware-qemu-single:
+    name: test-firmware-qemu-single (${{ matrix.device }} / ${{ matrix.openwrt_release }})
+    needs: [prepare-matrix, build-image]
+    if: |
+      fromJson(needs.prepare-matrix.outputs.qemu_single_matrix).include[0] != null
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.qemu_single_matrix) }}
+    env:
+      PYTHONUNBUFFERED: "1"
+      PYTEST_ADDOPTS: "--color=yes"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/checkout@v6
+        with:
+          repository: fcefyn-testbed/libremesh-tests
+          ref: main
+          path: libremesh-tests
+
+      - uses: actions/checkout@v6
+        with:
+          repository: aparcar/openwrt-tests
+          ref: main
+          path: openwrt-tests
+
+      - name: Set OPENWRT_TESTS_DIR for pytest
+        run: echo "OPENWRT_TESTS_DIR=$GITHUB_WORKSPACE/openwrt-tests" >> "$GITHUB_ENV"
+
+      - name: Download firmware artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: firmware-${{ matrix.device }}-${{ matrix.openwrt_release }}
+          path: fw
+
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends qemu-system-x86 ovmf
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Sync libremesh-tests environment
+        run: |
+          cd libremesh-tests
+          uv sync
+
+      - name: Locate firmware image
+        id: firmware
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          candidates=(fw/firmware-${{ matrix.device }}.img)
+          if [[ ${#candidates[@]} -eq 0 ]]; then
+            echo "::error::No firmware-${{ matrix.device }}.img under fw/" >&2
+            ls -la fw/ || true
+            exit 1
+          fi
+          echo "path=${candidates[0]}" >> "$GITHUB_OUTPUT"
+          file "${candidates[0]}" || true
+          ls -la "${candidates[0]}"
+          sha256sum "${candidates[0]}"
+
+      - name: Run single-node QEMU LibreMesh tests
+        working-directory: libremesh-tests
+        env:
+          # The qemu_x86-64_libremesh.yaml env in libremesh-tests
+          # configures a QEMUDriver + QEMUNetworkStrategyLibreMesh
+          # that boots the supplied disk image, waits for dropbear
+          # (~30s after lime-config completes), and forwards SSH
+          # to the guest's anygw 10.13.0.1:22. This is the
+          # canonical LibreMesh-on-x86_64 test path.
+          LG_ENV: targets/qemu_x86-64_libremesh.yaml
+        run: |
+          set -euo pipefail
+          LOG_DIR="$GITHUB_WORKSPACE/qemu-single-logs/${{ matrix.device }}-${{ matrix.openwrt_release }}"
+          mkdir -p "$LOG_DIR"
+          # Single-node validation: lime-* runtime, base shell, LAN.
+          # Multi-node coverage lives in `test-mesh-qemu` below.
+          uv run pytest \
+            tests/test_libremesh.py \
+            tests/test_base.py \
+            tests/test_lan.py \
+            --lg-env "${LG_ENV}" \
+            --firmware "$GITHUB_WORKSPACE/${{ steps.firmware.outputs.path }}" \
+            --lg-log "$LOG_DIR/" \
+            --junitxml="$LOG_DIR/report.xml" \
+            --log-cli-level=INFO \
+            -v
+
+      - name: Upload QEMU single-node test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-qemu-single-${{ matrix.device }}-${{ matrix.openwrt_release }}
+          path: ${{ github.workspace }}/qemu-single-logs/${{ matrix.device }}-${{ matrix.openwrt_release }}/*
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # QEMU multi-node mesh test. Spawns N=3 QEMU instances of the
+  # x86-combined image tied through vwifi-server (mac80211_hwsim ↔
+  # 802.11s). Requires KVM acceleration (TCG can't fit three VMs in
+  # the runner budget) and a vwifi-server binary on PATH.
+  test-mesh-qemu:
+    name: test-mesh-qemu (${{ matrix.device }} / ${{ matrix.openwrt_release }})
+    needs: [prepare-matrix, build-image, test-firmware-qemu-single]
+    if: |
+      fromJson(needs.prepare-matrix.outputs.qemu_mesh_matrix).include[0] != null
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.qemu_mesh_matrix) }}
+    env:
+      PYTHONUNBUFFERED: "1"
+      PYTEST_ADDOPTS: "--color=yes"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/checkout@v6
+        with:
+          repository: fcefyn-testbed/libremesh-tests
+          ref: main
+          path: libremesh-tests
+
+      - uses: actions/checkout@v6
+        with:
+          repository: aparcar/openwrt-tests
+          ref: main
+          path: openwrt-tests
+
+      - name: Set OPENWRT_TESTS_DIR for pytest
+        run: echo "OPENWRT_TESTS_DIR=$GITHUB_WORKSPACE/openwrt-tests" >> "$GITHUB_ENV"
+
+      - name: Install QEMU and build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 ovmf cmake build-essential libnl-3-dev libnl-genl-3-dev pkg-config
+
+      - name: Enable KVM access for runner user
+        run: tools/ci/enable_kvm.sh
+
+      # vwifi-server pinned at Raizo62/vwifi@4a9842e6 (release v7.0).
+      # The in-guest vwifi-client comes from packages/vwifi/.
+      - name: Cache vwifi-server build
+        id: cache-vwifi-server
+        uses: actions/cache@v4
+        with:
+          path: ~/.vwifi-server-bin
+          key: vwifi-server-4a9842e6-${{ runner.os }}
+
+      - name: Build vwifi-server from source
+        if: steps.cache-vwifi-server.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.vwifi-server-bin
+          tmp=$(mktemp -d)
+          git clone https://github.com/Raizo62/vwifi.git "$tmp/vwifi"
+          git -C "$tmp/vwifi" checkout 4a9842e6
+          cmake -S "$tmp/vwifi" -B "$tmp/build"
+          cmake --build "$tmp/build" -j"$(nproc)"
+          for bin in vwifi-server vwifi-client vwifi-ctrl; do
+            cp "$tmp/build/$bin" ~/.vwifi-server-bin/
+          done
+          rm -rf "$tmp"
+
+      - name: Install vwifi-server
+        run: |
+          sudo install -m 0755 ~/.vwifi-server-bin/vwifi-server /usr/local/bin/
+          vwifi-server --help || vwifi-server -h || true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Sync libremesh-tests environment
+        run: |
+          cd libremesh-tests
+          uv sync
+
+      - name: Download firmware artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: firmware-${{ matrix.device }}-${{ matrix.openwrt_release }}
+          path: fw
+
+      - name: Run multi-node QEMU mesh tests
+        working-directory: libremesh-tests
+        env:
+          # `LG_VIRTUAL_MESH=1` switches the `mesh_nodes` fixture from the
+          # labgrid path to virtual_mesh_launcher.launch_virtual_mesh().
+          LG_VIRTUAL_MESH: "1"
+          VIRTUAL_MESH_NODES: "3"
+          VIRTUAL_MESH_MAX_NODES: "3"
+          VIRTUAL_MESH_IMAGE: ${{ github.workspace }}/fw/firmware-${{ matrix.device }}.img
+        run: |
+          set -euo pipefail
+          LOG_DIR="$GITHUB_WORKSPACE/qemu-mesh-logs/${{ matrix.device }}-${{ matrix.openwrt_release }}"
+          mkdir -p "$LOG_DIR"
+          vwifi-server -u >"$LOG_DIR/vwifi-server.log" 2>&1 &
+          echo $! > "$LOG_DIR/vwifi-server.pid"
+          trap 'kill "$(cat "$LOG_DIR/vwifi-server.pid")" 2>/dev/null || true' EXIT
+          sleep 1
+          uv run pytest tests/test_mesh.py \
+            --lg-log "$LOG_DIR/" \
+            --junitxml="$LOG_DIR/report.xml" \
+            --log-cli-level=INFO \
+            -v
+
+      - name: Upload QEMU mesh test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-qemu-mesh-${{ matrix.device }}-${{ matrix.openwrt_release }}
+          path: ${{ github.workspace }}/qemu-mesh-logs/${{ matrix.device }}-${{ matrix.openwrt_release }}/*
+          if-no-files-found: ignore
+          retention-days: 14
+
+  summary:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - prepare-matrix
+      - build-feed
+      - build-image
+      - test-firmware
+      - test-mesh
+      - test-mesh-pairs
+      - test-firmware-qemu-single
+      - test-mesh-qemu
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build summary
+        env:
+          TRIGGER: ${{ github.event_name }}
+          TARGETS_MATRIX: ${{ needs.prepare-matrix.outputs.targets_matrix }}
+          ARCHS_MATRIX: ${{ needs.prepare-matrix.outputs.archs_matrix }}
+          TEST_TARGETS_MATRIX: ${{ needs.prepare-matrix.outputs.test_targets_matrix }}
+          MESH_TEST_MATRIX: ${{ needs.prepare-matrix.outputs.mesh_test_matrix }}
+          MESH_PAIRS_MATRIX: ${{ needs.prepare-matrix.outputs.mesh_pairs_matrix }}
+          QEMU_SINGLE_MATRIX: ${{ needs.prepare-matrix.outputs.qemu_single_matrix }}
+          QEMU_MESH_MATRIX: ${{ needs.prepare-matrix.outputs.qemu_mesh_matrix }}
+          BUILD_FEED_RESULT: ${{ needs.build-feed.result }}
+          BUILD_IMAGE_RESULT: ${{ needs.build-image.result }}
+          TEST_FIRMWARE_RESULT: ${{ needs.test-firmware.result }}
+          TEST_MESH_RESULT: ${{ needs.test-mesh.result }}
+          TEST_MESH_PAIRS_RESULT: ${{ needs.test-mesh-pairs.result }}
+          TEST_FIRMWARE_QEMU_SINGLE_RESULT: ${{ needs.test-firmware-qemu-single.result }}
+          TEST_MESH_QEMU_RESULT: ${{ needs.test-mesh-qemu.result }}
+        run: tools/ci/build_summary.sh

--- a/README.md
+++ b/README.md
@@ -130,6 +130,86 @@ If you get a `docker: Cannot connect to the Docker daemon at unix:///var/run/doc
 
 If you get a `opkg_download: Check your network settings and connectivity.` error, both check the connectivity and make sure that the firewall rules of your computer allow the container to reach the internet.
 
+##### Firmware CI (build + test)
+
+`.github/workflows/build-firmware.yml` driven by `.github/ci/targets.yml`
+provides an end-to-end CI pipeline for pull requests and scheduled runs.
+
+**How it works for contributors:**
+
+When you open a pull request, the CI:
+
+1. **Compiles your changes**: The SDK builds every package under
+   `packages/` from your PR commit, so modifications to `lime-system`,
+   `lime-proto-*`, etc. are included in the resulting `.ipk`/`.apk` feed.
+2. **Builds firmware images**: ImageBuilder creates per-device images
+   that install the packages you just compiled, not upstream packages.
+3. **Runs tests on your code**: The test jobs (`test-firmware`,
+   `test-mesh`, `test-mesh-qemu`) exercise the firmware built from your
+   PR. Failures indicate issues with your changes.
+
+This means you get real hardware and QEMU validation of your actual code
+before merge, not just syntax checks.
+
+Physical tests run on a self-hosted Labgrid testbed at FCEFyN (UNC,
+Argentina) and require approval via the `physical-lab` environment gate.
+QEMU tests run on GitHub-hosted runners without approval.
+
+###### Updating `lime-docs` source pin
+
+`packages/lime-docs/Makefile` pins `libremesh/libremesh.github.io` with `PKG_SOURCE_VERSION` (full SHA) and `PKG_MIRROR_HASH` (sha256 of the reproducible `.tar.zst` OpenWrt generates). OpenWrt 24.10 rejects `PKG_MIRROR_HASH:=skip`, and `gh-action-sdk` runs `make package/lime-docs/check`, so both values must stay correct.
+
+When bumping to newer documentation:
+
+1. Choose the upstream commit SHA (e.g. `git ls-remote https://github.com/libremesh/libremesh.github.io refs/heads/main`).
+2. Set `PKG_SOURCE_VERSION` to that full SHA.
+3. Set `PKG_VERSION` to `YYYY.MM.DD~shortsha`, where `YYYY.MM.DD` comes from the docs repo (`git -C <docs-clone> show -s --format=%ad --date=short HEAD | sed 's|-|.|g'`) and `shortsha` is the first 7 hex digits of `PKG_SOURCE_VERSION`.
+4. Get `PKG_MIRROR_HASH` from CI (most reliable). Set the new SHA + version in the Makefile, push, and read the value the workflow logs:
+
+   ```text
+   WARNING: PKG_MIRROR_HASH does not match lime-docs-<PKG_VERSION>.tar.zst hash <sha256>
+   Package HASH check failed
+   ```
+
+   Copy that `<sha256>` into `PKG_MIRROR_HASH`. Reason: OpenWrt's `download.pl` picks one of two paths (GitHub tarball API or `git clone` + `git archive`) depending on mirror state, and each path produces a different tarball. The hash CI prints reflects the path actually taken in CI, which is deterministic per commit once chosen.
+
+5. (Optional, faster) reproduce locally inside the SDK image so the first push succeeds:
+
+   ```shell
+   docker run --rm --user root -v "$PWD:/work" \
+     ghcr.io/openwrt/imagebuilder:mediatek-filogic-v24.10.6 \
+     sh -lc 'cd /tmp && /builder/scripts/dl_github_archive.py \
+       --dl-dir=/tmp --url=https://github.com/libremesh/libremesh.github.io/ \
+       --version=<SHA> --subdir=lime-docs-<PKG_VERSION> \
+       --source=lime-docs-<PKG_VERSION>.tar.zst \
+       --hash=0000000000000000000000000000000000000000000000000000000000000000 \
+       --submodules skip 2>&1; sha256sum /tmp/lime-docs-<PKG_VERSION>.tar.zst'
+   ```
+
+   If the GitHub API path succeeds locally and CI exercises the git-clone fallback, the hashes will differ - defer to step 4.
+
+```shell
+mkdir -p ./out-feed ./feed-merged/lime_packages
+# PACKAGES="" -> compile every package in the lime_packages feed (default).
+tools/ci/build_feed.sh aarch64_cortex-a53 ./out-feed
+# Merge arch-specific + all feed output (lime-system is PKGARCH:=all)
+cp -a ./out-feed/bin/packages/aarch64_cortex-a53/lime_packages/. ./feed-merged/lime_packages/ 2>/dev/null || true
+cp -a ./out-feed/bin/packages/all/lime_packages/. ./feed-merged/lime_packages/ 2>/dev/null || true
+docker run --rm \
+  --user root \
+  -e MKHASH=/builder/staging_dir/host/bin/mkhash \
+  -e PATH=/builder/staging_dir/host/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+  -v "$(pwd)/feed-merged/lime_packages:/work" \
+  ghcr.io/openwrt/imagebuilder:mediatek-filogic-v24.10.6 \
+  sh -lc 'cd /work && /builder/scripts/ipkg-make-index.sh . > Packages && gzip -9nc Packages > Packages.gz'
+PACKAGES="lime-system lime-proto-babeld lime-proto-batadv lime-proto-anygw lime-hwd-openwrt-wan lime-hwd-ground-routing lime-app lime-debug lime-docs lime-docs-minimal shared-state-babeld_hosts shared-state-bat_hosts shared-state-dnsmasq_hosts shared-state-nodes_and_links babeld-auto-gw-mode check-date-http batctl-default -dnsmasq -odhcpd-ipv6only" \
+ARCH=aarch64_cortex-a53 FEED_BRANCH=openwrt-24.10 DEVICE_NAME=linksys_e8450 \
+tools/ci/build_image.sh mediatek-mt7622 linksys_e8450 24.10.6 \
+  ./feed-merged ./out
+```
+
+The workflow produces firmware artifacts with stable names: `firmware-<device>.<ext>`.
+
 ##### Package selection
 
 With the `PACKAGES=` argument, you can specify which packages should be preinstalled inside the image. All packages and packages they depend on will be included in the image. This list of packes will produce an image close to the official ones:

--- a/packages/lime-docs/Makefile
+++ b/packages/lime-docs/Makefile
@@ -4,18 +4,20 @@
 
 include $(TOPDIR)/rules.mk
 
-GIT_COMMIT_DATE:=$(shell git log -n 1 --pretty=%ad --date=short . | sed 's|-|.|g' )
-GIT_COMMIT_TSTAMP:=$(shell git log -n 1 --pretty=%at . )
-
+# Pinned upstream docs content. Do not derive PKG_VERSION from *this*
+# repository's git history for packages/lime-docs: every Makefile commit would
+# change PKG_SOURCE_SUBDIR and invalidate PKG_MIRROR_HASH under OpenWrt 24.10
+# reproducible tarball rules (and gh-action-sdk runs `make package/.../check`).
 PKG_NAME:=lime-docs
-PKG_VERSION=$(GIT_COMMIT_DATE)~$(GIT_COMMIT_TSTAMP)
+PKG_SOURCE_VERSION:=3b580071fde1a817837a596fd41ae4bf7797ab1d
+# Commit date of PKG_SOURCE_VERSION on libremesh.github.io + short sha suffix.
+PKG_VERSION:=2026.04.07~3b58007
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/libremesh/libremesh.github.io/
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=HEAD
 PKG_SOURCE_SUBMODULES:=skip
-PKG_MIRROR_HASH:=skip
+PKG_MIRROR_HASH:=6975fe2a33bea711631c5b4e5311186b6b32a0cc3164b1ccc9d89b840361bcb1
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk

--- a/tools/ci/build_feed.sh
+++ b/tools/ci/build_feed.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Local reproducer of the CI feed build (same logic as openwrt/gh-action-sdk@v9).
+# Requires Docker (and QEMU/binfmt if the SDK arch differs from the host).
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <opkg_arch> <artifacts_dir>" >&2
+  echo "  opkg_arch: OpenWrt package arch, e.g. aarch64_cortex-a53 or mips_24kc" >&2
+  echo "  artifacts_dir: empty or writable directory; receives bin/packages/<arch>/<feed>/" >&2
+  echo "Optional env: SDK_ARCH (default: <opkg_arch>-openwrt-24.10), FEEDNAME (default: lime_packages)," >&2
+  echo "  SDK_PACKAGES or PACKAGES (default: empty -> compile whole feed), BUILD, BUILD_LOG, V" >&2
+  exit 1
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+fi
+
+ARCH_OPKG="$1"
+ARTIFACTS_DIR="$(realpath -m "$2")"
+FEEDNAME="${FEEDNAME:-lime_packages}"
+PACKAGES="${SDK_PACKAGES:-${PACKAGES:-}}"
+SDK_ARCH="${SDK_ARCH:-${ARCH_OPKG}-openwrt-24.10}"
+
+mkdir -p "${ARTIFACTS_DIR}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+git clone --depth 1 --branch v9 https://github.com/openwrt/gh-action-sdk "${TMP_DIR}/gh-action-sdk"
+
+docker build \
+  --build-arg "ARCH=${SDK_ARCH}" \
+  -t local/openwrt-gh-action-sdk:v9 \
+  "${TMP_DIR}/gh-action-sdk"
+
+docker run --rm \
+  --env ARCH="${SDK_ARCH}" \
+  --env BUILD="${BUILD:-1}" \
+  --env BUILD_LOG="${BUILD_LOG:-1}" \
+  --env FEEDNAME="${FEEDNAME}" \
+  --env IGNORE_ERRORS="n m y" \
+  --env INDEX="${INDEX:-0}" \
+  --env "NO_REFRESH_CHECK=${NO_REFRESH_CHECK:-}" \
+  --env "NO_SHFMT_CHECK=${NO_SHFMT_CHECK:-}" \
+  --env PACKAGES="${PACKAGES}" \
+  --env "V=${V:-}" \
+  -v "$(pwd):/feed" \
+  -v "${ARTIFACTS_DIR}:/artifacts" \
+  local/openwrt-gh-action-sdk:v9
+
+echo ">>> Feed output: ${ARTIFACTS_DIR}/bin/packages/${ARCH_OPKG}/${FEEDNAME}/"

--- a/tools/ci/build_image.sh
+++ b/tools/ci/build_image.sh
@@ -1,0 +1,843 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+  echo "Usage: $0 <imagebuilder> <profile> <openwrt_release> <feed_dir> <output_dir>" >&2
+  exit 1
+fi
+
+IMAGEBUILDER="$1"
+PROFILE="$2"
+OPENWRT_RELEASE="$3"
+FEED_DIR="$(realpath -m "$4")"
+OUTPUT_DIR="$(realpath -m "$5")"
+
+ARCH="${ARCH:?ARCH env var is required}"
+FEED_BRANCH="${FEED_BRANCH:?FEED_BRANCH env var is required}"
+PACKAGES="${PACKAGES:?PACKAGES env var is required}"
+
+# BUILD_INITRAMFS=1 repacks the ImageBuilder rootfs into a RAM-bootable
+# kernel+CPIO image and ships THAT as the firmware artifact. Otherwise the
+# squashfs-sysupgrade is uploaded for IPK validation only.
+BUILD_INITRAMFS="${BUILD_INITRAMFS:-0}"
+
+# fit          -> kernel + DTB + CPIO under one FIT config (mediatek/filogic).
+# multi-uimage -> legacy IH_TYPE_MULTI uImage (ath79 boards w/o FIT).
+# x86-combined -> ImageBuilder's GRUB+kernel+ext4 disk image (QEMU x86_64).
+# dual-tftp    -> kernel.bin + rootfs.uimage (uImage-wrapped CPIO) as TWO
+#                 separate files (ath79 LibreRouter: U-Boot TFTP-loads each
+#                 to a distinct RAM address; `bootm <kernel> <ramdisk>`).
+IMAGE_FORMAT="${IMAGE_FORMAT:-fit}"
+case "${IMAGE_FORMAT}" in
+  fit|multi-uimage|x86-combined|dual-tftp) ;;
+  *)
+    echo "ERROR: invalid IMAGE_FORMAT=${IMAGE_FORMAT} (expected: fit | multi-uimage | x86-combined | dual-tftp)" >&2
+    exit 1
+    ;;
+esac
+
+FIT_ARCH="${FIT_ARCH:-}"
+FIT_KERNEL_LOADADDR="${FIT_KERNEL_LOADADDR:-}"
+FIT_DTS="${FIT_DTS:-}"
+FIT_CONFIG="${FIT_CONFIG:-config-1}"
+# CRITICAL: FIT_BOOTARGS must NOT contain `root=...`; the upstream
+# mediatek/filogic chosen/bootargs has `root=/dev/fit0 rootwait ubi.block=0,fit`
+# which would mount the on-flash squashfs over our initramfs.
+FIT_BOOTARGS="${FIT_BOOTARGS:-console=ttyS0,115200n1 pci=pcie_bus_perf}"
+
+# Patch the FIT-shipped DTB to inject local-mac-address (workaround for
+# openwrt#22858) on boards whose OEM MAC lives in a UBI factory volume.
+DTB_PATCH_NVMEM_MAC="${DTB_PATCH_NVMEM_MAC:-0}"
+
+# Rewrite SPI-NAND partitioning to the legacy 23.05 layout (separate
+# bl2/fip/factory/ubi MTDs) on Belkin RT3200 layout 1.0 units; without it
+# the kernel UBI MTD overwrites BL31/FIP and bricks the device.
+DTB_FORCE_LEGACY_PARTITIONS="${DTB_FORCE_LEGACY_PARTITIONS:-0}"
+
+if [[ "${BUILD_INITRAMFS}" == "1" && "${IMAGE_FORMAT}" == "x86-combined" ]]; then
+  echo "ERROR: BUILD_INITRAMFS=1 is incompatible with IMAGE_FORMAT=x86-combined" >&2
+  exit 1
+fi
+
+if [[ "${BUILD_INITRAMFS}" == "1" ]]; then
+  # dual-tftp ships kernel.bin + rootfs.cpio as separate TFTP artifacts;
+  # no FIT/uImage repacking, so FIT_* vars are not required.
+  if [[ "${IMAGE_FORMAT}" != "dual-tftp" ]]; then
+    required_vars=(FIT_ARCH FIT_KERNEL_LOADADDR FIT_CONFIG FIT_BOOTARGS)
+    # ath79 (multi-uimage) fuses the DTB into kernel-bin so FIT_DTS is empty.
+    if [[ "${IMAGE_FORMAT}" == "fit" ]]; then
+      required_vars+=(FIT_DTS)
+    fi
+    for var in "${required_vars[@]}"; do
+      if [[ -z "${!var}" ]]; then
+        echo "ERROR: BUILD_INITRAMFS=1 (IMAGE_FORMAT=${IMAGE_FORMAT}) requires ${var} env var" >&2
+        exit 1
+      fi
+    done
+  fi
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DTB_PATCHER_HOST="${SCRIPT_DIR}/patch_dtb_local_mac.py"
+DTB_PARTITIONS_PATCHER_HOST="${SCRIPT_DIR}/patch_dtb_partitions.py"
+if [[ "${DTB_PATCH_NVMEM_MAC}" == "1" && ! -f "${DTB_PATCHER_HOST}" ]]; then
+  echo "ERROR: DTB_PATCH_NVMEM_MAC=1 but ${DTB_PATCHER_HOST} not found" >&2
+  exit 1
+fi
+if [[ "${DTB_FORCE_LEGACY_PARTITIONS}" == "1" && ! -f "${DTB_PARTITIONS_PATCHER_HOST}" ]]; then
+  echo "ERROR: DTB_FORCE_LEGACY_PARTITIONS=1 but ${DTB_PARTITIONS_PATCHER_HOST} not found" >&2
+  exit 1
+fi
+
+if [[ ! -d "${FEED_DIR}/lime_packages" ]]; then
+  echo "ERROR: Feed dir must contain lime_packages/: ${FEED_DIR}/lime_packages" >&2
+  exit 1
+fi
+
+# 24.10.x = .ipk + opkg + Packages[.gz]; 25.12.x = .apk + apk-tools +
+# packages.adb. Branches downstream config and `make image` flags.
+case "${OPENWRT_RELEASE}" in
+  24.10.*) PKG_FORMAT=ipk ;;
+  *)       PKG_FORMAT=apk ;;
+esac
+echo ">>> Package format for ${OPENWRT_RELEASE}: ${PKG_FORMAT}"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+mkdir -p "${WORK_DIR}/out" "${WORK_DIR}/keys" "${OUTPUT_DIR}"
+chmod 0755 "${WORK_DIR}"
+
+# Stage the DTB patchers in WORK_DIR; the in-container repack step
+# only sees /work and /feed.
+if [[ -f "${DTB_PATCHER_HOST}" ]]; then
+  cp "${DTB_PATCHER_HOST}" "${WORK_DIR}/patch_dtb_local_mac.py"
+  chmod 0755 "${WORK_DIR}/patch_dtb_local_mac.py"
+fi
+if [[ -f "${DTB_PARTITIONS_PATCHER_HOST}" ]]; then
+  cp "${DTB_PARTITIONS_PATCHER_HOST}" "${WORK_DIR}/patch_dtb_partitions.py"
+  chmod 0755 "${WORK_DIR}/patch_dtb_partitions.py"
+fi
+
+# Repositories snippet appended to the IB's repos config.
+#   ipk -> repositories.conf (one `src/gz <name> <url>` per line).
+#   apk -> repositories       (one URL per line, file:// required).
+if [[ "${PKG_FORMAT}" == "ipk" ]]; then
+  cat > "${WORK_DIR}/repositories.snippet" <<EOF
+src/gz lime_packages_local file:///feed/lime_packages
+src/gz libremesh https://feed.libremesh.org/master/${FEED_BRANCH}/${ARCH}
+EOF
+else
+  cat > "${WORK_DIR}/repositories.snippet" <<EOF
+file:///feed/lime_packages/packages.adb
+https://feed.libremesh.org/master/${FEED_BRANCH}/${ARCH}/packages.adb
+EOF
+fi
+
+cat > "${WORK_DIR}/keys/a71b3c8285abd28b" <<'EOF'
+untrusted comment: signed by libremesh.org key a71b3c8285abd28b
+RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8
+EOF
+
+IMAGE_TAG="ghcr.io/openwrt/imagebuilder:${IMAGEBUILDER}-v${OPENWRT_RELEASE}"
+echo ">>> Building ${PROFILE} with ${IMAGE_TAG} (BUILD_INITRAMFS=${BUILD_INITRAMFS})"
+
+# Make bind-mounted files readable by the container `buildbot` user (uid 1000).
+chmod -R a+rX "${WORK_DIR}" "${FEED_DIR}"
+chmod a+w "${WORK_DIR}/out"
+
+# Export so docker `-e VAR` (no =value) forwards real values to the in-container script.
+export BUILD_INITRAMFS IMAGE_FORMAT FIT_ARCH FIT_KERNEL_LOADADDR FIT_DTS \
+       FIT_CONFIG FIT_BOOTARGS DTB_PATCH_NVMEM_MAC \
+       DTB_FORCE_LEGACY_PARTITIONS PROFILE PACKAGES \
+       ARCH OPENWRT_RELEASE PKG_FORMAT
+
+# apk needs to (re)generate packages.adb in /feed; ipk's index is static.
+if [[ "${PKG_FORMAT}" == "apk" ]]; then
+  FEED_MOUNT_FLAGS=":rw"
+else
+  FEED_MOUNT_FLAGS=":ro"
+fi
+
+docker run --rm \
+  --user root \
+  -e BUILD_INITRAMFS \
+  -e IMAGE_FORMAT \
+  -e FIT_ARCH \
+  -e FIT_KERNEL_LOADADDR \
+  -e FIT_DTS \
+  -e FIT_CONFIG \
+  -e FIT_BOOTARGS \
+  -e DTB_PATCH_NVMEM_MAC \
+  -e DTB_FORCE_LEGACY_PARTITIONS \
+  -e PROFILE \
+  -e PACKAGES \
+  -e ARCH \
+  -e OPENWRT_RELEASE \
+  -e PKG_FORMAT \
+  -v "${WORK_DIR}:/work" \
+  -v "${FEED_DIR}:/feed${FEED_MOUNT_FLAGS}" \
+  "${IMAGE_TAG}" \
+  sh -lc '
+    set -e
+    cp /work/keys/* keys/ 2>/dev/null || true
+
+    if [ "${PKG_FORMAT}" = "ipk" ]; then
+      # opkg-lede treats `option check_signature` (any value) as enabled.
+      sed -i "/^option check_signature/d" repositories.conf
+      cat /work/repositories.snippet >> repositories.conf
+
+      echo "=== final repositories.conf ==="
+      cat repositories.conf
+      echo "=== mounted feed contents (/feed/lime_packages) ==="
+      ls -la /feed/lime_packages/ | head -40
+      feed_ipks=$(find /feed/lime_packages -maxdepth 1 -name "*.ipk" | wc -l)
+      feed_pkgs=$(grep -c "^Package:" /feed/lime_packages/Packages 2>/dev/null || echo 0)
+      echo "Feed has ${feed_ipks} IPKs and ${feed_pkgs} Packages entries"
+
+      mkdir -p /tmp/preflight/tmp /tmp/preflight-lists
+      /builder/staging_dir/host/bin/opkg \
+        --offline-root /tmp/preflight \
+        --add-arch all:100 \
+        --add-arch "${ARCH}:200" \
+        -f /builder/repositories.conf \
+        --cache /tmp/preflight-cache \
+        --lists-dir /tmp/preflight-lists \
+        update >/tmp/preflight.log 2>&1 || true
+      echo "=== opkg pre-flight update (last 25 lines) ==="
+      tail -n 25 /tmp/preflight.log
+      if ! /builder/staging_dir/host/bin/opkg \
+          --offline-root /tmp/preflight \
+          --add-arch all:100 \
+          --add-arch "${ARCH}:200" \
+          -f /builder/repositories.conf \
+          --cache /tmp/preflight-cache \
+          --lists-dir /tmp/preflight-lists \
+          list 2>/dev/null | grep -q "^lime-system "; then
+        echo "ERROR: opkg cannot see lime-system in any configured feed" >&2
+        /builder/staging_dir/host/bin/opkg \
+          --offline-root /tmp/preflight \
+          --add-arch all:100 \
+          --add-arch "${ARCH}:200" \
+          -f /builder/repositories.conf \
+          --cache /tmp/preflight-cache \
+          --lists-dir /tmp/preflight-lists \
+          list 2>/dev/null | grep -E "^(lime|shared-state|babeld-auto|check-date|batctl)" >&2 || true
+        exit 1
+      fi
+      echo "=== Pre-flight OK: local feed is visible to opkg ==="
+
+      make image PROFILE="${PROFILE}" BIN_DIR=/work/out PACKAGES="${PACKAGES}"
+
+    else
+      cat /work/repositories.snippet >> repositories
+
+      # The IB Makefile drops `--allow-untrusted` from apk invocations
+      # when CONFIG_SIGNATURE_CHECK=y; our local feed is unsigned.
+      if grep -q "^CONFIG_SIGNATURE_CHECK=y" .config; then
+        echo ">>> Disabling CONFIG_SIGNATURE_CHECK in IB .config (local apk feed is unsigned)"
+        sed -i "s/^CONFIG_SIGNATURE_CHECK=y/# CONFIG_SIGNATURE_CHECK is not set/" .config
+      fi
+
+      echo "=== final repositories ==="
+      cat repositories
+      echo "=== mounted feed contents (/feed/lime_packages) ==="
+      ls -la /feed/lime_packages/ | head -40
+      feed_apks=$(find /feed/lime_packages -maxdepth 1 -name "*.apk" | wc -l)
+      echo "Feed has ${feed_apks} APKs"
+
+      APK=""
+      for cand in \
+        /builder/staging_dir/host/usr/bin/apk \
+        /builder/staging_dir/host/bin/apk \
+        /builder/staging_dir/hostpkg/usr/bin/apk \
+        /usr/bin/apk \
+        $(command -v apk 2>/dev/null || true)
+      do
+        if [ -n "$cand" ] && [ -x "$cand" ]; then
+          APK="$cand"; break
+        fi
+      done
+      if [ -z "$APK" ]; then
+        echo "ERROR: cannot locate apk binary in the IB" >&2
+        find /builder/staging_dir/host -maxdepth 4 -name apk 2>/dev/null >&2 || true
+        exit 1
+      fi
+      echo "Using apk binary: $APK"
+
+      # apk 3.x: `--allow-untrusted` is a global flag (before sub-command).
+      if [ ! -f /feed/lime_packages/packages.adb ]; then
+        echo ">>> packages.adb missing - generating with the IB-host apk"
+        cd /feed/lime_packages
+        help_text=$("$APK" --help 2>&1 || true)
+        if printf "%s\n" "$help_text" | grep -qw mkndx; then
+          "$APK" --allow-untrusted mkndx --output packages.adb -- *.apk
+        elif printf "%s\n" "$help_text" | grep -qw index; then
+          "$APK" --allow-untrusted index --output packages.adb *.apk
+        else
+          "$APK" --allow-untrusted mkndx --output packages.adb -- *.apk
+        fi
+        cd /builder
+      fi
+
+      # apk pre-flight: list lime-system against an empty offline root.
+      mkdir -p /tmp/preflight
+      "$APK" \
+        --root /tmp/preflight \
+        --no-cache \
+        --allow-untrusted \
+        --repositories-file /builder/repositories \
+        --repository /feed/lime_packages/packages.adb \
+        update >/tmp/preflight.log 2>&1 || true
+      echo "=== apk pre-flight update (last 25 lines) ==="
+      tail -n 25 /tmp/preflight.log || true
+      if ! "$APK" \
+          --root /tmp/preflight \
+          --no-cache \
+          --allow-untrusted \
+          --repositories-file /builder/repositories \
+          --repository /feed/lime_packages/packages.adb \
+          list lime-system 2>/dev/null | grep -q "^lime-system-"; then
+        echo "WARNING: apk pre-flight could not list lime-system" >&2
+        echo "(non-fatal: apk-tools list semantics are looser than opkg; we proceed and let make image surface any real error)" >&2
+      else
+        echo "=== Pre-flight OK: local feed is visible to apk ==="
+      fi
+
+      make image \
+        PROFILE="${PROFILE}" \
+        BIN_DIR=/work/out \
+        PACKAGES="${PACKAGES}" \
+        APK_FLAGS="--allow-untrusted --repository file:///feed/lime_packages/packages.adb"
+    fi
+
+    echo "=== /work/out contents (post make image) ==="
+    ls -la /work/out/
+    find /work/out -type f -printf "%p (%s bytes)\n"
+
+    # IB does not regenerate the staging initramfs FIT under
+    # CONFIG_TARGET_ROOTFS_INITRAMFS=y; it carries vanilla OpenWrt
+    # without our packages. Assemble it from kernel-bin + DTB + CPIO.
+    if [ "${BUILD_INITRAMFS:-0}" = "1" ]; then
+      echo "=== Repacking initramfs FIT (RAM-bootable, embedded LibreMesh) ==="
+
+      ARCH_DIR="$(echo /builder/build_dir/target-*_musl)"
+      if [ ! -d "${ARCH_DIR}" ]; then
+        echo "ERROR: cannot locate target-<arch>_musl under /builder/build_dir" >&2
+        ls -la /builder/build_dir >&2 || true
+        exit 1
+      fi
+      LINUX_DIR="$(ls -d ${ARCH_DIR}/linux-*/ 2>/dev/null | head -n 1 | sed "s|/$||")"
+      # Skip root.orig-<board> (IB pristine snapshot, no packages).
+      ROOT_DIR="$(ls -d ${ARCH_DIR}/root-*/ 2>/dev/null \
+                  | grep -v "/root\.orig-" \
+                  | head -n 1 | sed "s|/$||")"
+      if [ ! -d "${LINUX_DIR}" ] || [ ! -d "${ROOT_DIR}" ]; then
+        echo "ERROR: cannot locate linux-* / root-* under ${ARCH_DIR}" >&2
+        ls -la "${ARCH_DIR}" >&2 || true
+        exit 1
+      fi
+      echo "  linux build dir: ${LINUX_DIR}"
+      echo "  rootfs dir     : ${ROOT_DIR}"
+
+      # Catch the "vanilla OpenWrt CPIO" failure mode at build time.
+      ROOTFS_FILES="$(find "${ROOT_DIR}" -mindepth 1 2>/dev/null | wc -l)"
+      ROOTFS_BYTES="$(du -sb "${ROOT_DIR}" 2>/dev/null | cut -f1)"
+      ROOTFS_HUMAN="$(du -sh "${ROOT_DIR}" 2>/dev/null | cut -f1)"
+      echo "  rootfs entries : ${ROOTFS_FILES}"
+      echo "  rootfs size    : ${ROOTFS_HUMAN} (${ROOTFS_BYTES} bytes)"
+      echo "  /lib/modules/* :"
+      ls -la "${ROOT_DIR}/lib/modules" 2>/dev/null | head -10 || \
+        echo "    (no /lib/modules - kmod packages were not installed!)"
+      echo "  kmod .ko count :"
+      ko_count=$(find "${ROOT_DIR}/lib/modules" -name "*.ko" 2>/dev/null | wc -l)
+      echo "    ${ko_count} .ko files"
+      echo "  /etc/banner    :"
+      head -3 "${ROOT_DIR}/etc/banner" 2>/dev/null || echo "    (no banner)"
+      echo "  /etc/uci-defaults entries:"
+      ls "${ROOT_DIR}/etc/uci-defaults" 2>/dev/null | head -20 || \
+        echo "    (no uci-defaults dir)"
+      echo "  lime-system traces:"
+      find "${ROOT_DIR}" -maxdepth 5 -path "*/lime/*" 2>/dev/null | head -10 || true
+      # Bounds catch an obviously broken rootfs (LibreMesh baseline ~1100/120).
+      if [ "${ROOTFS_FILES:-0}" -lt 800 ] || [ "${ko_count}" -lt 30 ]; then
+        echo "ERROR: rootfs at ${ROOT_DIR} is implausibly small (${ROOTFS_FILES} entries, ${ko_count} .ko)" >&2
+        exit 1
+      fi
+
+      KERNEL_BIN="${LINUX_DIR}/${PROFILE}-kernel.bin"
+      if [ ! -f "${KERNEL_BIN}" ]; then
+        echo "ERROR: missing ${KERNEL_BIN}" >&2
+        ls -la "${LINUX_DIR}" >&2 | head -40
+        exit 1
+      fi
+      echo "  kernel-bin     : ${KERNEL_BIN} ($(stat -c%s "${KERNEL_BIN}") bytes)"
+      # mediatek/filogic: gzipped vmlinux (1f8b0800).
+      # ath79: legacy uImage wrapping lzma kernel+DTB (27051956).
+      kernel_magic=$(od -An -tx1 -N4 "${KERNEL_BIN}" | tr -d " ")
+      case "${IMAGE_FORMAT}" in
+        fit)
+          if [ "${kernel_magic}" != "1f8b0800" ]; then
+            echo "ERROR: ${KERNEL_BIN} is not a gzip stream (magic=${kernel_magic})" >&2
+            exit 1
+          fi
+          ;;
+        multi-uimage|dual-tftp)
+          if [ "${kernel_magic}" != "27051956" ]; then
+            echo "ERROR: ${KERNEL_BIN} is not a uImage (magic=${kernel_magic})" >&2
+            exit 1
+          fi
+          ;;
+      esac
+
+      # ath79 fuses DTB into kernel-bin; DTB + dtc lookup is FIT-only.
+      DTB_FILE=""
+      DTC_BIN=""
+      DTC_DIR=""
+      if [ "${IMAGE_FORMAT}" = "fit" ]; then
+        DTB_FILE="${LINUX_DIR}/image-${FIT_DTS}.dtb"
+        if [ ! -f "${DTB_FILE}" ]; then
+          echo "ERROR: missing ${DTB_FILE}" >&2
+          ls "${LINUX_DIR}" 2>/dev/null | grep -E "\.dtb$" >&2 | head -40
+          exit 1
+        fi
+        DTC_BIN="$(find ${LINUX_DIR} -name dtc -type f -executable 2>/dev/null | head -n 1)"
+        if [ -z "${DTC_BIN}" ] || [ ! -x "${DTC_BIN}" ]; then
+          echo "ERROR: cannot find dtc under ${LINUX_DIR}" >&2
+          find "${LINUX_DIR}" -name dtc -type f 2>/dev/null >&2 || true
+          exit 1
+        fi
+        DTC_DIR="$(dirname "${DTC_BIN}")"
+        echo "  using dtc      : ${DTC_BIN}"
+      else
+        echo "  IMAGE_FORMAT   : ${IMAGE_FORMAT} (no separate DTB; ath79 appends DTB to kernel-bin)"
+      fi
+
+      REPACK_DIR="/tmp/initramfs-repack"
+      rm -rf "${REPACK_DIR}"
+      mkdir -p "${REPACK_DIR}"
+
+      # Optional FIT-only DTB transforms (each gated, share dtc round-trip):
+      #   DTB_PATCH_NVMEM_MAC=1        -> inject local-mac-address into
+      #                                   GMAC/WAN nodes (openwrt#22858).
+      #   DTB_FORCE_LEGACY_PARTITIONS=1 -> rewrite SPI-NAND partitions to
+      #                                    23.05 layout for Belkin RT3200
+      #                                    layout 1.0 units.
+      # NOTE: this block runs under `sh -lc`, so no apostrophes in comments.
+      DTB_NEEDS_PATCH=0
+      if [ "${DTB_PATCH_NVMEM_MAC:-0}" = "1" ]; then DTB_NEEDS_PATCH=1; fi
+      if [ "${DTB_FORCE_LEGACY_PARTITIONS:-0}" = "1" ]; then DTB_NEEDS_PATCH=1; fi
+
+      if [ "${IMAGE_FORMAT}" = "fit" ] && [ "${DTB_NEEDS_PATCH}" = "1" ]; then
+        if ! command -v python3 >/dev/null 2>&1; then
+          echo "ERROR: DTB patching requires python3 inside the ImageBuilder container" >&2
+          exit 1
+        fi
+        DTB_DTS_ORIG="${REPACK_DIR}/$(basename "${DTB_FILE}").orig.dts"
+        DTB_DTS_STAGE1="${REPACK_DIR}/$(basename "${DTB_FILE}").stage1.dts"
+        DTB_DTS_STAGE2="${REPACK_DIR}/$(basename "${DTB_FILE}").stage2.dts"
+        DTB_PATCHED="${REPACK_DIR}/$(basename "${DTB_FILE}")"
+        "${DTC_BIN}" -I dtb -O dts -q -o "${DTB_DTS_ORIG}" "${DTB_FILE}"
+        # Stage 1: local-mac-address injection. --require-patch makes the
+        # build fail if the GMAC/WAN nodes the patcher targets are gone
+        # (e.g. an upstream kernel rename) instead of shipping a no-op patch.
+        if [ "${DTB_PATCH_NVMEM_MAC:-0}" = "1" ]; then
+          if [ ! -f /work/patch_dtb_local_mac.py ]; then
+            echo "ERROR: DTB_PATCH_NVMEM_MAC=1 but /work/patch_dtb_local_mac.py is missing" >&2
+            ls -la /work >&2 || true
+            exit 1
+          fi
+          echo "=== Patching DTB stage 1: local-mac-address (workaround openwrt#22858) ==="
+          python3 /work/patch_dtb_local_mac.py "${PROFILE}" \
+            --in "${DTB_DTS_ORIG}" --out "${DTB_DTS_STAGE1}" --require-patch
+        else
+          cp "${DTB_DTS_ORIG}" "${DTB_DTS_STAGE1}"
+        fi
+        if [ "${DTB_FORCE_LEGACY_PARTITIONS:-0}" = "1" ]; then
+          if [ ! -f /work/patch_dtb_partitions.py ]; then
+            echo "ERROR: DTB_FORCE_LEGACY_PARTITIONS=1 but /work/patch_dtb_partitions.py is missing" >&2
+            ls -la /work >&2 || true
+            exit 1
+          fi
+          echo "=== Patching DTB stage 2: legacy 23.05 SPI-NAND partitioning ==="
+          python3 /work/patch_dtb_partitions.py \
+            --in "${DTB_DTS_STAGE1}" --out "${DTB_DTS_STAGE2}"
+        else
+          cp "${DTB_DTS_STAGE1}" "${DTB_DTS_STAGE2}"
+        fi
+        "${DTC_BIN}" -I dts -O dtb -q -o "${DTB_PATCHED}" "${DTB_DTS_STAGE2}"
+        echo "  patched DTB    : ${DTB_PATCHED} ($(stat -c%s "${DTB_PATCHED}") bytes; original $(stat -c%s "${DTB_FILE}") bytes)"
+        # Stage 1 only adds properties; stage 2 may legitimately shrink.
+        orig_sz=$(stat -c%s "${DTB_FILE}")
+        new_sz=$(stat -c%s "${DTB_PATCHED}")
+        if [ "${DTB_FORCE_LEGACY_PARTITIONS:-0}" != "1" ] && [ "${new_sz}" -lt "${orig_sz}" ]; then
+          echo "ERROR: patched DTB shrunk from ${orig_sz} to ${new_sz} bytes - refusing to ship" >&2
+          exit 1
+        fi
+        if [ "${new_sz}" -lt 1024 ]; then
+          echo "ERROR: patched DTB is implausibly small (${new_sz} bytes) - dtc likely dropped data" >&2
+          exit 1
+        fi
+        DTB_FILE="${DTB_PATCHED}"
+      elif [ "${IMAGE_FORMAT}" != "fit" ] && [ "${DTB_NEEDS_PATCH}" = "1" ]; then
+        echo "ERROR: DTB patching is incompatible with IMAGE_FORMAT=${IMAGE_FORMAT}" >&2
+        echo "       DTB_PATCH_NVMEM_MAC=${DTB_PATCH_NVMEM_MAC:-0} DTB_FORCE_LEGACY_PARTITIONS=${DTB_FORCE_LEGACY_PARTITIONS:-0}" >&2
+        exit 1
+      else
+        echo "=== Skipping DTB patch (DTB_PATCH_NVMEM_MAC=${DTB_PATCH_NVMEM_MAC:-0} DTB_FORCE_LEGACY_PARTITIONS=${DTB_FORCE_LEGACY_PARTITIONS:-0}) ==="
+      fi
+
+      # Initramfs CPIO must be uncompressed: IB reuses the sysupgrade
+      # kernel without RD_GZIP/LZ4/XZ. A gzipped CPIO falls back to the
+      # on-flash root silently. Raw newc magic 070701 is consumed directly.
+      BUILD_MARKER="ci-${OPENWRT_RELEASE:-unknown}-${PROFILE}-$(date -u +%Y%m%dT%H%M%SZ)"
+      mkdir -p "${ROOT_DIR}/etc"
+      printf "%s\n" "${BUILD_MARKER}" > "${ROOT_DIR}/etc/lime-build-marker"
+      echo "  build marker   : ${BUILD_MARKER}"
+
+      # Kernel mountpoints: preinit needs /proc, /sys, /dev, /tmp to exist
+      # as directories so mount -t proc/sysfs/tmpfs succeeds. base-files
+      # creates them, but verify anyway.
+      for mp in proc sys dev tmp; do
+        if [ ! -d "${ROOT_DIR}/${mp}" ]; then
+          echo "  creating missing /${mp} mountpoint"
+          mkdir -p "${ROOT_DIR}/${mp}"
+        fi
+      done
+
+      # /init script: the kernel runs /init as PID 1. For initramfs boots
+      # this MUST export INITRAMFS=1 so that /lib/preinit/80_mount_root
+      # skips do_mount_root (which would pivot_root into the flash overlay
+      # and break /proc). This matches OpenWrt upstream target/linux/generic/
+      # other-files/init. Without it, mount_root finds rootfs_data on flash,
+      # pivot_root fails on rootfs, ramoverlay loses /proc, lime-config
+      # never runs, and the device boots as root@(none).
+      rm -f "${ROOT_DIR}/init"
+      cat > "${ROOT_DIR}/init" <<INITEOF
+#!/bin/sh
+export INITRAMFS=1
+exec /sbin/init
+INITEOF
+      chmod 0755 "${ROOT_DIR}/init"
+      echo "  /init script   :"
+      cat "${ROOT_DIR}/init"
+      if [ ! -x "${ROOT_DIR}/init" ]; then
+        echo "ERROR: ${ROOT_DIR}/init is not executable" >&2
+        exit 1
+      fi
+      if [ ! -e "${ROOT_DIR}/sbin/init" ] && [ ! -L "${ROOT_DIR}/sbin/init" ]; then
+        echo "ERROR: ${ROOT_DIR}/sbin/init does not exist; /init exec will fail" >&2
+        ls -la "${ROOT_DIR}/sbin/" 2>/dev/null | head -20 >&2 || true
+        exit 1
+      fi
+
+      echo "  packing rootfs CPIO from ${ROOT_DIR}"
+      ( cd "${ROOT_DIR}" && \
+        find . | /builder/staging_dir/host/bin/cpio -o -H newc 2>/dev/null ) \
+          > "${REPACK_DIR}/rootfs.cpio"
+      ls -la "${REPACK_DIR}/rootfs.cpio"
+      cpio_bytes=$(stat -c%s "${REPACK_DIR}/rootfs.cpio")
+      echo "  cpio size      : $((cpio_bytes / 1024 / 1024)) MiB (${cpio_bytes} bytes) vs rootfs ${ROOTFS_HUMAN}"
+      cpio_magic=$(head -c 6 "${REPACK_DIR}/rootfs.cpio")
+      if [ "${cpio_magic}" != "070701" ]; then
+        echo "ERROR: rootfs.cpio has unexpected magic \"${cpio_magic}\" (expected 070701 newc)" >&2
+        head -c 16 "${REPACK_DIR}/rootfs.cpio" | od -c | head >&2
+        exit 1
+      fi
+      cpio_min=$((ROOTFS_BYTES * 80 / 100))
+      if [ "${cpio_bytes}" -lt "${cpio_min}" ]; then
+        echo "ERROR: cpio size ${cpio_bytes} is <80% of rootfs ${ROOTFS_BYTES} - likely truncated/compressed" >&2
+        exit 1
+      fi
+      echo "  cpio file types (top 10):"
+      /builder/staging_dir/host/bin/cpio -tv < "${REPACK_DIR}/rootfs.cpio" 2>/dev/null \
+        | awk "{print \$1}" | sort | uniq -c | sort -rn | head -10 || true
+
+      # `cpio -t` (no -v): GNU cpio strips leading ./ in -tv listings.
+      echo "  /init in CPIO  :"
+      init_paths="$(/builder/staging_dir/host/bin/cpio -t < "${REPACK_DIR}/rootfs.cpio" 2>/dev/null \
+                    | grep -E "^(\\./)?init$" || true)"
+      if [ -z "${init_paths}" ]; then
+        echo "ERROR: /init is missing from rootfs.cpio" >&2
+        echo "       Without /init the kernel will fall through to prepare_namespace()" >&2
+        echo "       and panic with \"Unable to mount root fs on unknown-block(0,0)\"." >&2
+        echo "       cpio -t entries ending in init:" >&2
+        /builder/staging_dir/host/bin/cpio -t < "${REPACK_DIR}/rootfs.cpio" 2>/dev/null \
+          | grep -E "(^|/)init$" | head -20 >&2 || true
+        exit 1
+      fi
+      echo "    ${init_paths}"
+
+      if [ "${IMAGE_FORMAT}" = "dual-tftp" ]; then
+        # dual-tftp (ath79 LibreRouter): ship kernel.bin and a ramdisk
+        # uImage wrapping the rootfs CPIO. U-Boot TFTP-loads each to a
+        # distinct RAM address; `bootm <kernel> <ramdisk>` makes U-Boot
+        # pass initrd_start/initrd_end to the kernel natively via the
+        # MIPS boot params (not via kernel command line / DT bootargs).
+        echo "=== dual-tftp: shipping kernel.bin + rootfs ramdisk uImage ==="
+        KERNEL_OUT="/work/out/openwrt-${OPENWRT_RELEASE:-}-${PROFILE}-kernel.bin"
+        RAMDISK_OUT="/work/out/openwrt-${OPENWRT_RELEASE:-}-${PROFILE}-rootfs.uimage"
+        cp "${KERNEL_BIN}" "${KERNEL_OUT}"
+        /builder/staging_dir/host/bin/mkimage \
+          -A mips -O linux -T ramdisk -C none \
+          -a 0 -e 0 \
+          -n "LibreMesh rootfs ${PROFILE}" \
+          -d "${REPACK_DIR}/rootfs.cpio" "${RAMDISK_OUT}"
+        echo "  kernel  : ${KERNEL_OUT} ($(stat -c%s "${KERNEL_OUT}") bytes)"
+        echo "  ramdisk : ${RAMDISK_OUT} ($(stat -c%s "${RAMDISK_OUT}") bytes)"
+        /builder/staging_dir/host/bin/mkimage -l "${RAMDISK_OUT}" || true
+      elif [ "${IMAGE_FORMAT}" = "fit" ]; then
+      PATH="${DTC_DIR}:${PATH}" /builder/scripts/mkits.sh \
+        -A "${FIT_ARCH}" \
+        -C gzip \
+        -a "${FIT_KERNEL_LOADADDR}" \
+        -e "${FIT_KERNEL_LOADADDR}" \
+        -c "${FIT_CONFIG}" \
+        -v "OpenWrt LibreMesh ${PROFILE}" \
+        -k "${KERNEL_BIN}" \
+        -D "${PROFILE}" \
+        -d "${DTB_FILE}" \
+        -i "${REPACK_DIR}/rootfs.cpio" \
+        -o "${REPACK_DIR}/initramfs.its"
+
+      # mkits.sh has no `bootargs` flag inside `configurations`. Without
+      # an explicit override U-Boot falls back to chosen/bootargs which
+      # has `root=/dev/fit0 ...` and ignores our initramfs.
+      echo "=== Injecting bootargs=\"${FIT_BOOTARGS}\" into FIT config ${FIT_CONFIG} ==="
+      sed -i "/^[[:space:]]*${FIT_CONFIG} {[[:space:]]*\$/,/^[[:space:]]*};[[:space:]]*\$/ s|^\\([[:space:]]*\\)};[[:space:]]*\$|\\1        bootargs = \"${FIT_BOOTARGS}\";\\n\\1};|" "${REPACK_DIR}/initramfs.its"
+
+      bootargs_count=$(grep -c "bootargs = \"${FIT_BOOTARGS}\";" "${REPACK_DIR}/initramfs.its" || true)
+      if [ "${bootargs_count}" -ne 1 ]; then
+        echo "ERROR: bootargs injection produced ${bootargs_count} matches in initramfs.its (expected exactly 1)" >&2
+        echo "----- initramfs.its (configurations section) -----" >&2
+        sed -n "/configurations {/,/^};/p" "${REPACK_DIR}/initramfs.its" >&2 || true
+        exit 1
+      fi
+      echo "  bootargs injected: ${bootargs_count} occurrence(s) (expected 1) - OK"
+      echo "----- initramfs.its configurations block -----"
+      sed -n "/configurations {/,/^};/p" "${REPACK_DIR}/initramfs.its"
+
+      PATH="${DTC_DIR}:${PATH}" /builder/staging_dir/host/bin/mkimage \
+        -f "${REPACK_DIR}/initramfs.its" \
+        "${REPACK_DIR}/initramfs-libremesh.itb"
+
+      INITRAMFS_OUT="/work/out/openwrt-${OPENWRT_RELEASE:-}-${PROFILE}-initramfs-libremesh.itb"
+      cp "${REPACK_DIR}/initramfs-libremesh.itb" "${INITRAMFS_OUT}"
+      echo "=== Initramfs FIT generated (FIT_CONFIG=${FIT_CONFIG}) ==="
+      ls -la "${INITRAMFS_OUT}"
+      /builder/staging_dir/host/bin/mkimage -l "${INITRAMFS_OUT}" \
+        | grep -E "Image |Type:|Compression:|Data Size|Architecture|Load Address|Entry Point|Configuration |Kernel:|FDT:|Init Ramdisk:" || true
+      if ! grep -q "default = \"${FIT_CONFIG}\"" "${REPACK_DIR}/initramfs.its"; then
+        echo "ERROR: initramfs.its has no default config = \"${FIT_CONFIG}\"" >&2
+        head -80 "${REPACK_DIR}/initramfs.its" >&2 || true
+        exit 1
+      fi
+      else
+        # multi-uimage (ath79): IH_TYPE_MULTI image with sub0=kernel.lzma,
+        # sub1=rootfs.cpio. DTB is fused into kernel-bin upstream.
+        echo "=== Building multi-uimage (kernel.lzma + rootfs.cpio) for ath79 ==="
+        # mkimage prepends a 64-byte image_header; strip it.
+        KERNEL_LZMA="${REPACK_DIR}/kernel.lzma"
+        dd if="${KERNEL_BIN}" of="${KERNEL_LZMA}" bs=1 skip=64 status=none
+        kernel_lzma_size=$(stat -c%s "${KERNEL_LZMA}")
+        uimage_data_line=$(/builder/staging_dir/host/bin/mkimage -l "${KERNEL_BIN}" 2>/dev/null \
+                           | awk -F"[: ]+" "/Data Size/ {print \$3; exit}")
+        if [ -n "${uimage_data_line}" ] && [ "${kernel_lzma_size}" -ne "${uimage_data_line}" ]; then
+          echo "ERROR: stripped lzma size ${kernel_lzma_size} != uImage data length ${uimage_data_line}" >&2
+          exit 1
+        fi
+        # OpenWrt lzma uses `-lc1 -lp2 -pb2` so the first byte is 0x6d
+        # (not 0x5d). Property bytes are <= 0xe0; we reject competing magics.
+        kernel_lzma_first=$(od -An -tx1 -N1 "${KERNEL_LZMA}" | tr -d " ")
+        kernel_lzma_first_dec=$(od -An -tu1 -N1 "${KERNEL_LZMA}" | tr -d " ")
+        case "${kernel_lzma_first}" in
+          1f|fd|28|42)
+            echo "ERROR: kernel payload after uImage strip starts with 0x${kernel_lzma_first} (gzip/xz/zstd/bzip2 magic, not lzma1)" >&2
+            echo "       OpenWrt ath79 expects an lzma1-compressed kernel (kernel-bin then append-dtb then lzma then uImage lzma)." >&2
+            exit 1
+            ;;
+        esac
+        if [ "${kernel_lzma_first_dec}" -gt 224 ]; then
+          echo "ERROR: kernel payload first byte 0x${kernel_lzma_first} (${kernel_lzma_first_dec}) exceeds lzma1 property byte max (224)" >&2
+          exit 1
+        fi
+        echo "  kernel.lzma    : ${KERNEL_LZMA} (${kernel_lzma_size} bytes, first byte 0x${kernel_lzma_first})"
+
+        UIMAGE_OUT="${REPACK_DIR}/initramfs-libremesh.uimage"
+        /builder/staging_dir/host/bin/mkimage \
+          -A "${FIT_ARCH}" \
+          -O linux \
+          -T multi \
+          -C lzma \
+          -a "${FIT_KERNEL_LOADADDR}" \
+          -e "${FIT_KERNEL_LOADADDR}" \
+          -n "OpenWrt LibreMesh ${PROFILE} initramfs" \
+          -d "${KERNEL_LZMA}:${REPACK_DIR}/rootfs.cpio" \
+          "${UIMAGE_OUT}"
+
+        echo "=== multi-uimage generated ==="
+        ls -la "${UIMAGE_OUT}"
+        /builder/staging_dir/host/bin/mkimage -l "${UIMAGE_OUT}" \
+          | grep -E "Image |Type:|Compression:|Data Size|Architecture|Load Address|Entry Point|Image [0-9]+:" || true
+
+        if ! /builder/staging_dir/host/bin/mkimage -l "${UIMAGE_OUT}" \
+            | grep -qE "(Image Type|Type:).*Multi[- ]File"; then
+          echo "ERROR: ${UIMAGE_OUT} is not a multi-file uImage" >&2
+          /builder/staging_dir/host/bin/mkimage -l "${UIMAGE_OUT}" >&2 || true
+          exit 1
+        fi
+
+        INITRAMFS_OUT="/work/out/openwrt-${OPENWRT_RELEASE:-}-${PROFILE}-initramfs-libremesh.uimage"
+        cp "${UIMAGE_OUT}" "${INITRAMFS_OUT}"
+        echo "=== Initramfs multi-uimage exported ==="
+        ls -la "${INITRAMFS_OUT}"
+      fi
+    else
+      echo "=== Skipping initramfs repack (BUILD_INITRAMFS=0) ==="
+      echo "Target will ship the squashfs-sysupgrade artifact and is filtered out of the test-firmware matrix."
+    fi
+  '
+
+echo "=== Selecting firmware artifact for ${PROFILE} ==="
+ls -la "${WORK_DIR}/out/" || true
+
+# Verify the produced image actually carries LibreMesh by grepping the
+# manifest. `make image` can silently drop PACKAGES on dep conflicts and
+# ship a vanilla OpenWrt artifact otherwise.
+MANIFEST_FILE="$(compgen -G "${WORK_DIR}/out/*${PROFILE}*.manifest" 2>/dev/null | head -n 1 || true)"
+if [[ -z "${MANIFEST_FILE}" || ! -f "${MANIFEST_FILE}" ]]; then
+  echo "::error::ImageBuilder produced no .manifest for ${PROFILE} - cannot verify LibreMesh content" >&2
+  find "${WORK_DIR}/out" -maxdepth 1 -type f -printf '  %p (%s bytes)\n' >&2 || true
+  exit 1
+fi
+echo "=== Manifest: ${MANIFEST_FILE} ==="
+echo "Total packages in manifest: $(wc -l < "${MANIFEST_FILE}")"
+required_pkgs=(lime-system lime-proto-batadv lime-proto-anygw batctl-default)
+missing=()
+for pkg in "${required_pkgs[@]}"; do
+  if ! grep -qE "^${pkg} " "${MANIFEST_FILE}"; then
+    missing+=("${pkg}")
+  fi
+done
+if (( ${#missing[@]} > 0 )); then
+  echo "::error::Image manifest is missing required LibreMesh packages: ${missing[*]}" >&2
+  echo "This means make image silently dropped them despite the opkg pre-flight pass." >&2
+  echo "=== Manifest contents (lime/shared-state/batctl entries) ===" >&2
+  grep -E '^(lime|shared-state|batctl|babeld|firewall)' "${MANIFEST_FILE}" >&2 || true
+  echo "=== First 40 manifest lines ===" >&2
+  head -n 40 "${MANIFEST_FILE}" >&2 || true
+  exit 1
+fi
+echo ">>> Manifest validation OK: lime-system + lime-proto-batadv + lime-proto-anygw + batctl-default present"
+grep -E '^(lime-|shared-state-|batctl|babeld|firewall4)' "${MANIFEST_FILE}" || true
+
+# Pick the artifact to ship to test-firmware.
+#   dual-tftp            -> kernel.bin + rootfs.cpio (two files).
+#   x86-combined         -> gunzip the *-ext4-combined.img.gz disk image.
+#   BUILD_INITRAMFS=1    -> *-initramfs-libremesh.{itb,uimage} (FIT or multi-uimage).
+#   BUILD_INITRAMFS=0    -> *-squashfs-sysupgrade.{itb,bin} (IPK validation only).
+DEVICE_NAME="${DEVICE_NAME:-${PROFILE}}"
+SOURCE_FILE=""
+if [[ "${IMAGE_FORMAT}" == "dual-tftp" ]]; then
+  KERNEL_SRC="$(compgen -G "${WORK_DIR}/out/*${PROFILE}-kernel.bin" 2>/dev/null | head -n 1 || true)"
+  RAMDISK_SRC="$(compgen -G "${WORK_DIR}/out/*${PROFILE}-rootfs.uimage" 2>/dev/null | head -n 1 || true)"
+  if [[ -z "${KERNEL_SRC}" || -z "${RAMDISK_SRC}" ]]; then
+    echo "::error::dual-tftp: expected *-kernel.bin + *-rootfs.uimage under ${WORK_DIR}/out" >&2
+    find "${WORK_DIR}/out" -type f -printf '  %p (%s bytes)\n' >&2 || true
+    exit 1
+  fi
+  cp "${KERNEL_SRC}"  "${OUTPUT_DIR}/firmware-${DEVICE_NAME}.bin"
+  cp "${RAMDISK_SRC}" "${OUTPUT_DIR}/firmware-${DEVICE_NAME}.uimage"
+  MANIFEST_TARGET="${OUTPUT_DIR}/firmware-${DEVICE_NAME}.manifest"
+  cp "${MANIFEST_FILE}" "${MANIFEST_TARGET}"
+  echo ">>> dual-tftp kernel  : ${OUTPUT_DIR}/firmware-${DEVICE_NAME}.bin ($(stat -c%s "${OUTPUT_DIR}/firmware-${DEVICE_NAME}.bin") bytes)"
+  echo ">>> dual-tftp ramdisk : ${OUTPUT_DIR}/firmware-${DEVICE_NAME}.uimage ($(stat -c%s "${OUTPUT_DIR}/firmware-${DEVICE_NAME}.uimage") bytes)"
+  echo ">>> Manifest output   : ${MANIFEST_TARGET} ($(wc -l < "${MANIFEST_TARGET}") packages)"
+  echo ">>> Kernel sha256     : $(sha256sum "${OUTPUT_DIR}/firmware-${DEVICE_NAME}.bin" | cut -d' ' -f1)"
+  echo ">>> Ramdisk sha256    : $(sha256sum "${OUTPUT_DIR}/firmware-${DEVICE_NAME}.uimage" | cut -d' ' -f1)"
+  exit 0
+elif [[ "${IMAGE_FORMAT}" == "x86-combined" ]]; then
+  combined_gz="$(compgen -G "${WORK_DIR}/out/*ext4-combined.img.gz" 2>/dev/null | head -n 1 || true)"
+  if [[ -z "${combined_gz}" ]]; then
+    echo "::error::IMAGE_FORMAT=x86-combined: no *ext4-combined.img.gz under ${WORK_DIR}/out." >&2
+    echo "       Confirm the x86-64/generic ImageBuilder profile produced the combined recipe." >&2
+    find "${WORK_DIR}/out" -type f -printf '  %p (%s bytes)\n' >&2 || true
+    exit 1
+  fi
+  combined_img="${combined_gz%.gz}"
+  if [[ ! -f "${combined_img}" ]]; then
+    # OpenWrt pads the combined image past the gzip stream, so gunzip
+    # exits 2 with a "trailing garbage ignored" warning. The bytes are
+    # correct; treat 0 and 2 as success.
+    set +e
+    gunzip -kc "${combined_gz}" > "${combined_img}" 2>/tmp/gunzip.err
+    gz_rc=$?
+    set -e
+    if [[ $gz_rc -ne 0 && $gz_rc -ne 2 ]]; then
+      echo "::error::gunzip failed on ${combined_gz} (rc=$gz_rc)" >&2
+      cat /tmp/gunzip.err >&2 || true
+      exit 1
+    fi
+    if [[ ! -s "${combined_img}" ]]; then
+      echo "::error::gunzip produced empty output for ${combined_gz}" >&2
+      exit 1
+    fi
+    if [[ -s /tmp/gunzip.err ]]; then
+      echo ">>> gunzip notice (non-fatal): $(cat /tmp/gunzip.err)"
+    fi
+  fi
+  SOURCE_FILE="${combined_img}"
+  echo ">>> Matched x86-combined image: ${combined_gz} -> ${SOURCE_FILE} (gunzip)"
+elif [[ "${BUILD_INITRAMFS}" == "1" ]]; then
+  case "${IMAGE_FORMAT}" in
+    fit)          initramfs_patterns=("*${PROFILE}-initramfs-libremesh.itb" "*${PROFILE}*initramfs-libremesh.itb") ;;
+    multi-uimage) initramfs_patterns=("*${PROFILE}-initramfs-libremesh.uimage" "*${PROFILE}*initramfs-libremesh.uimage") ;;
+    dual-tftp)    echo "BUG: dual-tftp should have exited earlier" >&2; exit 1 ;;
+  esac
+  for pattern in "${initramfs_patterns[@]}"; do
+    match="$(compgen -G "${WORK_DIR}/out/${pattern}" 2>/dev/null | head -n 1 || true)"
+    if [[ -n "${match}" && -f "${match}" ]]; then
+      SOURCE_FILE="${match}"
+      echo ">>> Matched initramfs pattern '${pattern}' -> ${SOURCE_FILE}"
+      break
+    fi
+  done
+  if [[ -z "${SOURCE_FILE}" ]]; then
+    echo "::error::BUILD_INITRAMFS=1 (IMAGE_FORMAT=${IMAGE_FORMAT}) was set but no initramfs artifact found in ${WORK_DIR}/out." >&2
+    echo "The mkimage repack step likely failed silently. /work/out contents:" >&2
+    find "${WORK_DIR}/out" -type f -printf '  %p (%s bytes)\n' >&2 || true
+    exit 1
+  fi
+else
+  for pattern in \
+    "*${PROFILE}*-squashfs-sysupgrade.itb" \
+    "*${PROFILE}*-squashfs-sysupgrade.bin" \
+    "*${PROFILE}*-sysupgrade.bin"; do
+    match="$(compgen -G "${WORK_DIR}/out/${pattern}" 2>/dev/null | head -n 1 || true)"
+    if [[ -n "${match}" && -f "${match}" ]]; then
+      SOURCE_FILE="${match}"
+      echo ">>> Matched sysupgrade pattern '${pattern}' -> ${SOURCE_FILE} (build-image-only target, not TFTP-booted)"
+      break
+    fi
+  done
+  if [[ -z "${SOURCE_FILE}" ]]; then
+    echo "::error::No sysupgrade artifact found for ${PROFILE} despite a successful make image." >&2
+    find "${WORK_DIR}/out" -type f -printf '  %p (%s bytes)\n' >&2 || true
+    exit 1
+  fi
+fi
+
+if [[ "${IMAGE_FORMAT}" == "x86-combined" ]]; then
+  EXTENSION="img"
+else
+  EXTENSION="${SOURCE_FILE##*.}"
+fi
+TARGET_FILE="${OUTPUT_DIR}/firmware-${DEVICE_NAME}.${EXTENSION}"
+cp "${SOURCE_FILE}" "${TARGET_FILE}"
+
+MANIFEST_TARGET="${OUTPUT_DIR}/firmware-${DEVICE_NAME}.manifest"
+cp "${MANIFEST_FILE}" "${MANIFEST_TARGET}"
+
+echo ">>> Firmware output: ${TARGET_FILE} ($(stat -c%s "${TARGET_FILE}") bytes)"
+echo ">>> Manifest output: ${MANIFEST_TARGET} ($(wc -l < "${MANIFEST_TARGET}") packages)"
+echo ">>> Firmware sha256: $(sha256sum "${TARGET_FILE}" | cut -d' ' -f1)"

--- a/tools/ci/build_summary.sh
+++ b/tools/ci/build_summary.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Render the workflow summary to $GITHUB_STEP_SUMMARY and enforce the
+# CI gate: exit non-zero if any critical job failed or was cancelled.
+#
+# All matrices and job results are passed as opaque env vars (instead of
+# `${{ ... }}` interpolation) so the JSON values are not parsed as bash
+# tokens.
+
+set -euo pipefail
+
+OUT="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+{
+  printf '## Firmware build summary\n\n'
+  printf -- '- Trigger: `%s`\n'                              "${TRIGGER:-}"
+  printf -- '- Targets matrix: `%s`\n'                       "${TARGETS_MATRIX:-}"
+  printf -- '- Arch matrix: `%s`\n'                          "${ARCHS_MATRIX:-}"
+  printf -- '- Physical test matrix: `%s`\n'                 "${TEST_TARGETS_MATRIX:-}"
+  printf -- '- Mesh test matrix: `%s`\n'                     "${MESH_TEST_MATRIX:-}"
+  printf -- '- Mesh pairs matrix (daily): `%s`\n'            "${MESH_PAIRS_MATRIX:-}"
+  printf -- '- QEMU single-node matrix: `%s`\n'              "${QEMU_SINGLE_MATRIX:-}"
+  printf -- '- QEMU mesh matrix: `%s`\n'                     "${QEMU_MESH_MATRIX:-}"
+  printf -- '- Feed stage result: `%s`\n'                    "${BUILD_FEED_RESULT:-}"
+  printf -- '- Image stage result: `%s`\n'                   "${BUILD_IMAGE_RESULT:-}"
+  printf -- '- test-firmware result: `%s`\n'                 "${TEST_FIRMWARE_RESULT:-}"
+  printf -- '- test-mesh result: `%s`\n'                     "${TEST_MESH_RESULT:-}"
+  printf -- '- test-mesh-pairs result: `%s`\n'               "${TEST_MESH_PAIRS_RESULT:-}"
+  printf -- '- test-firmware-qemu-single result: `%s`\n'     "${TEST_FIRMWARE_QEMU_SINGLE_RESULT:-}"
+  printf -- '- test-mesh-qemu result: `%s`\n'                "${TEST_MESH_QEMU_RESULT:-}"
+} >> "$OUT"
+
+# --- CI gate ---
+# `skipped` is acceptable (job condition not met for this event type).
+# `failure` or `cancelled` on any stage blocks the merge.
+gate_ok=true
+declare -A job_results=(
+  [build-feed]="${BUILD_FEED_RESULT:-}"
+  [build-image]="${BUILD_IMAGE_RESULT:-}"
+  [test-firmware]="${TEST_FIRMWARE_RESULT:-}"
+  [test-mesh]="${TEST_MESH_RESULT:-}"
+  [test-mesh-pairs]="${TEST_MESH_PAIRS_RESULT:-}"
+  [test-firmware-qemu-single]="${TEST_FIRMWARE_QEMU_SINGLE_RESULT:-}"
+  [test-mesh-qemu]="${TEST_MESH_QEMU_RESULT:-}"
+)
+
+{
+  printf '\n## CI gate\n\n'
+  printf '| Job | Result | Pass |\n'
+  printf '|-----|--------|------|\n'
+} >> "$OUT"
+
+for job in build-feed build-image test-firmware test-mesh test-mesh-pairs \
+           test-firmware-qemu-single test-mesh-qemu; do
+  result="${job_results[$job]}"
+  case "$result" in
+    success|skipped) icon="✅" ;;
+    *)               icon="❌"; gate_ok=false ;;
+  esac
+  printf '| %s | `%s` | %s |\n' "$job" "$result" "$icon" >> "$OUT"
+done
+
+if $gate_ok; then
+  printf '\n**CI gate: PASS** — all jobs succeeded or were legitimately skipped.\n' >> "$OUT"
+else
+  printf '\n**CI gate: FAIL** — one or more jobs failed or were cancelled.\n' >> "$OUT"
+  exit 1
+fi

--- a/tools/ci/enable_kvm.sh
+++ b/tools/ci/enable_kvm.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Make /dev/kvm world-accessible on the GitHub-hosted runner so the QEMU
+# mesh launcher can use KVM acceleration. udev reload + trigger applies the
+# rule to the existing device node, not just to future hot-plugs.
+
+set -euo pipefail
+
+echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+  | sudo tee /etc/udev/rules.d/99-kvm-allow-all.rules >/dev/null
+sudo udevadm control --reload-rules
+sudo udevadm trigger --name-match=kvm
+ls -l /dev/kvm
+test -r /dev/kvm && test -w /dev/kvm

--- a/tools/ci/lab_stage_firmware.sh
+++ b/tools/ci/lab_stage_firmware.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Stage a single-node firmware artifact for a labgrid place.
+#
+# Renames `firmware-<DEVICE>.*` under fw/ to `firmware-<PLACE>.*` so parallel
+# jobs against units sharing the same hardware profile do not race on the
+# labgrid TFTP symlink. Exports `LG_IMAGE` to GITHUB_ENV.
+#
+# Inputs (env vars):
+#   DEVICE           build artifact device name
+#   PLACE            labgrid place name
+#   OPENWRT_RELEASE  release dimension (separates 24.10.x vs 25.12.x)
+#   RUN_ID           github.run_id (used in TFTP path to isolate runs)
+#   GITHUB_ENV       path to GHA env file (set by the runner)
+
+set -euo pipefail
+
+DEVICE="${DEVICE:?DEVICE required}"
+PLACE="${PLACE:?PLACE required}"
+OPENWRT_RELEASE="${OPENWRT_RELEASE:?OPENWRT_RELEASE required}"
+RUN_ID="${RUN_ID:?RUN_ID required}"
+
+echo "$(date -u +'%Y-%m-%dT%H:%M:%SZ') staging firmware for $DEVICE@$OPENWRT_RELEASE on place $PLACE"
+
+BASE="/srv/tftp/firmwares/ci"
+STAGE="$BASE/$RUN_ID/$PLACE/$OPENWRT_RELEASE"
+if ! mkdir -p "$STAGE" 2>/tmp/mkdir.err; then
+  echo "::error::Cannot create $STAGE: $(cat /tmp/mkdir.err)"
+  echo "Fix on the lab host (one-time):"
+  echo "  sudo install -d -o \$RUNNER_USER -g \$RUNNER_USER -m 0775 $BASE"
+  ls -ld /srv/tftp /srv/tftp/firmwares "$BASE" 2>/dev/null || true
+  exit 1
+fi
+
+shopt -s nullglob
+files=(fw/firmware-"$DEVICE".*)
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "::error::No firmware-$DEVICE.* under fw/"
+  ls -la fw/ || true
+  exit 1
+fi
+
+src_prefix="firmware-$DEVICE"
+dst_prefix="firmware-$PLACE"
+for f in "${files[@]}"; do
+  base="$(basename "$f")"
+  if [[ "$base" != "$src_prefix"* ]]; then
+    echo "::warning::Unexpected artifact name $base (does not start with $src_prefix); copying as-is"
+    cp -a "$f" "$STAGE/"
+    continue
+  fi
+  suffix="${base#$src_prefix}"
+  cp -a "$f" "$STAGE/${dst_prefix}${suffix}"
+done
+
+# Dual-TFTP mode: build_image.sh emits firmware-<device>.bin (kernel) and
+# firmware-<device>.uimage (ramdisk-wrapped rootfs CPIO) for devices that
+# need two TFTP loads + `bootm <kernel> <ramdisk>`.
+KERNEL_FILE="$STAGE/firmware-$PLACE.bin"
+RAMDISK_FILE="$STAGE/firmware-$PLACE.uimage"
+
+if [[ -f "$KERNEL_FILE" && -f "$RAMDISK_FILE" ]]; then
+  echo "=== dual-tftp mode: kernel + rootfs ramdisk uImage ==="
+  echo "LG_IMAGE=$KERNEL_FILE" >> "${GITHUB_ENV:-/dev/null}"
+  echo "LG_IMAGE_INITRD=$RAMDISK_FILE" >> "${GITHUB_ENV:-/dev/null}"
+  echo "Staged LG_IMAGE=$KERNEL_FILE"
+  echo "Staged LG_IMAGE_INITRD=$RAMDISK_FILE"
+  echo "=== firmware sanity ==="
+  file "$KERNEL_FILE" || true
+  ls -la "$KERNEL_FILE"
+  sha256sum "$KERNEL_FILE"
+  file "$RAMDISK_FILE" || true
+  ls -la "$RAMDISK_FILE"
+  sha256sum "$RAMDISK_FILE"
+else
+  # Single-image mode (FIT, multi-uimage, x86-combined, sysupgrade).
+  image_candidates=("$STAGE"/firmware-"$PLACE".*)
+  LG_IMAGE=""
+  for f in "${image_candidates[@]}"; do
+    case "$f" in
+      *.manifest|*.sha256|*.txt|*.log) ;;
+      *) LG_IMAGE="$f"; break ;;
+    esac
+  done
+  if [[ -z "$LG_IMAGE" ]]; then
+    echo "::error::No bootable firmware artifact under $STAGE (only sidecars?)"
+    ls -la "$STAGE" || true
+    exit 1
+  fi
+
+  echo "LG_IMAGE=$LG_IMAGE" >> "${GITHUB_ENV:-/dev/null}"
+  echo "Staged LG_IMAGE=$LG_IMAGE"
+  echo "=== firmware sanity ==="
+  file "$LG_IMAGE" || true
+  ls -la "$LG_IMAGE"
+  sha256sum "$LG_IMAGE"
+fi
+
+# Print the LibreMesh subset of the manifest for at-a-glance verification.
+MANIFEST="$STAGE/firmware-$PLACE.manifest"
+if [[ -f "$MANIFEST" ]]; then
+  echo "=== manifest sidecar ($(wc -l < "$MANIFEST") packages): LibreMesh entries ==="
+  grep -E '^(lime-|shared-state-|batctl|babeld|firewall4)' "$MANIFEST" \
+    || echo "(no LibreMesh entries; image is NOT LibreMesh)"
+else
+  echo "::warning::No manifest sidecar at $MANIFEST"
+fi

--- a/tools/ci/lab_stage_mesh.sh
+++ b/tools/ci/lab_stage_mesh.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Stage firmware artifacts for a mesh test (multi-node) and run pytest.
+#
+# Inputs (env vars):
+#   MODE              "full"  -> N-node mesh from MESH_PLACES_JSON / MESH_DEVICES_JSON
+#                     "pair"  -> 2-node walking-chain pair from PLACE_A/DEVICE_A/PLACE_B/DEVICE_B
+#   OPENWRT_RELEASE   release dimension
+#   RUN_ID            github.run_id
+#   PAIR              pair index (only when MODE=pair)
+#   MESH_PLACES_JSON  JSON array of labgrid places (when MODE=full)
+#   MESH_DEVICES_JSON JSON array of artifact device names (when MODE=full)
+#   PLACE_A, DEVICE_A, PLACE_B, DEVICE_B (when MODE=pair)
+#   SRC_DIR           source dir under workspace ("fw-mesh" or "fw-pair")
+#   LOGS_DIR          relative log output dir ("mesh-logs" or "mesh-pairs-logs")
+#   GITHUB_WORKSPACE  set by the runner
+
+set -euo pipefail
+
+MODE="${MODE:-full}"
+OPENWRT_RELEASE="${OPENWRT_RELEASE:?OPENWRT_RELEASE required}"
+RUN_ID="${RUN_ID:?RUN_ID required}"
+SRC_DIR="${SRC_DIR:-fw-mesh}"
+LOGS_DIR="${LOGS_DIR:-mesh-logs}"
+
+case "$MODE" in
+  full)
+    BASE="/srv/tftp/firmwares/ci/$RUN_ID/mesh/$OPENWRT_RELEASE"
+    mapfile -t PLACES < <(echo "${MESH_PLACES_JSON:?}" | jq -r '.[]')
+    mapfile -t DEVICES < <(echo "${MESH_DEVICES_JSON:?}" | jq -r '.[]')
+    if [[ ${#PLACES[@]} -ne ${#DEVICES[@]} ]]; then
+      echo "::error::places/devices length mismatch (${#PLACES[@]} vs ${#DEVICES[@]})" >&2
+      exit 1
+    fi
+    ;;
+  pair)
+    BASE="/srv/tftp/firmwares/ci/$RUN_ID/mesh-pairs/${PAIR:?}/$OPENWRT_RELEASE"
+    PLACES=("${PLACE_A:?}" "${PLACE_B:?}")
+    DEVICES=("${DEVICE_A:?}" "${DEVICE_B:?}")
+    ;;
+  *)
+    echo "::error::Unknown MODE=$MODE" >&2
+    exit 1
+    ;;
+esac
+
+for place in "${PLACES[@]}"; do
+  if ! mkdir -p "$BASE/$place" 2>/tmp/mkdir.err; then
+    echo "::error::Cannot create $BASE/$place: $(cat /tmp/mkdir.err)"
+    echo "Fix on the lab host (one-time):"
+    echo "  sudo install -d -o \$RUNNER_USER -g \$RUNNER_USER -m 0775 /srv/tftp/firmwares/ci"
+    ls -ld /srv/tftp /srv/tftp/firmwares /srv/tftp/firmwares/ci 2>/dev/null || true
+    exit 1
+  fi
+done
+
+pick_image() {
+  local dir="$1" base_prefix="$2" picked=""
+  for f in "$dir"/${base_prefix}.*; do
+    case "$f" in
+      *.manifest|*.sha256|*.txt|*.log) ;;
+      *) picked="$f"; break ;;
+    esac
+  done
+  if [[ -z "$picked" ]]; then
+    echo "::error::No bootable firmware under $dir (only sidecars?)" >&2
+    ls -la "$dir" >&2 || true
+    return 1
+  fi
+  echo "$picked"
+}
+
+mesh_places=()
+mesh_image_map_entries=()
+for i in "${!PLACES[@]}"; do
+  place="${PLACES[$i]}"
+  device="${DEVICES[$i]}"
+  src_dir="$GITHUB_WORKSPACE/$SRC_DIR/$device"
+  if [[ ! -d "$src_dir" ]]; then
+    echo "::error::Missing artifact dir $src_dir for place=$place device=$device" >&2
+    exit 1
+  fi
+  src_prefix="firmware-${device}"
+  dst_prefix="firmware-${place}"
+  for f in "$src_dir"/${src_prefix}.*; do
+    base="$(basename "$f")"
+    suffix="${base#$src_prefix}"
+    cp -a "$f" "$BASE/$place/${dst_prefix}${suffix}"
+  done
+  img=$(pick_image "$BASE/$place" "${dst_prefix}")
+  echo "=== mesh firmware sanity (place=$place / device=$device) ==="
+  file "$img" || true
+  ls -la "$img"
+  sha256sum "$img"
+  manifest="${img%.*}.manifest"
+  if [[ -f "$manifest" ]]; then
+    echo "=== manifest for $(basename "$img"): LibreMesh entries ==="
+    grep -E '^(lime-|shared-state-|batctl|babeld|firewall4)' "$manifest" \
+      || echo "(no LibreMesh entries; image is NOT LibreMesh)"
+  else
+    echo "::warning::No manifest sidecar at $manifest"
+  fi
+  mesh_places+=("labgrid-fcefyn-$place")
+  mesh_image_map_entries+=("labgrid-fcefyn-$place=$img")
+done
+
+IFS=',' LG_MESH_PLACES_VALUE="${mesh_places[*]}"
+IFS=',' LG_IMAGE_MAP_VALUE="${mesh_image_map_entries[*]}"
+unset IFS
+export LG_PROXY=labgrid-fcefyn
+export LG_MESH_PLACES="$LG_MESH_PLACES_VALUE"
+export LG_IMAGE_MAP="$LG_IMAGE_MAP_VALUE"
+mkdir -p "$GITHUB_WORKSPACE/$LOGS_DIR"
+echo "LG_MESH_PLACES=$LG_MESH_PLACES"
+echo "LG_IMAGE_MAP=$LG_IMAGE_MAP"
+cd libremesh-tests
+uv run pytest tests/test_mesh.py \
+  --lg-log "$GITHUB_WORKSPACE/$LOGS_DIR/" \
+  --junitxml="$GITHUB_WORKSPACE/$LOGS_DIR/report.xml" \
+  --log-cli-level=INFO -v
+rm -rf "$BASE"

--- a/tools/ci/patch_dtb_local_mac.py
+++ b/tools/ci/patch_dtb_local_mac.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Inject `local-mac-address` properties into the GMAC and DSA-WAN nodes of a
+flattened DTS so the kernel never queries the (UBI-backed) factory NVMEM for
+the device MAC.
+
+Background
+==========
+On targets whose `factory` partition lives inside a UBI volume - e.g. the
+Belkin RT3200 / Linksys E8450 (`mt7622-linksys-e8450-ubi.dts`) - `gmac0`
+and the WAN switch port reference NVMEM cells provided by the UBI factory
+volume:
+
+    &gmac0 {
+        nvmem-cells = <&macaddr_factory_7fff4>;
+        nvmem-cell-names = "mac-address";
+    };
+
+The kernel calls `of_get_mac_address()` very early during `mtk_eth_soc.probe`,
+which calls into `nvmem_cell_get()` for the `mac-address` cell. UBI itself is
+not yet attached at that point, so `nvmem_cell_get()` returns `-EPROBE_DEFER`.
+Per OpenWrt issue [openwrt/openwrt#22858] (NVMEM core perpetual `-EPROBE_DEFER`
+blocks fallback mechanisms), the deferral is never converted to `-ENODEV`
+even after the underlying flash partition fails to materialise, so the
+ethernet driver stays stuck forever:
+
+    [    X.YYY] platform 1b100000.ethernet: deferred probe pending: (reason unknown)
+
+…and the MT7915E PCIe WiFi card never finishes its DMA-side probe either
+(it shares the same factory volume for its EEPROM cell), leaving LibreMesh
+without LAN, WAN nor WiFi - exactly the failure mode CI run 25004392669 hit
+on `belkin_rt3200_2`.
+
+The kernel resolves MAC addresses via `of_get_mac_address()`, which checks
+DT properties **before** falling back to NVMEM:
+
+    1. mac-address      (DT property)        <- short-circuits NVMEM
+    2. local-mac-address (DT property)        <- short-circuits NVMEM
+    3. nvmem-cells "mac-address"             <- suffers from the bug above
+
+So injecting a deterministic `local-mac-address` into each affected node
+makes the `nvmem-cells` reference moot for MAC purposes and unblocks the
+deferred probe entirely.
+
+What this patches
+=================
+Two node classes are patched in-place:
+
+* `mac@<unit>` whose `compatible = "mediatek,eth-mac"` AND whose existing
+  body declares `nvmem-cell-names = "mac-address"`. Matches `gmac0` (and
+  `gmac1` if present) - the SoC GMAC nodes that otherwise stall
+  `mtk_eth_soc.probe`.
+* `port@<unit>` (DSA switch ports) whose body declares
+  `nvmem-cell-names = "mac-address"`. Matches the WAN port (`port@4` on
+  the MT7531 switch in linksys_e8450-ubi).
+
+Nodes that already carry `local-mac-address` or `mac-address` are skipped,
+so re-running the patch is idempotent.
+
+MAC generation
+==============
+Each patched node receives a deterministic locally-administered unicast MAC
+derived from `<profile>-<role>` via SHA-256. `role` is `gmac<unit>`,
+`wan-port@<unit>`, etc., so two patched nodes never collide.
+
+* The first byte is forced to `0x02` (locally-administered, unicast) per
+  IEEE 802. This guarantees the MAC will never collide with an OEM-assigned
+  address space and makes lab traffic easy to filter (`02:*:*:*:*:*` is
+  obviously synthetic).
+* The remaining five bytes come from `sha256(seed)[2:12]` so different
+  CI rebuilds of the same board profile produce the same MAC - important
+  for the testbed's DHCP / DNS records that pin per-DUT addresses.
+
+The MAC is written into the DTS as a `[xx xx xx xx xx xx]` byte array,
+which is the canonical DTS encoding for `local-mac-address` (matches what
+upstream board DTSes write when they hard-code a MAC).
+
+CLI
+===
+    patch_dtb_local_mac.py <profile> [--in <dts>] [--out <dts>]
+
+If `--in`/`--out` are omitted the script reads stdin / writes stdout, which
+is the form `tools/ci/build_image.sh` uses inside the ImageBuilder container
+(`dtc -I dtb -O dts <dtb> | python3 patch_dtb_local_mac.py <profile> | dtc
+-I dts -O dtb -o <dtb>`). Diagnostics go to stderr so they are visible in
+the CI job log without contaminating the patched DTS on stdout.
+
+Exit codes
+==========
+0 - patch attempted; output written. `--require-patch` upgrades
+    "no node matched" to a hard error (exit 2). Useful in CI to fail the
+    build loudly if a future DTS rename silently drops the patch instead
+    of shipping a still-broken firmware.
+2 - required patch could not be applied (only with `--require-patch`).
+1 - argv / I/O error.
+
+[openwrt/openwrt#22858]: https://github.com/openwrt/openwrt/issues/22858
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+
+
+def gen_mac(seed: str) -> str:
+    """Return a deterministic locally-administered unicast MAC encoded as
+    six space-separated lowercase hex bytes (DTS `[xx xx xx xx xx xx]`)."""
+    digest = hashlib.sha256(seed.encode("utf-8")).digest()
+    octets = bytearray(digest[:6])
+    # IEEE 802: bit 1 of the first octet is U/L (1 = locally administered),
+    # bit 0 is I/G (0 = unicast). Force `0b000000_10` = 0x02 in the low
+    # nibble while preserving the SHA-derived high nibble for entropy.
+    octets[0] = (octets[0] & 0xFC) | 0x02
+    return " ".join(f"{b:02x}" for b in octets)
+
+
+def _find_block_end(text: str, open_brace_idx: int) -> int:
+    """Given the index of an opening `{`, return the index just past the
+    matching `}`. Counts nested braces. Returns -1 if no match."""
+    depth = 1
+    i = open_brace_idx + 1
+    while i < len(text) and depth > 0:
+        c = text[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        return -1
+    return i  # past the closing `}`
+
+
+# Anchor we use both as the "patch me" marker (in classify) and as the
+# insertion point inside the matched block. DTS grammar (and `dtc -I dts`)
+# enforce "properties must precede subnodes" within a node, so anchoring
+# on an existing property guarantees our injected `local-mac-address`
+# also lands in the property zone - even when the node carries
+# subnodes after its property block (e.g. `port@4` on Belkin RT3200's
+# MT7531 DSA switch wraps a `fixed-link {...}` after its
+# `nvmem-cell-names`, which is precisely what made the previous
+# "before closing `};`" placement explode with
+# `dtc: Properties must precede subnodes` (CI run 25011299098).
+#
+# The capturing group (`([ \t]*)`) reuses the anchor's own indentation
+# for the new property, so the patched DTS keeps the source's spacing
+# convention (tabs vs spaces) intact.
+NVMEM_MAC_ANCHOR_RE = re.compile(
+    r'^([ \t]*)nvmem-cell-names\s*=\s*"mac-address"\s*;[ \t]*\n',
+    re.MULTILINE,
+)
+
+
+def _inject_local_mac(text: str, node_re: re.Pattern, classify,
+                      label: str, *, multi: bool = True) -> tuple[str, int]:
+    """Walk every node header matched by `node_re`, scope each body to its
+    matching brace pair, and inject a `local-mac-address` property
+    immediately after the `nvmem-cell-names = "mac-address";` line in the
+    body whenever `classify(block_text, regex_match)` returns a non-empty
+    seed string.
+
+    `classify` is responsible for both filtering (return `None` to skip)
+    and deciding the MAC seed; it is only called for nodes that do **not**
+    already carry a `local-mac-address` or `mac-address` property, so it
+    cannot leak state between siblings even on already-patched DTSes.
+
+    Iteration runs back-to-front so insertions never shift offsets of
+    earlier matches still queued for processing.
+
+    Returns `(patched_text, count)` where `count` is the number of nodes
+    that received the new property. When `multi=False` only the first
+    match is patched (used for tests that need exactly-one semantics)."""
+    out = text
+    count = 0
+    matches = list(node_re.finditer(out))
+    for m in reversed(matches):
+        header_start = m.start()
+        # m.end() points just past the `{` we anchored on (regex includes it).
+        open_brace_idx = m.end() - 1
+        if open_brace_idx < 0 or out[open_brace_idx] != "{":
+            continue
+        end = _find_block_end(out, open_brace_idx)
+        if end < 0:
+            continue
+        block = out[header_start:end]
+        # Skip nodes that already pin a MAC via DT properties - both
+        # `local-mac-address` and `mac-address` short-circuit
+        # `of_get_mac_address()` ahead of any NVMEM lookup, so injecting
+        # again would be redundant and (for `mac-address`) would silently
+        # override an OEM-pinned address. The negative lookbehind
+        # forbids `nvmem-cell-names = "mac-address"` from matching, since
+        # that string carries `mac-address` as the cell *name*, not as
+        # an actual MAC property.
+        if re.search(r"(?<!cell-names = \")\b(?:local-mac-address|mac-address)\s*=", block):
+            print(f"[patch_dtb_local_mac] {label} at offset {header_start}: "
+                  "already has mac-address/local-mac-address, skipping",
+                  file=sys.stderr)
+            continue
+        seed = classify(block, m)
+        if not seed:
+            continue
+        anchor_m = NVMEM_MAC_ANCHOR_RE.search(block)
+        if anchor_m is None:
+            # classify already required the anchor string; if we get here
+            # the DTS shape changed (e.g. anchor split across lines) and
+            # we'd rather fail loudly than ship a half-patched DTB.
+            print(f"[patch_dtb_local_mac] {label} (seed={seed}): "
+                  "anchor `nvmem-cell-names = \"mac-address\";` not found "
+                  "on its own line - refusing to guess insertion point",
+                  file=sys.stderr)
+            continue
+        indent = anchor_m.group(1)
+        # anchor_m.end() points just past the trailing `\n` of the anchor
+        # line, so insertion lands on a fresh line at the same depth.
+        insert_at = header_start + anchor_m.end()
+        mac = gen_mac(seed)
+        prop = f"{indent}local-mac-address = [{mac}];\n"
+        out = out[:insert_at] + prop + out[insert_at:]
+        count += 1
+        print(f"[patch_dtb_local_mac] {label} (seed={seed}): inserted "
+              f"local-mac-address = [{mac}]", file=sys.stderr)
+        if not multi:
+            break
+    return out, count
+
+
+def patch_dts(dts: str, profile: str) -> tuple[str, int]:
+    """Apply both GMAC and DSA-WAN injections to the DTS source.
+
+    Returns `(patched_dts, total_count)`."""
+    total = 0
+
+    # 1) `mac@<unit>` with `compatible = "mediatek,eth-mac"` AND
+    # `nvmem-cell-names = "mac-address"` - the SoC GMAC nodes
+    # `mtk_eth_soc` binds against. The unit address is the GMAC index
+    # (0 or 1), folded into the seed so two GMACs on the same board
+    # never collide.
+    mac_re = re.compile(r"\bmac@([0-9a-f]+)\s*\{", re.IGNORECASE)
+
+    def _classify_eth_mac(block: str, m: re.Match) -> str | None:
+        if 'compatible = "mediatek,eth-mac"' not in block:
+            return None
+        if 'nvmem-cell-names = "mac-address"' not in block:
+            return None
+        return f"{profile}-gmac{m.group(1)}"
+
+    dts, c = _inject_local_mac(dts, mac_re, _classify_eth_mac,
+                               label="mediatek,eth-mac")
+    total += c
+
+    # 2) DSA switch ports (`port@<unit>`) with
+    # `nvmem-cell-names = "mac-address"` - the WAN port on Belkin
+    # RT3200's MT7531 (port@4) is the canonical case; other vendors may
+    # ship MAC NVMEM cells on additional ports.
+    port_re = re.compile(r"\bport@([0-9a-f]+)\s*\{", re.IGNORECASE)
+
+    def _classify_mac_port(block: str, m: re.Match) -> str | None:
+        if 'nvmem-cell-names = "mac-address"' not in block:
+            return None
+        return f"{profile}-port{m.group(1)}"
+
+    dts, c = _inject_local_mac(dts, port_re, _classify_mac_port,
+                               label="dsa-port")
+    total += c
+
+    return dts, total
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(
+        description="Inject local-mac-address into MAC-bearing DTS nodes "
+                    "so the kernel skips the broken UBI-NVMEM lookup.",
+    )
+    p.add_argument("profile", help="OpenWrt profile name; used as MAC seed")
+    p.add_argument("--in", dest="in_path", default=None,
+                   help="DTS input path (default: stdin)")
+    p.add_argument("--out", dest="out_path", default=None,
+                   help="DTS output path (default: stdout)")
+    p.add_argument("--require-patch", action="store_true",
+                   help="Exit 2 if no node was patched")
+    args = p.parse_args(argv)
+
+    try:
+        if args.in_path:
+            with open(args.in_path, "r", encoding="utf-8") as f:
+                src = f.read()
+        else:
+            src = sys.stdin.read()
+    except OSError as exc:
+        print(f"[patch_dtb_local_mac] read failed: {exc}", file=sys.stderr)
+        return 1
+
+    patched, count = patch_dts(src, args.profile)
+    print(f"[patch_dtb_local_mac] total nodes patched: {count}",
+          file=sys.stderr)
+
+    if count == 0 and args.require_patch:
+        print("[patch_dtb_local_mac] --require-patch: no nodes matched, "
+              "this means the DTS no longer contains the GMAC / WAN "
+              "patterns we know how to patch. Update this script.",
+              file=sys.stderr)
+        return 2
+
+    try:
+        if args.out_path:
+            with open(args.out_path, "w", encoding="utf-8") as f:
+                f.write(patched)
+        else:
+            sys.stdout.write(patched)
+    except OSError as exc:
+        print(f"[patch_dtb_local_mac] write failed: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/ci/patch_dtb_partitions.py
+++ b/tools/ci/patch_dtb_partitions.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""Rewrite the linksys_e8450-ubi DTB partitioning to use the legacy 23.05
+layout (separate `bl2`, `fip`, `factory`, `ubi` MTD partitions) instead
+of the OpenWrt 24.10 all-UBI layout (only `bl2` + `ubi`, with `fip` and
+`factory` living as static volumes inside UBI).
+
+Background
+==========
+
+In February 2024 OpenWrt mainline merged "mediatek: mt7622: modernize
+Linksys E8450 / Belkin RT3200 UBI build" (DEVICE_COMPAT_VERSION 1.0 →
+2.0). The new mt7622-linksys-e8450-ubi.dts shipped in 24.10 declares
+exactly two MTD partitions:
+
+    bl2      0x000000  size 0x80000   (read-only)
+    ubi      0x080000  size 0x7f80000 (compatible = "linux,ubi";
+                                       declares fip / factory / ubootenv
+                                       / fit volumes inline)
+
+That layout is correct on a device that has been migrated by
+`owrt-ubi-installer v1.1.3+`, which physically reflashes BL2 + FIP and
+re-creates the UBI from scratch with `fip` and `factory` as static
+volumes.
+
+It is catastrophically wrong on a device that is still on the legacy
+23.05 layout, where:
+
+    bl2      0x000000  size 0x80000   (read-only)
+    fip      0x080000  size 0x140000  (read-only)
+    factory  0x1c0000  size 0x100000  (read-only)
+    ubi      0x300000  size 0x7d00000
+
+When the kernel-side UBI driver attaches the 24.10 `ubi` MTD
+(0x080000-0x8000000), its scan walks every PEB-sized block. The bytes
+that on a layout-1.0 device hold BL31+u-boot (0x080000-0x1c0000) and
+the WiFi/MAC factory data (0x1c0000-0x2c0000) carry no valid UBI EC
+header, so UBI marks those blocks as candidate empty PEBs and over
+time writes its volume table on top of them. The next power cycle then
+KODs because BL2 cannot read BL31 from the now-overwritten `fip`
+region (`ERROR: BL2: Failed to load image id 3 (-2)`).
+
+The lab observed exactly this: every Belkin RT3200 unit passed the
+first CI run after recovery and entered KOD on the next power-cycle,
+and `hexdump /dev/mtd2` (factory) on the device showed `UBI#` magic
+where calibration data should sit.
+
+Why we patch the FIT-shipped DTB instead of migrating the hardware
+=================================================================
+
+The proper fix is `owrt-ubi-installer v1.1.4` (Linksys E8450 / Belkin
+RT3200, OpenWrt 24.10.0): it reflashes BL2, rebuilds the UBI as
+layout 2.0, and migrates the factory volume into UBI. We tried to run
+it on the lab Belkins (see chat transcript 2026-04-27) and it aborts
+with:
+
+    INSTALLER: cannot find Wi-Fi EEPROM data
+    sysrq: Trigger a crash
+
+because earlier 24.10 CI runs already wrote UBI metadata over the
+on-flash `factory` MTD partition: there is no calibration data left to
+back up, so the installer refuses to migrate. Recovering it would
+require a backup taken before the corruption (which we do not have)
+plus serial-console reflashing. Patching the FIT-shipped DTB avoids
+the recovery entirely: we ship a DTB that tells the kernel the device
+is on layout 1.0, the kernel attaches UBI strictly to 0x300000+, and
+the on-flash BL31/FIP that we just put back with `mtk_uartboot` stays
+untouched forever. CI runs are RAM-booted initramfs anyway, so the
+device never sysupgrades and never sees DEVICE_COMPAT_VERSION
+enforcement.
+
+The patch is one-sided: it only matters for the kernel that runs
+during a CI test run. The installed-on-flash bootchain (BL2 + FIP +
+recovery) stays at 23.05.5 (what `mtk_uartboot` and the
+`openwrt-mediatek-mt7622-linksys_e8450-ubi-bl31-uboot.fip` recovery
+images write).
+
+What this patches
+=================
+
+Round-tripping the FIT-shipped DTB through dtc -I dtb -O dts gives us
+a free-standing DTS where:
+
+* the `&snand { partitions { ... } }` block lists exactly two
+  partitions (`bl2`, `ubi`) with the 24.10 offsets, and the `ubi`
+  child node carries `compatible = "linux,ubi"` plus a `volumes {}`
+  subtree declaring `ubi-volume-fit`, `ubi-volume-factory`,
+  `ubi-volume-ubootenv` etc.;
+
+* the `wmac`, `wmac1`, `gmac0`, and `wan` nodes reference the
+  factory cells through their `nvmem-cells` properties, either as
+  symbolic labels (`<&eeprom_factory_0>` etc.) when the DTB carries
+  `__symbols__` (built with `dtc -@`), OR as numeric phandles
+  (`<0x44>` etc.) when it does not. OpenWrt 24.10 builds normal
+  kernel DTBs WITHOUT `-@`, so the references in the FIT-shipped
+  DTB this patcher receives are the numeric form. Empirical
+  evidence from CI run 25059904061: `dtc -I dtb -O dts` on
+  `image-mt7622-linksys-e8450-ubi.dtb` produced a DTS where every
+  `eeprom_factory_*` / `macaddr_factory_*` label was missing
+  while the corresponding `eeprom@<addr>` / `macaddr@<addr>` nodes
+  carried `phandle = <0xNN>;` properties.
+
+We replace the entire `partitions { ... }` block with the layout 1.0
+shape:
+
+    bl2      partition@0
+    fip      partition@80000      (read-only)
+    factory  partition@1c0000     (read-only) - also the parent node
+                                    for the eeprom_factory_* and
+                                    macaddr_factory_* nvmem-cells
+    ubi      partition@300000
+
+The `factory` MTD partition declares the four nvmem-cells with
+their original node names (`eeprom@0`, `eeprom@5000`,
+`macaddr@7fff4`, `macaddr@7fffa`) and copies each cell's
+`phandle = <0xNN>;` value verbatim from the original
+`ubi-volume-factory > nvmem-layout` children. Re-using the same
+phandle integers means the numeric references in
+`wmac`/`wmac1`/`gmac0`/`wan` keep pointing at the right node after
+recompile, no symbol table needed. We also keep the upstream
+labels (`eeprom_factory_0:` etc.) for human readability and so the
+patch is also correct against a DTB that DOES carry symbols (for a
+future OpenWrt rev that flips on `-@` for kernel DTBs).
+
+Idempotency and safety
+======================
+
+* The patcher refuses to run if the partitioning block it expects to
+  rewrite (a `partitions { ... }` block whose body contains
+  `compatible = "linux,ubi"`) is not found exactly once. That guards
+  against future kernel revs that move the UBI declaration somewhere
+  else, or against accidentally running this on an already-patched
+  DTB (which has no `linux,ubi` block left).
+
+* For each of the four expected factory cells the patcher reads the
+  cell's phandle from the original block (if a `phandle` property
+  exists; missing-phandle cells just emit the new node without one,
+  trusting that nothing references them). If the input DTS has
+  zero matches for a given cell name (e.g. `eeprom@0` vanished
+  entirely), the patcher hard-fails - that would mean the upstream
+  DTS shape changed in an incompatible way and the script needs
+  updating.
+
+CLI
+===
+
+    patch_dtb_partitions.py [--in <dts>] [--out <dts>]
+
+stdin/stdout when `--in`/`--out` are omitted; matches the
+`patch_dtb_local_mac.py` convention used elsewhere in
+tools/ci/build_image.sh.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+
+# Layout 1.0 partitioning, transcribed verbatim from
+# https://github.com/openwrt/openwrt/blob/v23.05.5/target/linux/mediatek/dts/mt7622-linksys-e8450-ubi.dts
+# (the dtsi `&snand { partitions { ... } }` block) and merged with the
+# `&factory` nvmem cell declarations from the same file.
+#
+# Why these exact reg ranges:
+#   bl2      0x000000-0x080000 - fixed by mt7622 boot ROM (the BootROM
+#                                pulls BL2 from offset 0).
+#   fip      0x080000-0x1c0000 - BL2 v2.4 looks for the FIP at 0x80000
+#                                and reads up to 1.25 MiB; matches the
+#                                23.05.5 OpenWrt FIP size.
+#   factory  0x1c0000-0x2c0000 - vendor-supplied calibration EEPROM
+#                                + dual MAC; OEM stores it here and the
+#                                23.05 DTS expects it here.
+#   ubi      0x300000-0x8000000 - leaves a 0x40000 gap (256 KiB) before
+#                                ubi for the U-Boot environment, which
+#                                23.05 stores in flash but does NOT
+#                                expose as an MTD partition (legacy
+#                                layout matches OpenWrt mainline).
+#
+# Placeholders `__PHANDLE_<name>_<addr>__` are replaced at rewrite
+# time with the literal phandle property line copied from the
+# original DTS. Each placeholder is at the END of the cell's reg
+# line so a missing phandle (cell had no upstream reference)
+# resolves to an empty string with no spurious whitespace artefact.
+LAYOUT_1_0_BLOCK = """\
+\t\tpartitions {
+\t\t\tcompatible = "fixed-partitions";
+\t\t\t#address-cells = <0x01>;
+\t\t\t#size-cells = <0x01>;
+
+\t\t\tpartition@0 {
+\t\t\t\tlabel = "bl2";
+\t\t\t\treg = <0x00 0x80000>;
+\t\t\t\tread-only;
+\t\t\t};
+
+\t\t\tpartition@80000 {
+\t\t\t\tlabel = "fip";
+\t\t\t\treg = <0x80000 0x140000>;
+\t\t\t\tread-only;
+\t\t\t};
+
+\t\t\tfactory: partition@1c0000 {
+\t\t\t\tlabel = "factory";
+\t\t\t\treg = <0x1c0000 0x100000>;
+\t\t\t\tread-only;
+\t\t\t\tcompatible = "nvmem-cells";
+\t\t\t\t#address-cells = <0x01>;
+\t\t\t\t#size-cells = <0x01>;
+
+\t\t\t\teeprom_factory_0: eeprom@0 {
+\t\t\t\t\treg = <0x00 0x4da8>;__PHANDLE_eeprom_0__
+\t\t\t\t};
+
+\t\t\t\teeprom_factory_5000: eeprom@5000 {
+\t\t\t\t\treg = <0x5000 0xe00>;__PHANDLE_eeprom_5000__
+\t\t\t\t};
+
+\t\t\t\tmacaddr_factory_7fff4: macaddr@7fff4 {
+\t\t\t\t\treg = <0x7fff4 0x06>;__PHANDLE_macaddr_7fff4__
+\t\t\t\t};
+
+\t\t\t\tmacaddr_factory_7fffa: macaddr@7fffa {
+\t\t\t\t\treg = <0x7fffa 0x06>;__PHANDLE_macaddr_7fffa__
+\t\t\t\t};
+\t\t\t};
+
+\t\t\tpartition@300000 {
+\t\t\t\tlabel = "ubi";
+\t\t\t\treg = <0x300000 0x7d00000>;
+\t\t\t};
+\t\t};
+"""
+
+
+# `partitions {` line, top-level (not a member like `volumes {`). The
+# leading indent is captured so the replacement keeps the same column
+# level as the original block, which is required for some readers that
+# rely on dtc's whitespace cues (and keeps CI diffs readable).
+PARTITIONS_HEADER_RE = re.compile(
+    r"^([ \t]*)partitions\s*\{",
+    re.MULTILINE,
+)
+
+
+# Marker we use to identify "this `partitions {` block is the one
+# attached to the SPI-NAND". We can't anchor on the parent node name
+# because dtc decompiles `&snand` to a path-based node ID we cannot
+# predict (depends on SoC dtsi); but the all-UBI partitioning is the
+# only place in any mediatek/mt7622 DTS where a partition declares
+# `compatible = "linux,ubi"`, so that string is a reliable selector.
+LINUX_UBI_MARKER = 'compatible = "linux,ubi"'
+
+
+# Cells we must find inside the original `ubi-volume-factory >
+# nvmem-layout` block, identified by their (node_name, addr_hex)
+# tuple - these are deterministic across OpenWrt revs because they
+# come straight from the upstream DTS source. We extract each cell's
+# numeric phandle (if any) so the new MTD-backed partition can
+# replicate it; numeric references downstream (`<0xNN>`) then
+# resolve to the new node without depending on a `__symbols__`
+# section that 24.10 does not emit.
+FACTORY_CELLS: tuple[tuple[str, str], ...] = (
+    ("eeprom",  "0"),
+    ("eeprom",  "5000"),
+    ("macaddr", "7fff4"),
+    ("macaddr", "7fffa"),
+)
+
+
+def _find_block_end(text: str, open_brace_idx: int) -> int:
+    """Return the index just past the `}` matching the `{` at
+    `open_brace_idx`. -1 on unbalanced input."""
+    depth = 1
+    i = open_brace_idx + 1
+    while i < len(text) and depth > 0:
+        c = text[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        return -1
+    return i
+
+
+def _find_snand_partitions(dts: str) -> tuple[int, int, str] | None:
+    """Locate the start..end byte range of the `partitions { ... };`
+    block whose body declares `compatible = "linux,ubi";`.
+
+    Returns `(start, end, indent)` where `indent` is the whitespace
+    preceding the `partitions {` keyword (used to reapply the original
+    indentation to the replacement block). Returns None when no block
+    matches. Raises `RuntimeError` when more than one block matches -
+    that would mean a future DTS rev has multiple UBI-on-flash
+    partitionings and we no longer know which one is the SPI-NAND.
+    """
+    matches: list[tuple[int, int, str]] = []
+    for hdr in PARTITIONS_HEADER_RE.finditer(dts):
+        open_brace_idx = hdr.end() - 1
+        if dts[open_brace_idx] != "{":
+            continue
+        end = _find_block_end(dts, open_brace_idx)
+        if end < 0:
+            continue
+        # Walk forward to the trailing `;` so we replace the full
+        # statement (`partitions { ... };`), not just the braces. dtc
+        # always emits the `;` immediately after `}` (possibly with
+        # intervening whitespace).
+        tail_end = end
+        while tail_end < len(dts) and dts[tail_end] in " \t":
+            tail_end += 1
+        if tail_end < len(dts) and dts[tail_end] == ";":
+            tail_end += 1
+        # Also consume the trailing newline if present so the splice
+        # leaves the surrounding DTS clean.
+        if tail_end < len(dts) and dts[tail_end] == "\n":
+            tail_end += 1
+        block = dts[hdr.start():tail_end]
+        if LINUX_UBI_MARKER in block:
+            matches.append((hdr.start(), tail_end, hdr.group(1)))
+    if not matches:
+        return None
+    if len(matches) > 1:
+        raise RuntimeError(
+            f"Found {len(matches)} `partitions {{}}` blocks containing "
+            f"{LINUX_UBI_MARKER!r}; expected exactly one. Refusing to "
+            "guess which one is the SPI-NAND. Update this script."
+        )
+    return matches[0]
+
+
+def _extract_factory_phandles(
+    block: str,
+) -> dict[tuple[str, str], int | None]:
+    """Walk `block` (typically the SPI-NAND `partitions { ... }`
+    block we are about to replace) and return a mapping from
+    `(node_name, addr)` to the phandle integer for each entry of
+    FACTORY_CELLS.
+
+    A `None` value means "node was found but had no `phandle`
+    property"; this is legal - it means nothing references that cell
+    and we can emit the new node without an explicit phandle.
+
+    Raises `RuntimeError` when a cell node is missing entirely,
+    which would mean the upstream DTS shape changed and we need to
+    update FACTORY_CELLS.
+    """
+    out: dict[tuple[str, str], int | None] = {}
+    for name, addr in FACTORY_CELLS:
+        # Match `\b<name>@<addr> {` so addresses like `7fff4` cannot
+        # accidentally be matched against `1c0000` etc. dtc may emit
+        # the address as the bare hex digits or with a `0x` prefix in
+        # rare cases - anchor to the literal upstream form, which
+        # never carries the prefix on node units.
+        pattern = rf"(?<![\w-]){re.escape(name)}@{re.escape(addr)}\s*\{{"
+        m = re.search(pattern, block)
+        if not m:
+            raise RuntimeError(
+                f"Cannot find `{name}@{addr}` in the original "
+                "ubi-volume-factory block. The upstream DTS shape "
+                "changed and patch_dtb_partitions.py needs updating "
+                "(check FACTORY_CELLS against the current "
+                "mt7622-linksys-e8450-ubi.dts)."
+            )
+        open_brace_idx = m.end() - 1
+        node_end = _find_block_end(block, open_brace_idx)
+        if node_end < 0:
+            raise RuntimeError(
+                f"Unbalanced braces while reading `{name}@{addr}` "
+                "node in the original DTS."
+            )
+        body = block[open_brace_idx:node_end]
+        pm = re.search(
+            r"phandle\s*=\s*<\s*(0x[0-9a-fA-F]+|\d+)\s*>",
+            body,
+        )
+        if pm is None:
+            out[(name, addr)] = None
+            continue
+        raw = pm.group(1)
+        out[(name, addr)] = int(raw, 16) if raw.startswith("0x") else int(raw)
+    return out
+
+
+def _format_phandle_line(value: int | None) -> str:
+    """Render the phandle property line that follows a cell's `reg`
+    declaration. Empty string when there is no phandle to copy -
+    the placeholder slot in LAYOUT_1_0_BLOCK is on the same line as
+    `reg = ...;` so this collapses cleanly.
+    """
+    if value is None:
+        return ""
+    # Hex form mirrors what dtc emits in -I dtb -O dts output, which
+    # makes intermediate `.dts` files easier to diff against the
+    # original. The exact textual form is irrelevant once dtc -I dts
+    # -O dtb consumes it.
+    return f"\n\t\t\t\t\tphandle = <0x{value:x}>;"
+
+
+def patch_dts(dts: str) -> tuple[str, str]:
+    """Apply the layout 1.0 rewrite. Returns `(patched_dts, summary)`.
+
+    The summary string is suitable for stderr emission and lists the
+    range that was rewritten and which phandles were preserved.
+    Raises `RuntimeError` on any condition that would result in a
+    half-patched / silently broken DTB."""
+    found = _find_snand_partitions(dts)
+    if found is None:
+        raise RuntimeError(
+            "No `partitions { ... }` block containing "
+            f"{LINUX_UBI_MARKER!r} found in the input DTS. The DTB "
+            "either is already on layout 1.0 (so this patch is a "
+            "no-op and should not have been requested), or the kernel "
+            "DTS shape changed and this script needs updating."
+        )
+    start, end, _indent = found
+    original_block = dts[start:end]
+    # Extract phandles from the soon-to-be-deleted block BEFORE we
+    # replace it. Numeric references downstream (in wmac/gmac0/wan)
+    # would otherwise dangle.
+    phandles = _extract_factory_phandles(original_block)
+    template = LAYOUT_1_0_BLOCK
+    for (name, addr), value in phandles.items():
+        placeholder = f"__PHANDLE_{name}_{addr}__"
+        if placeholder not in template:
+            raise RuntimeError(
+                f"Internal: template is missing placeholder "
+                f"{placeholder} - fix LAYOUT_1_0_BLOCK to match "
+                "FACTORY_CELLS."
+            )
+        template = template.replace(placeholder, _format_phandle_line(value))
+    # Defensive: any leftover placeholder means the FACTORY_CELLS
+    # table and the template diverged.
+    if "__PHANDLE_" in template:
+        leftover = re.findall(r"__PHANDLE_[\w]+__", template)
+        raise RuntimeError(
+            "Internal: unsubstituted placeholders left in template: "
+            f"{leftover}"
+        )
+    # The original block we replace ends with `;` (statement
+    # terminator), so the template must do the same. Sanity-check
+    # ourselves so a future template edit cannot ship a broken DTS.
+    if not template.rstrip("\n").endswith("};"):
+        raise RuntimeError(
+            "Internal: layout 1.0 template does not end with `};` - "
+            "this should be unreachable, fix the template literal."
+        )
+    # We do NOT try to re-indent the template to match the original
+    # block's column. dtc is whitespace-agnostic; the recompiled
+    # .dtb is identical regardless of indentation depth.
+    out = dts[:start] + template + dts[end:]
+    phandle_summary = ", ".join(
+        f"{name}@{addr}->{('skip' if v is None else f'0x{v:x}')}"
+        for (name, addr), v in phandles.items()
+    )
+    summary = (
+        f"rewrote partitions block at bytes {start}..{end} "
+        f"({end - start} bytes -> {len(template)} bytes); "
+        f"factory phandles: {phandle_summary}"
+    )
+    return out, summary
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(
+        description="Rewrite linksys_e8450-ubi DTB partitioning to layout 1.0",
+    )
+    p.add_argument("--in", dest="in_path", default=None,
+                   help="DTS input path (default: stdin)")
+    p.add_argument("--out", dest="out_path", default=None,
+                   help="DTS output path (default: stdout)")
+    args = p.parse_args(argv)
+
+    try:
+        if args.in_path:
+            with open(args.in_path, "r", encoding="utf-8") as f:
+                src = f.read()
+        else:
+            src = sys.stdin.read()
+    except OSError as exc:
+        print(f"[patch_dtb_partitions] read failed: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        patched, summary = patch_dts(src)
+    except RuntimeError as exc:
+        print(f"[patch_dtb_partitions] {exc}", file=sys.stderr)
+        return 2
+
+    print(f"[patch_dtb_partitions] {summary}", file=sys.stderr)
+
+    try:
+        if args.out_path:
+            with open(args.out_path, "w", encoding="utf-8") as f:
+                f.write(patched)
+        else:
+            sys.stdout.write(patched)
+    except OSError as exc:
+        print(f"[patch_dtb_partitions] write failed: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/ci/prepare_matrix.sh
+++ b/tools/ci/prepare_matrix.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+#
+# Compute the GitHub Actions matrix outputs from .github/ci/targets.yml.
+#
+# Inputs (env vars):
+#   TARGETS_INPUT              comma-separated devices or "all"
+#   RELEASES_OVERRIDE          comma-separated OpenWrt releases ("" -> targets.yml default)
+#   PHYSICAL_RELEASES_OVERRIDE comma-separated lab releases ("" -> targets.yml default)
+#   MESH_COUNT_INPUT           "0", "2" or "3"; ignored on pull_request (forced to 3)
+#   EVENT_NAME                 github.event_name (e.g. pull_request)
+#   GITHUB_OUTPUT              path to GHA output file
+#
+# Outputs (written to GITHUB_OUTPUT):
+#   targets_matrix, test_targets_matrix, mesh_test_matrix, mesh_pairs_matrix,
+#   qemu_single_matrix, qemu_mesh_matrix, archs_matrix, lime_packages_list,
+#   feed_hash
+
+set -euo pipefail
+
+TARGETS_INPUT="${TARGETS_INPUT:-all}"
+RELEASES_OVERRIDE="${RELEASES_OVERRIDE:-}"
+PHYSICAL_RELEASES_OVERRIDE="${PHYSICAL_RELEASES_OVERRIDE:-}"
+MESH_COUNT_INPUT="${MESH_COUNT_INPUT:-0}"
+EVENT_NAME="${EVENT_NAME:-}"
+
+if grep -RIn '^PKG_MIRROR_HASH:=skip' packages/; then
+  echo "PKG_MIRROR_HASH:=skip is deprecated on OpenWrt 24.10; pin PKG_SOURCE_VERSION and set a real sha256." >&2
+  exit 1
+fi
+
+all_targets_json="$(yq -r '.targets | tojson' .github/ci/targets.yml)"
+default_releases_json="$(yq -r '.openwrt_releases | tojson' .github/ci/targets.yml)"
+feed_branches_json="$(yq -r '.feed_branches | tojson' .github/ci/targets.yml)"
+default_physical_releases_json="$(yq -r '.default_physical_releases | tojson' .github/ci/targets.yml)"
+packages="$(yq -r '.packages' .github/ci/targets.yml)"
+
+if [[ -n "$RELEASES_OVERRIDE" ]]; then
+  releases_json="$(
+    jq -cn --arg list "$RELEASES_OVERRIDE" '
+      $list | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))
+    '
+  )"
+else
+  releases_json="$default_releases_json"
+fi
+if [[ "$(jq 'length' <<< "$releases_json")" -eq 0 ]]; then
+  echo "No OpenWrt releases selected (override='$RELEASES_OVERRIDE')" >&2
+  exit 1
+fi
+
+# Every release must have a feed_branches entry, otherwise build_image.sh
+# would route the local feed against the wrong upstream branch.
+missing="$(
+  jq -cn --argjson rel "$releases_json" --argjson fb "$feed_branches_json" '
+    $rel - ($fb | keys)
+  '
+)"
+if [[ "$(jq 'length' <<< "$missing")" -gt 0 ]]; then
+  echo "openwrt_releases entries missing from feed_branches map: $missing" >&2
+  exit 1
+fi
+
+if [[ -n "$PHYSICAL_RELEASES_OVERRIDE" ]]; then
+  physical_releases_json="$(
+    jq -cn --arg list "$PHYSICAL_RELEASES_OVERRIDE" '
+      $list | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))
+    '
+  )"
+else
+  physical_releases_json="$default_physical_releases_json"
+fi
+
+if [[ "$TARGETS_INPUT" == "all" ]]; then
+  selected_targets="$all_targets_json"
+else
+  selected_targets="$(
+    jq -c --arg list "$TARGETS_INPUT" '
+      ($list | split(",") | map(gsub("^\\s+|\\s+$"; ""))) as $wanted
+      | map(select((.device as $d | any($wanted[]; . == $d))))
+    ' <<< "$all_targets_json"
+  )"
+fi
+
+if [[ "$(jq 'length' <<< "$selected_targets")" -eq 0 ]]; then
+  echo "No targets selected after filtering input: $TARGETS_INPUT" >&2
+  exit 1
+fi
+
+# `targets_matrix`: cross-product of selected targets x release. Per-target
+# `packages:` may include the `{{ packages_default }}` placeholder which is
+# replaced by the top-level default at this step.
+targets_matrix="$(
+  jq -c --argjson releases "$releases_json" --argjson feeds "$feed_branches_json" --arg pkg "$packages" '
+    {include: (
+      . as $tgts
+      | $releases
+      | map(. as $rel
+        | $tgts
+        | map(. + {
+            openwrt_release: $rel,
+            feed_branch: ($feeds[$rel] // ""),
+            packages: ((.packages // $pkg) | gsub("\\{\\{\\s*packages_default\\s*\\}\\}"; $pkg)),
+            build_initramfs: (if (.build_initramfs == true) then "1" else "0" end),
+            image_format: (.image_format // "fit"),
+            fit_arch: (.fit_arch // ""),
+            fit_kernel_loadaddr: (.fit_kernel_loadaddr // ""),
+            fit_dts: (.fit_dts // ""),
+            fit_config: (.fit_config // "config-1"),
+            fit_bootargs: (.fit_bootargs // ""),
+            dtb_patch_nvmem_mac: (if (.dtb_patch_nvmem_mac == true) then "1" else "0" end),
+            dtb_force_legacy_partitions: (if (.dtb_force_legacy_partitions == true) then "1" else "0" end),
+            test_firmware: (if (.test_firmware == false) then "0" else "1" end),
+            test_qemu: (if (.test_qemu == true) then "1" else "0" end),
+            test_places: (.test_places // [.device]),
+            uboot_interrupt_spam_sec: (.uboot_interrupt_spam_sec // "" | tostring)
+          })
+      ) | add
+    )}
+  ' <<< "$selected_targets"
+)"
+
+# `test_targets_matrix`: physical single-node entries, expanded by labgrid
+# place. Filtered by `physical_releases_json` so build-only smoke releases
+# (e.g. 25.12.2 today) do not enqueue any lab job.
+test_targets_matrix="$(
+  jq -c --argjson phys "$physical_releases_json" '
+    {include: (
+      .include
+      | map(select(.test_firmware == "1"))
+      | map(select([.openwrt_release] | inside($phys)))
+      | map(. as $t | $t.test_places | map($t + {place: .}))
+      | add // []
+    )}
+  ' <<< "$targets_matrix"
+)"
+
+# mesh_test_matrix: physical mesh shape from MESH_COUNT_INPUT.
+# pull_request cannot pass workflow inputs, so it forces N=3.
+if [[ "$EVENT_NAME" == "pull_request" ]]; then
+  MESH_COUNT_INPUT="3"
+fi
+case "$MESH_COUNT_INPUT" in
+  "2") mesh_places_json='["openwrt_one","bananapi_bpi-r4"]' ;;
+  "3") mesh_places_json='["openwrt_one","bananapi_bpi-r4","belkin_rt3200_2"]' ;;
+  *)   mesh_places_json='[]' ;;
+esac
+mesh_device_map_json='{"openwrt_one":"openwrt_one","bananapi_bpi-r4":"bananapi_bpi-r4","belkin_rt3200_2":"linksys_e8450","belkin_rt3200_3":"linksys_e8450"}'
+if [[ "$mesh_places_json" == "[]" ]]; then
+  mesh_test_matrix='{"include":[]}'
+else
+  mesh_test_matrix="$(
+    jq -cn --argjson phys "$physical_releases_json" --argjson places "$mesh_places_json" --argjson devmap "$mesh_device_map_json" '
+      {include: ($phys | map({
+        openwrt_release: .,
+        places: $places,
+        devices: ($places | map($devmap[.]))
+      }))}
+    '
+  )"
+fi
+
+# `mesh_pairs_matrix`: walking-chain matrix used by the daily cron.
+# Three 2-node pairs that share devices on purpose so each unit gets two
+# end-to-end mesh validations per day. Excludes belkin_rt3200_1 (in repair).
+# Note: pair #3 pairs bananapi_bpi-r4 (wired-only) with belkin_rt3200_3 on
+# VLAN 200; two identical-model belkins are NOT paired because LibreMesh's
+# primary_mac() derives identity from eth0 and same-model devices in
+# initramfs mode share that MAC, producing a mesh identity collision.
+if [[ "$(jq 'length' <<< "$physical_releases_json")" -eq 0 ]]; then
+  mesh_pairs_matrix='{"include":[]}'
+else
+  primary_release="$(jq -r '.[0]' <<< "$physical_releases_json")"
+  mesh_pairs_matrix="$(
+    jq -cn --arg rel "$primary_release" '
+      {include: [
+        {pair: 1, place_a: "belkin_rt3200_2", device_a: "linksys_e8450",
+                  place_b: "openwrt_one",     device_b: "openwrt_one",
+                  openwrt_release: $rel},
+        {pair: 2, place_a: "openwrt_one",     device_a: "openwrt_one",
+                  place_b: "bananapi_bpi-r4", device_b: "bananapi_bpi-r4",
+                  openwrt_release: $rel},
+        {pair: 3, place_a: "bananapi_bpi-r4", device_a: "bananapi_bpi-r4",
+                  place_b: "belkin_rt3200_3", device_b: "linksys_e8450",
+                  openwrt_release: $rel}
+      ]}
+    '
+  )"
+fi
+
+# QEMU matrices. Crossed against the FULL release list (not the physical
+# filter) so QEMU validation runs on every supported branch.
+qemu_single_matrix="$(
+  jq -c '{include: (.include | map(select(.test_qemu == "1")))}' <<< "$targets_matrix"
+)"
+qemu_mesh_matrix="$qemu_single_matrix"
+
+# `archs_matrix` drives build-feed. Keyed on (arch, release) because the SDK
+# toolchain differs across releases and the resulting IPKs are not
+# interchangeable. extra_feeds / extra_packages aggregate per (arch, release).
+archs_matrix="$(
+  jq -c --argjson releases "$releases_json" '
+    ([.[] | {
+      arch,
+      sdk_arch,
+      index_imagebuilder,
+      extra_feeds: (.extra_feeds // []),
+      extra_packages: (.extra_packages // [])
+    }]) as $base
+    | {
+        include: (
+          $releases
+          | map(. as $rel
+            | $base
+            | map(. + {openwrt_release: $rel,
+                       sdk_arch: (
+                         .sdk_arch | sub("-openwrt-[0-9]+\\.[0-9]+(\\.[0-9]+)?$";
+                                         "-openwrt-" + ($rel | split(".") | .[:2] | join(".")))
+                       )})
+          )
+          | add
+          | group_by([.arch, .openwrt_release])
+          | map({
+              arch: .[0].arch,
+              sdk_arch: .[0].sdk_arch,
+              index_imagebuilder: .[0].index_imagebuilder,
+              openwrt_release: .[0].openwrt_release,
+              extra_feeds: ([.[] | .extra_feeds[]] | unique | join(" ")),
+              extra_packages: ([.[] | .extra_packages[]] | unique | join(" "))
+            })
+        )
+      }
+  ' <<< "$selected_targets"
+)"
+
+# extra_hash: 12-char sha256 prefix over (extra_feeds, extra_packages) so the
+# build-feed cache key busts whenever the upstream commit pin or package
+# selection of an extra src-git feed changes.
+archs_matrix="$(
+  entries="$(jq -c '.include[]' <<<"$archs_matrix")"
+  updated="[]"
+  while IFS= read -r entry; do
+    ef="$(jq -r '.extra_feeds' <<<"$entry")"
+    ep="$(jq -r '.extra_packages' <<<"$entry")"
+    eh="$(printf '%s|%s' "$ef" "$ep" | sha256sum | cut -c1-12)"
+    updated="$(jq -c --argjson e "$entry" --arg eh "$eh" '. + [$e + {extra_hash: $eh}]' <<<"$updated")"
+  done <<<"$entries"
+  jq -cn --argjson inc "$updated" '{include: $inc}'
+)"
+
+# `lime_packages_list`: union of every package name listed in targets.yml,
+# filtered to names that exist as `packages/<name>/Makefile`. Restricting to
+# requested packages keeps gh-action-sdk's per-package compile loop bounded.
+requested_pkgs="$(
+  yq -r '[.packages, (.targets[].packages // empty)]
+         | map(select(. != null))
+         | join(" ")' .github/ci/targets.yml \
+    | tr ' \t' '\n' \
+    | sed -n 's/^[A-Za-z0-9_+-][A-Za-z0-9_+-]*$/&/p' \
+    | grep -v '^-' \
+    | grep -vw 'packages_default' \
+    | sort -u
+)"
+available_lime="$(
+  find packages -mindepth 2 -maxdepth 2 -name Makefile -printf '%h\n' \
+    | xargs -n1 basename | sort -u
+)"
+lime_packages_list="$(
+  comm -12 <(printf '%s\n' "$requested_pkgs") <(printf '%s\n' "$available_lime") \
+    | tr '\n' ' ' | sed 's/[[:space:]]*$//'
+)"
+echo "Computed package list ($(echo "$lime_packages_list" | wc -w) packages):"
+echo "$lime_packages_list" | tr ' ' '\n'
+
+# `feed_hash`: sha256 over package sources, build_feed.sh and the resolved
+# package list. Other targets.yml or workflow edits do NOT bust the cache.
+feed_hash="$(
+  {
+    find packages -type f \( -name 'Makefile' -o -path 'packages/*/files/*' -o -path 'packages/*/patches/*' -o -path 'packages/*/src/*' \) -print0 \
+      | LC_ALL=C sort -z \
+      | xargs -0 sha256sum
+    sha256sum tools/ci/build_feed.sh
+    printf 'lime_packages_list=%s\n' "$lime_packages_list"
+  } | sha256sum | cut -d' ' -f1
+)"
+echo "Computed feed_hash=$feed_hash"
+
+if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+  echo "GITHUB_OUTPUT not set; printing values to stdout instead." >&2
+  GITHUB_OUTPUT="/dev/stdout"
+fi
+
+{
+  echo "targets_matrix=$targets_matrix"
+  echo "test_targets_matrix=$test_targets_matrix"
+  echo "mesh_test_matrix=$mesh_test_matrix"
+  echo "mesh_pairs_matrix=$mesh_pairs_matrix"
+  echo "qemu_single_matrix=$qemu_single_matrix"
+  echo "qemu_mesh_matrix=$qemu_mesh_matrix"
+  echo "archs_matrix=$archs_matrix"
+  echo "lime_packages_list=$lime_packages_list"
+  echo "feed_hash=$feed_hash"
+} >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Hey! This adds the CI pipeline we've been running on our fork for the past couple of months. It builds firmware from PR commits and tests it on real hardware before merge, so contributors get actual validation instead of just linting.

## What it does

The workflow (`.github/workflows/build-firmware.yml`) driven by `.github/ci/targets.yml` runs on every PR, on manual dispatch, and on a daily schedule. The pipeline:

1. **Compiles packages from the PR branch** via the OpenWrt SDK, so your changes to `lime-system`, `lime-proto-*`, etc. end up in the firmware
2. **Builds per-device initramfs images** using ImageBuilder, with the freshly compiled feed injected
3. **Tests on physical hardware** via Labgrid + pytest (single-node and multi-node mesh)
4. **Tests on QEMU** with vwifi-simulated WiFi mesh (no hardware needed, runs on GitHub-hosted runners)

Physical tests run on a self-hosted testbed at FCEFyN (Universidad Nacional de Cordoba, Argentina). The lab has Belkin RT3200 x3, OpenWrt One, LibreRouter v1, and BananaPi BPi-R4. Tests require approval via the `physical-lab` environment gate so random PRs can't run code on the hardware.

QEMU tests spin up x86_64 VMs with `mac80211_hwsim` + vwifi for WiFi simulation, no approval needed.

## What's included

- `.github/workflows/build-firmware.yml` - the workflow itself
- `.github/ci/targets.yml` - device matrix (which devices to build/test, which OpenWrt releases, packages, etc.)
- `tools/ci/*.sh` - helper scripts for SDK feed compilation, ImageBuilder image creation, firmware staging on the TFTP server, matrix preparation, KVM setup
- `tools/ci/patch_dtb_local_mac.py` - injects a valid MAC into the FIT DTB for mt7622 units with corrupted factory partitions
- `tools/ci/patch_dtb_partitions.py` - forces legacy SPI-NAND partition layout on Belkin RT3200 to avoid bricking units on layout 1.0
- `packages/lime-docs/Makefile` - pins `PKG_SOURCE_VERSION` and `PKG_MIRROR_HASH` (OpenWrt 24.10 rejects `skip`)
- `README.md` - contributor-facing docs on how the CI works and how to update the lime-docs pin

## Test suite

The test suite lives in [fcefyn-testbed/libremesh-tests](https://github.com/fcefyn-testbed/libremesh-tests) (public repo, the workflow checks it out during test jobs). It includes:

- Single-node tests: system health, LAN, WAN, WiFi, LibreMesh-specific checks (lime-config, anygw, shared-state, babeld, batman-adv)
- Multi-node mesh tests: batman neighbors, L3 cross-ping, babeld route propagation
- QEMU mesh tests: same suite on virtual nodes with vwifi

## Things to discuss

- **Runner registration**: for the physical tests to work on `libremesh/lime-packages`, the FCEFyN self-hosted runner needs to be registered in the `libremesh` org (or as a repo-level runner on this repo). I can set that up once we agree on the approach. The workflow targets the `testbed-fcefyn` runner label.

- **`physical-lab` environment**: the workflow gates physical test jobs behind a GitHub Actions [environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) called `physical-lab`. This needs to be created in Settings > Environments for this repo, with one or more reviewers (individuals or a team) who approve runs before they hit the hardware. Without it, physical test jobs will fail. QEMU tests don't need this and run without approval on GitHub-hosted runners.

- **libremesh-tests repo**: the test suite currently lives in [fcefyn-testbed/libremesh-tests](https://github.com/fcefyn-testbed/libremesh-tests) (public). The workflow checks it out cross-org, so it works as-is. We can transfer it to the `libremesh` org later and update the checkout reference.

- **vwifi feed**: the QEMU mesh tests use a [vwifi package](https://github.com/fcefyn-testbed/vwifi_cli_package) pinned by SHA in `targets.yml`. This is also a public repo under `fcefyn-testbed`, same situation as libremesh-tests.