### PR TITLE
Revert "fix: remove WAN link-local firewall exception"

### DIFF
--- a/packages/lime-proto-wan/files/usr/lib/lua/lime/proto/wan.lua
+++ b/packages/lime-proto-wan/files/usr/lib/lua/lime/proto/wan.lua
@@ -49,6 +49,19 @@ function wan.setup_interface(ifname, args)
 	end
 
 	uci:save("network")
+
+	--! Accepting link local traffic also on WAN should not cause hazards.
+	--! It is very helpful in cases where the devices have problem to the other
+	--! ports, to have at least an addictional way to enter for rescue operation
+	local ALLOW_WAN_LL_SECT = "lime_allow_wan_all_link_local"
+	uci:set("firewall", ALLOW_WAN_LL_SECT, "rule")
+	uci:set("firewall", ALLOW_WAN_LL_SECT, "name", ALLOW_WAN_LL_SECT)
+	uci:set("firewall", ALLOW_WAN_LL_SECT, "src", "wan")
+	uci:set("firewall", ALLOW_WAN_LL_SECT, "family", "ipv6")
+	uci:set("firewall", ALLOW_WAN_LL_SECT, "src_ip", "fe80::/10")
+	uci:set("firewall", ALLOW_WAN_LL_SECT, "dest_ip", "fe80::/10")
+	uci:set("firewall", ALLOW_WAN_LL_SECT, "target", "ACCEPT")
+	uci:save("firewall")
 end
 
 return wan


### PR DESCRIPTION
Reverts libremesh/lime-packages#1265

This feature was needed, and still is needed! The exception doesn't open the door to the whole IPv6 internet but just to link local addresses, it means only peers that are attached to the same switch as your router!
So the issue should be fixed, do not remove the needed feature! It also breaks babel routing on wan interface, and any other protocol which uses IPv6 link local for discovery or any other operation on wan interface.