### PR TITLE
shared-state-dnsmasq_leases: move broken dhcpscript to /etc/hotplug.d/dhcp/

### DIFF
--- a/packages/shared-state-dnsmasq_leases/files/etc/hotplug.d/dhcp/00-lease-share
+++ b/packages/shared-state-dnsmasq_leases/files/etc/hotplug.d/dhcp/00-lease-share
@@ -1,0 +1,4 @@
+#!/bin/sh
+if [ "$ACTION" = "add" ] || [ "$ACTION" = "del" ]; then
+	(shared-state-publish_dnsmasq_leases "$@" >/dev/null) &
+fi

--- a/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
+++ b/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
@@ -2,7 +2,6 @@
 
 dhcpHostsFile="/tmp/dhcp.hosts_remote"
 
-uci set dhcp.@dnsmasq[0].dhcpscript=/usr/bin/dnsmasq-lease-share.sh
 uci set dhcp.@dnsmasq[0].dhcphostsfile=$dhcpHostsFile
 uci commit dhcp
 

--- a/packages/shared-state-dnsmasq_leases/files/usr/bin/dnsmasq-lease-share.sh
+++ b/packages/shared-state-dnsmasq_leases/files/usr/bin/dnsmasq-lease-share.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-(shared-state-publish_dnsmasq_leases "$@" >/dev/null) &

--- a/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
+++ b/packages/ubus-lime-utils/files/usr/lib/lua/lime/node_status.lua
@@ -53,17 +53,14 @@ function node_status.get_station_stats(station)
 	local signal, chain = string.match(signal_str, "(%-?%d+)%s+%[(.-)%]")
 	station.signal = tonumber(signal)
 	station.chains = {}
-	--[[
-    succesive calls to this function will lead to an error
-    /usr/bin/lua: /usr/lib/lua/lime/node_status.lua:60: bad argument #1 to 'gmatch' (string expected, got nil)
-stack traceback:
-	[C]: in function 'gmatch'
-	/usr/lib/lua/lime/node_status.lua:60: in function 'get_station_stats'
-	...tate/publishers/shared-state-publish_wifi_links_info:32: in function 'get_wifi_links_info'
-	...tate/publishers/shared-state-publish_wifi_links_info:45: in main chunk
-	[C]: ?
-    ]]
-	--
+	--! succesive calls to this function will lead to an error
+	--! /usr/bin/lua: /usr/lib/lua/lime/node_status.lua:60: bad argument #1 to 'gmatch' (string expected, got nil)
+	--! stack traceback:
+	--! [C]: in function 'gmatch'
+	--! /usr/lib/lua/lime/node_status.lua:60: in function 'get_station_stats'
+	--! ...tate/publishers/shared-state-publish_wifi_links_info:32: in function 'get_wifi_links_info'
+	--! ...tate/publishers/shared-state-publish_wifi_links_info:45: in main chunk
+	--! [C]: ?
 	if chain ~= nil then
 		for num in string.gmatch(chain, "%-?%d+") do
 			table.insert(station.chains, tonumber(num))


### PR DESCRIPTION
Using dhcpscript the commands in /usr/bin/dnsmasq-lease-share.sh are sourced by /usr/lib/dnsmasq/dhcp-script.sh.
The execution of shared-state-publish_dnsmasq_leases was already broken, but it was not visible
until a recent change from '&>/dev/null' to '>/dev/null' that revelead the stderr.
```
Fri Aug 14 14:16:35 2026 daemon.debug dnsmasq-script[1]: /usr/lib/dnsmasq/dhcp-script.sh: /usr/bin/dnsmasq-lease-share.sh: line 2: /usr/bin/shared-state-publish_dnsmasq_leases: not found
```

The failure of the command is probably related to the usage of ujail, it could be tested removing
the default package procd-ujail. Cfr. [0].

Moved instead the command to /etc/hotplug.d/dhcp/00-lease-share that fires only on ACTION 'add' and 'del' and not on 'update'.

Since the previous was instead continuously failing and un-neededly running on updates:
as per the openwrt wiki the usage of dhcpscript do: `Run a custom script upon DHCP lease add / renew / remove actions` [1]

[0] https://forum.openwrt.org/t/dhcp-script-wont-execute/139587
[1] https://openwrt.org/docs/guide-user/base-system/dhcp?s[]=dhcpscript