### PR TITLE
Feature: lint helper pre push script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,11 +104,13 @@ The general workflow for branching is as follows:
 
 6. Make sure the tests are still running with success.
 
-7. Push the changes to `origin` (i.e. your fork)
+7. Run lint locally or set up the pre-push hook: to set up a git pre-push hook that runs lint locally, copy `tools/ci/lint/pre-push.sample` to `.git/hooks/pre-push` and make it executable.
+
+8. Push the changes to `origin` (i.e. your fork)
 
     ```git push origin <branch name>```
 
-8. Create a new Pull Request (see below).
+9. Create a new Pull Request (see below).
 
 #### Creating A Pull Request
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -123,6 +123,16 @@ foo.search_paths = {"/usr/lib/lua/lime/hwd/*.lua"}
 
 Coverage is measured using the [luacov](https://keplerproject.github.io/luacov/) library each time the tests are run. The results statistics are merged at `./luacov.stats.out` and a human friendly report is generated at `luacov.report.out`.
 
+## Linting
+
+To ensure code quality and consistency, we have a lint workflow that runs on GitHub Actions.
+You can also run the lint workflow locally before pushing your changes.
+
+To easily run lint locally before pushing, we provide a git pre-push hook:
+* Copy `tools/ci/lint/pre-push.sample` to `.git/hooks/pre-push`
+* Make it executable: `chmod +x .git/hooks/pre-push`
+* This script requires [act](https://github.com/nektos/act) and Docker to run the GitHub Actions workflow locally.
+
 ## Under the hood: tools in detail
 
 As one of the goals is that it must be easy for developers to write, modify and run the tests we created some simple tools to do this:

--- a/tools/ci/lint/pre-push.sample
+++ b/tools/ci/lint/pre-push.sample
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Run the lint workflow from .github/workflows/lint.yml locally using 'act'
+# Requires: https://github.com/nektos/act (and Docker)
+#
+# Install act:
+#   curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -b /usr/local/bin
+#   On first run, act will ask for an image size. Select "Medium" (~500MB), it is enough.
+#
+# Skip hook: git push --no-verify
+
+# Find act: check PATH first, then common local install locations
+ACT="$(command -v act 2>/dev/null)" \
+	|| ACT="$(git rev-parse --show-toplevel)/bin/act" \
+	|| ACT=""
+
+if [ ! -x "$ACT" ]; then
+	echo "Error: 'act' not found. Install it with:"
+	echo "  curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -b /usr/local/bin"
+	exit 1
+fi
+
+echo "=== Running lint workflow locally ==="
+"$ACT" push -W .github/workflows/lint.yml


### PR DESCRIPTION
I recently tried to update an old pull request but the CI rejected mi script because of linting errors. To make this easier for everyone, this PR adds documentation and points to a helper script to run the CI linting jobs locally before pushing.

I evaluated the possibility of just running the tools directly from the console, but running the actual CI job locally is much more accurate and guarantees we are testing against the same environment.

The CI workflow executes three specific scripts:

Lua Linting (tools/ci/lint/lua.sh): Uses luacheck to analyze Lua code for syntax errors, unused variables, and warnings.
Shell Linting (tools/ci/lint/sh.sh): Uses shellcheck to find bugs, edge cases, and bad practices in shell scripts.
Formatting (tools/ci/lint/format.sh): Enforces consistent code style using shfmt.
