### PR TITLE
ci: build-firmware: SDK use EXTRA_DEPENDS for lime-packages to speed up the compilation

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -110,7 +110,7 @@ jobs:
         env:
           ARCH: ${{ matrix.sdk_arch }}
           FEEDNAME: lime_packages
-          PACKAGES: ${{ needs.prepare-matrix.outputs.lime_packages_list }} ${{ matrix.extra_packages }}
+          # PACKAGES: ${{ needs.prepare-matrix.outputs.lime_packages_list }} ${{ matrix.extra_packages }}
           # Extra src-git feeds, space-separated `<type>|<name>|<url>[^<sha>]`
           # entries; gh-action-sdk appends each to feeds.conf. Pinning the
           # full 40-char SHA is required (smart-HTTP rejects short prefixes).

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -41,6 +41,11 @@ on:
         required: false
         type: boolean
         default: false
+      build_lime_packages_deps:
+        description: "Build all lime-packages dependencies, increases compilation time of feeds"
+        required: false
+        type: boolean
+        default: false
   schedule:
     # Daily lab sweep at 06:00 UTC (03:00 ART).
     - cron: "0 6 * * *"
@@ -104,6 +109,17 @@ jobs:
           restore-keys: |
             lime-feed-v3-${{ matrix.arch }}-${{ matrix.openwrt_release }}-${{ needs.prepare-matrix.outputs.feed_hash }}-
 
