### PR TITLE
ci: update libremesh-tests checkout to libremesh org

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -513,7 +513,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          repository: fcefyn-testbed/libremesh-tests
+          repository: libremesh/libremesh-tests
           ref: main
           path: libremesh-tests
 
@@ -748,7 +748,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          repository: fcefyn-testbed/libremesh-tests
+          repository: libremesh/libremesh-tests
           ref: main
           path: libremesh-tests
 
@@ -851,7 +851,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          repository: fcefyn-testbed/libremesh-tests
+          repository: libremesh/libremesh-tests
           ref: main
           path: libremesh-tests
 
@@ -932,7 +932,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          repository: fcefyn-testbed/libremesh-tests
+          repository: libremesh/libremesh-tests
           ref: main
           path: libremesh-tests
 
@@ -1037,7 +1037,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          repository: fcefyn-testbed/libremesh-tests
+          repository: libremesh/libremesh-tests
           ref: main
           path: libremesh-tests
 


### PR DESCRIPTION
The libremesh-tests repo was just transferred from fcefyn-testbed to libremesh. This updates all 5 checkout references in build-firmware.yml to point to `libremesh/libremesh-tests` instead of `fcefyn-testbed/libremesh-tests`.

The old URL still works via GitHub redirect, but better to keep it canonical.