+      - name: Prevent the compilation of all dependencies of the libremesh packages
+        if: steps.cache-feed.outputs.cache-hit != 'true' && github.event.inputs.build_lime_packages_deps != 'true'
+        run: |
+          shopt -s nullglob
+          sed -i \
+            -e '/^define Package\/\$(PKG_NAME)[^/]*$/,/^endef$/ s|DEPENDS:=|EXTRA_DEPENDS:=|g' \
+            -e '/^define Package\/\$(PKG_NAME)[^/]*$/,/^endef$/ s/+\($(PKG_NAME)[a-zA-Z0-9_-]*\)/\1 (>0),/g' \
+            -e '/^define Package\/\$(PKG_NAME)[^/]*$/,/^endef$/ s/+\([a-zA-Z_-][a-zA-Z0-9_-]*\)/\1 (>0),/g' \
+            -e '/^define Package\/\$(PKG_NAME)[^/]*$/,/^endef$/ s|,$||g' \
+            $(grep -l "PKGARCH:=all" packages/*/Makefile)
+
       - name: Build packages with openwrt/gh-action-sdk
         if: steps.cache-feed.outputs.cache-hit != 'true'
         uses: openwrt/gh-action-sdk@v9
@@ -121,6 +137,7 @@ jobs:
           # feed downstream with ImageBuilder's ipkg-make-index / apk mkndx.
           INDEX: "0"
           IGNORE_ERRORS: "n m y"
+          # V: "sc"
 
       - name: Diagnose feed build output
         if: steps.cache-feed.outputs.cache-hit != 'true'

--- a/packages/altermundi-grafana/Makefile
+++ b/packages/altermundi-grafana/Makefile
@@ -18,7 +18,7 @@ define Package/$(PKG_NAME)
             +prometheus-node-exporter-lua-wifi-stations-extra \
             +prometheus-node-exporter-lua-wifi-survey \
             +prometheus-node-exporter-lua-wifi-params \
-            +prometheus-node-exporter-lua-location-latlon \
+            +prometheus-node-exporter-lua-location-latlon
 
 endef
 

--- a/packages/check-date-http/Makefile
+++ b/packages/check-date-http/Makefile
@@ -9,7 +9,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+libuci-lua +lua 
+	DEPENDS:=+libuci-lua +lua
 	PKGARCH:=all
 endef
 

--- a/packages/lime-eth-config/Makefile
+++ b/packages/lime-eth-config/Makefile
@@ -11,7 +11,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Asociación Civil Altermundi <info@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+libubus-lua +lime-system +lua +luci-lib-jsonc 
+	DEPENDS:=+libubus-lua +lime-system +lua +luci-lib-jsonc
 	PKGARCH:=all
 endef
 

--- a/packages/miniserver-client/Makefile
+++ b/packages/miniserver-client/Makefile
@@ -18,7 +18,7 @@ define Package/$(PKG_NAME)
             +prometheus-node-exporter-lua-wifi-stations-extra \
             +prometheus-node-exporter-lua-wifi-survey \
             +prometheus-node-exporter-lua-wifi-params \
-            +prometheus-node-exporter-lua-location-latlon \
+            +prometheus-node-exporter-lua-location-latlon
 
 endef
 

--- a/packages/shared-state-babel_links_info/Makefile
+++ b/packages/shared-state-babel_links_info/Makefile
@@ -11,7 +11,7 @@ define Package/$(PKG_NAME)
 	TITLE:=Babel links module for shared-state
 	MAINTAINER:=Asociación Civil Altermundi <info@altermundi.net>
 	DEPENDS:=+lua +luci-lib-jsonc +ubus-lime-utils \
-		+libubus-lua +shared-state-ref_state_commons shared-state-async   
+		+libubus-lua +shared-state-ref_state_commons +shared-state-async
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-babeld_hosts/Makefile
+++ b/packages/shared-state-babeld_hosts/Makefile
@@ -10,7 +10,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=+hotplug-initd-services \
-		+lua +luci-lib-jsonc shared-state
+		+lua +luci-lib-jsonc +shared-state
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-bat_links_info/Makefile
+++ b/packages/shared-state-bat_links_info/Makefile
@@ -12,7 +12,7 @@ define Package/$(PKG_NAME)
 	TITLE:=Batman protocol links information module for shared-state
 	MAINTAINER:= Javier <jjorge@inti.gob.ar>
 	DEPENDS:=+lua +luci-lib-jsonc +ubus-lime-utils \
-		+lime-system +batctl-default +shared-state-ref_state_commons shared-state-async   
+		+lime-system +batctl-default +shared-state-ref_state_commons +shared-state-async
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-dnsmasq_hosts/Makefile
+++ b/packages/shared-state-dnsmasq_hosts/Makefile
@@ -10,7 +10,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=+lua +luci-lib-jsonc \
-		shared-state
+		+shared-state
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-dnsmasq_leases/Makefile
+++ b/packages/shared-state-dnsmasq_leases/Makefile
@@ -10,7 +10,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=+libuci-lua +lua \
-		+luci-lib-jsonc shared-state +shared-state-dnsmasq_hosts \
+		+luci-lib-jsonc +shared-state +shared-state-dnsmasq_hosts \
 		+luci-lib-nixio
 	PKGARCH:=all
 endef

--- a/packages/shared-state-dnsmasq_servers/Makefile
+++ b/packages/shared-state-dnsmasq_servers/Makefile
@@ -10,7 +10,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gui iribarren <gui@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=+lua +luci-lib-jsonc \
-		shared-state
+		+shared-state
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-node_info/Makefile
+++ b/packages/shared-state-node_info/Makefile
@@ -11,7 +11,7 @@ define Package/$(PKG_NAME)
 	TITLE:=Node information module for shared-state
 	MAINTAINER:= Javier <jjorge@inti.gob.ar>
 	DEPENDS:=+lua +luci-lib-jsonc +ubus-lime-utils \
-		+lime-system +ubus-lime-location +shared-state-ref_state_commons shared-state-async   
+		+lime-system +ubus-lime-location +shared-state-ref_state_commons +shared-state-async
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-nodes_and_links/Makefile
+++ b/packages/shared-state-nodes_and_links/Makefile
@@ -10,7 +10,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Nicolas Pace <nico@libre.ws>
 	URL:=http://libremesh.org
 	DEPENDS:=+lua +luci-lib-jsonc \
-		shared-state +ubus-lime-location
+		+shared-state +ubus-lime-location
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-pirania/Makefile
+++ b/packages/shared-state-pirania/Makefile
@@ -9,7 +9,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Asociación Civil AlterMundi <info@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc shared-state
+	DEPENDS:=+lua +luci-lib-jsonc +shared-state
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-ref_state_commons/Makefile
+++ b/packages/shared-state-ref_state_commons/Makefile
@@ -11,7 +11,7 @@ define Package/$(PKG_NAME)
 	TITLE:=Common components for reference satate datypes
 	MAINTAINER:= Javier <jjorge@inti.gob.ar>
 	DEPENDS:=+lua +luci-lib-jsonc +ubus-lime-utils \
-		+lime-system shared-state-async   
+		+lime-system +shared-state-async
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-wifi_links_info/Makefile
+++ b/packages/shared-state-wifi_links_info/Makefile
@@ -9,7 +9,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Asociación Civil Altermundi <info@altermundi.net>
 	DEPENDS:=+lua +luci-lib-jsonc +ubus-lime-utils \
-		+lime-system +libiwinfo-lua +shared-state-ref_state_commons shared-state-async 
+		+lime-system +libiwinfo-lua +shared-state-ref_state_commons +shared-state-async
 	PKGARCH:=all
 endef
 

--- a/packages/ubus-lime-utils/Makefile
+++ b/packages/ubus-lime-utils/Makefile
@@ -6,7 +6,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Santiago Piccinini <spiccinini@altermundi.net>
   SUBMENU:=3. Applications
   TITLE:=LIbremesh ubus utils module
-  DEPENDS:= +lua +libubox-lua +libubus-lua +libuci +lime-system +libiwinfo-lua +cgi-io +rpcd-mod-file \
+  DEPENDS:= +lua +libubox-lua +libubus-lua +uci +lime-system +libiwinfo-lua +cgi-io +rpcd-mod-file \
 	    +luci-lib-jsonc +rpcd
 
   PKGARCH:=all


### PR DESCRIPTION
The rest of the lime-packages built via by the ci via the action gh-action-sdk are compiled with NO_DEFAULT_FEEDS.
No issue so far since there is no libremesh package that needs to have one of its dependency actually compiled during it's own compilation.
Instead it speed up the compilation of a single architecture from 40m-1h to 10-15min.