### PR TITLE
lime-utils: init the package with the script unique_append

### DIFF
--- a/packages/check-date-http/Makefile
+++ b/packages/check-date-http/Makefile
@@ -9,7 +9,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+libuci-lua +lua
+	DEPENDS:=+libuci-lua +lua +lime-utils
 	PKGARCH:=all
 endef
 

--- a/packages/check-date-http/files/etc/uci-defaults/check-date-http-cron
+++ b/packages/check-date-http/files/etc/uci-defaults/check-date-http-cron
@@ -1,9 +1,6 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"*/20 * * * * ((sleep \$((RANDOM % 600)); check-date-http &> /dev/null)&)" \
 	/etc/crontabs/root
+
+exit 0

--- a/packages/eupgrade/Makefile
+++ b/packages/eupgrade/Makefile
@@ -9,7 +9,8 @@ define Package/$(PKG_NAME)
   CATEGORY:=Utilities
   TITLE:=$(PKG_NAME) provides semi automated firmware upgrades
   MAINTAINER:=Santiago Piccinini <spiccinini@altermundi.net>
-  DEPENDS:=+lua +lime-system +luci-lib-jsonc +luci-lib-nixio +libubus-lua +libuci-lua
+  DEPENDS:=+lua +lime-system +luci-lib-jsonc +luci-lib-nixio +libubus-lua +libuci-lua \
+    +lime-utils
   PKGARCH:=all
 endef
 

--- a/packages/eupgrade/files/etc/uci-defaults/99-eupgrades-cron
+++ b/packages/eupgrade/files/etc/uci-defaults/99-eupgrades-cron
@@ -1,9 +1,6 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"0 */6 * * * ((sleep \$((RANDOM % 120)); eupgrade-check &> /dev/null)&)" \
 	/etc/crontabs/root
+
+exit 0

--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -243,34 +243,15 @@ function utils.is_valid_hostname(hostname)
 end
 
 function utils.file_exists(name)
-	local f = io.open(name, "r")
-	if f ~= nil then
-		io.close(f)
-		return true
-	else
-		return false
-	end
+	return fs.stat(name, "type") == "reg"
 end
 
 function utils.read_file(name)
-	local f = io.open(name, "r")
-	local ret = nil
-	if f ~= nil then
-		ret = f:read("*all")
-		f:close()
-	end
-	return ret
+	return fs.readfile(name)
 end
 
 function utils.write_file(name, content)
-	local f = io.open(name, "w")
-	local ret = false
-	if f ~= nil then
-		f:write(content)
-		f:close()
-		ret = true
-	end
-	return ret
+	return fs.writefile(name, content)
 end
 
 function utils.is_installed(pkg)
@@ -304,11 +285,7 @@ function utils.tableMelt(t1, t2)
 end
 
 function utils.tableLength(t)
-	local count = 0
-	for _ in pairs(t) do
-		count = count + 1
-	end
-	return count
+	return #t
 end
 
 function utils.indexFromName(name)

--- a/packages/lime-utils/Makefile
+++ b/packages/lime-utils/Makefile
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+
+include ../../libremesh.mk
+
+define Package/$(PKG_NAME)
+  TITLE:=LibreMesh utils core
+  CATEGORY:=LibreMesh
+  MAINTAINER:=Samuele Longhi <agave@dracaena.it>
+  URL:=https://libremesh.org
+  PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/description
+	LibreMesh utils, core package with tools and helper scripts to use also outside the LibreMesh system.
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/lime-utils/files/usr/bin/unique_append
+++ b/packages/lime-utils/files/usr/bin/unique_append
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ -z "$1" ] || [ -z "$2" ]; then
+	printf "Usage: unique_append <string> <file>\nTwo arguments required."
+	exit 0
+fi
+[ ! -f "$2" ] && mkdir -p "$(dirname "$2")" && touch "$2"
+grep -qx "$1" "$2" || echo "$1" >>"$2"

--- a/packages/pirania/files/etc/uci-defaults/90-captive-portal-cron
+++ b/packages/pirania/files/etc/uci-defaults/90-captive-portal-cron
@@ -1,9 +1,4 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"*/10 * * * * [ \$(uci -q get pirania.base_config.enabled) = \"1\" ] && ((captive-portal update &> /dev/null)&)" \
 	/etc/crontabs/root

--- a/packages/pirania/files/etc/uci-defaults/91-tranca-redes-cron
+++ b/packages/pirania/files/etc/uci-defaults/91-tranca-redes-cron
@@ -1,11 +1,6 @@
 #!/bin/sh
 # Install Tranca Redes scheduler cron entry
 # Runs every minute to evaluate schedule and toggle active state
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	'* * * * * /usr/bin/tranca-redes-scheduler' \
 	/etc/crontabs/root

--- a/packages/shared-state-async/Makefile
+++ b/packages/shared-state-async/Makefile
@@ -41,7 +41,7 @@ define Package/$(PKG_NAME)
 	# TODO: Statically linking libstdcpp instead of depending on it and then
 	# stripping unused symbols might reduce space usage, until this is the
 	# only package to use it
-	DEPENDS:=+libstdcpp
+	DEPENDS:=+libstdcpp +lime-utils
 endef
 
 define Package/$(PKG_NAME)/description

--- a/packages/shared-state-async/files/etc/uci-defaults/shared-state-net_stats-cron
+++ b/packages/shared-state-async/files/etc/uci-defaults/shared-state-net_stats-cron
@@ -1,9 +1,4 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 mSc="net_stats"
 
 uci set shared-state.${mSc}=dataType
@@ -16,3 +11,5 @@ uci commit shared-state
 unique_append \
 	"*/3 * * * * ((sleep \$((RANDOM % 120)); shared-state-async insert net-stats < /tmp/shared-state/network_statistics.json &> /dev/null)&)" \
 	/etc/crontabs/root
+
+exit 0

--- a/packages/shared-state-async/files/etc/uci-defaults/shared-state-publish-all-cron
+++ b/packages/shared-state-async/files/etc/uci-defaults/shared-state-publish-all-cron
@@ -1,9 +1,6 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"*/30 * * * * ((sleep \$((RANDOM % 120)); shared-state-async-publish-all &> /dev/null)&)" \
 	/etc/crontabs/root
+
+exit 0

--- a/packages/shared-state-babeld_hosts/Makefile
+++ b/packages/shared-state-babeld_hosts/Makefile
@@ -10,7 +10,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=+hotplug-initd-services \
-		+lua +luci-lib-jsonc +shared-state
+		+lua +luci-lib-jsonc +shared-state +lime-utils
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-babeld_hosts/files/etc/uci-defaults/shared-state-babeld_hosts-cron
+++ b/packages/shared-state-babeld_hosts/files/etc/uci-defaults/shared-state-babeld_hosts-cron
@@ -1,9 +1,6 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"*/5 * * * * ((sleep \$((RANDOM % 120)); shared-state sync babeld-hosts &> /dev/null)&)" \
 	/etc/crontabs/root
+
+exit 0

--- a/packages/shared-state-bat_hosts/Makefile
+++ b/packages/shared-state-bat_hosts/Makefile
@@ -10,7 +10,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Asociación Civil Altermundi <info@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=+libubus-lua +lime-system +lua +luci-lib-jsonc +luci-lib-nixio \
-	         +shared-state-async
+	         +shared-state-async +lime-utils
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-bat_hosts/files/etc/uci-defaults/shared-state-bat_hosts-cron
+++ b/packages/shared-state-bat_hosts/files/etc/uci-defaults/shared-state-bat_hosts-cron
@@ -1,12 +1,9 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 uci set shared-state.bat_hosts=dataType
 uci set shared-state.bat_hosts.name='bat-hosts'
 uci set shared-state.bat_hosts.scope='community'
 uci set shared-state.bat_hosts.ttl='2400'
 uci set shared-state.bat_hosts.update_interval='30'
 uci commit shared-state
+
+exit 0

--- a/packages/shared-state-dnsmasq_hosts/Makefile
+++ b/packages/shared-state-dnsmasq_hosts/Makefile
@@ -10,7 +10,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gioacchino Mazzurco <gio@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=+lua +luci-lib-jsonc \
-		+shared-state
+		+shared-state +lime-utils
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
+++ b/packages/shared-state-dnsmasq_hosts/files/etc/uci-defaults/shared-state-dnsmasq_hosts-cron
@@ -1,9 +1,6 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"*/5 * * * * ((sleep \$((RANDOM % 120)); shared-state sync dnsmasq-hosts &> /dev/null) & )" \
 	/etc/crontabs/root
+
+exit 0

--- a/packages/shared-state-dnsmasq_leases/Makefile
+++ b/packages/shared-state-dnsmasq_leases/Makefile
@@ -11,7 +11,7 @@ define Package/$(PKG_NAME)
 	URL:=http://libremesh.org
 	DEPENDS:=+libuci-lua +lua \
 		+luci-lib-jsonc +shared-state +shared-state-dnsmasq_hosts \
-		+luci-lib-nixio
+		+luci-lib-nixio +lime-utils
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
+++ b/packages/shared-state-dnsmasq_leases/files/etc/uci-defaults/90_dnsmasq-lease-share
@@ -4,11 +4,6 @@ dhcpHostsFile="/tmp/dhcp.hosts_remote"
 
 uci set dhcp.@dnsmasq[0].dhcphostsfile=$dhcpHostsFile
 uci commit dhcp
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"*/5 * * * * ((sleep \$((RANDOM % 120)); shared-state sync dnsmasq-leases &> /dev/null)&)" \
 	/etc/crontabs/root

--- a/packages/shared-state-dnsmasq_servers/Makefile
+++ b/packages/shared-state-dnsmasq_servers/Makefile
@@ -10,7 +10,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Gui iribarren <gui@altermundi.net>
 	URL:=http://libremesh.org
 	DEPENDS:=+lua +luci-lib-jsonc \
-		+shared-state
+		+shared-state +lime-utils
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-dnsmasq_servers/files/etc/uci-defaults/shared-state-dnsmasq_servers
+++ b/packages/shared-state-dnsmasq_servers/files/etc/uci-defaults/shared-state-dnsmasq_servers
@@ -3,11 +3,8 @@
 # dnsmasq upon SIGHUP will re-read this file containing "server=/example.com/1.2.3.4" lines
 uci set dhcp.@dnsmasq[0].serversfile=/var/shared-state/dnsmasq_servers
 uci commit dhcp
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"*/5 * * * * ((sleep \$((RANDOM % 120)); shared-state sync dnsmasq-servers &> /dev/null)&)" \
 	/etc/crontabs/root
+
+exit 0

--- a/packages/shared-state-network_nodes/Makefile
+++ b/packages/shared-state-network_nodes/Makefile
@@ -9,7 +9,7 @@ define Package/$(PKG_NAME)
   TITLE:=$(PKG_NAME) provides data-type for network nodes marked as reliable by user
   MAINTAINER:=Asociacion Civil Altermundi <info@altermundi.net>
   DEPENDS:=+shared-state +shared-state-nodes_and_links +lime-system +luci-lib-jsonc \
-	   +libubus-lua
+	   +libubus-lua +lime-utils
   PKGARCH:=all
 endef
 

--- a/packages/shared-state-network_nodes/files/etc/uci-defaults/shared-state-network_nodes-cron
+++ b/packages/shared-state-network_nodes/files/etc/uci-defaults/shared-state-network_nodes-cron
@@ -1,9 +1,6 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"*/5 * * * * ((sleep \$((RANDOM % 120)); shared-state-multiwriter sync network_nodes &> /dev/null)&)" \
 	/etc/crontabs/root
+
+exit 0

--- a/packages/shared-state-nodes_and_links/Makefile
+++ b/packages/shared-state-nodes_and_links/Makefile
@@ -10,7 +10,7 @@ define Package/$(PKG_NAME)
 	MAINTAINER:=Nicolas Pace <nico@libre.ws>
 	URL:=http://libremesh.org
 	DEPENDS:=+lua +luci-lib-jsonc \
-		+shared-state +ubus-lime-location
+		+shared-state +ubus-lime-location +lime-utils
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-nodes_and_links/files/etc/uci-defaults/shared-state-bat_nodes_and_links
+++ b/packages/shared-state-nodes_and_links/files/etc/uci-defaults/shared-state-bat_nodes_and_links
@@ -1,9 +1,6 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"*/5 * * * * ((sleep \$((RANDOM % 120)); shared-state sync nodes_and_links &> /dev/null)&)" \
 	/etc/crontabs/root
+
+exit 0

--- a/packages/shared-state-pirania/Makefile
+++ b/packages/shared-state-pirania/Makefile
@@ -9,7 +9,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=LibreMesh
 	MAINTAINER:=Asociación Civil AlterMundi <info@altermundi.net>
 	URL:=http://libremesh.org
-	DEPENDS:=+lua +luci-lib-jsonc +shared-state
+	DEPENDS:=+lua +luci-lib-jsonc +shared-state +lime-utils
 	PKGARCH:=all
 endef
 

--- a/packages/shared-state-pirania/files/etc/uci-defaults/90-pirania-cron
+++ b/packages/shared-state-pirania/files/etc/uci-defaults/90-pirania-cron
@@ -1,9 +1,4 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"*/2 * * * * ((sleep \$((RANDOM % 30)); /etc/shared-state/publishers/shared-state-publish_vouchers && shared-state sync pirania-vouchers &> /dev/null)&)" \
 	/etc/crontabs/root

--- a/packages/shared-state/files/etc/uci-defaults/shared-state-publishers-cron
+++ b/packages/shared-state/files/etc/uci-defaults/shared-state-publishers-cron
@@ -1,9 +1,4 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"*/30 * * * * ((sleep \$((RANDOM % 1000)); shared-state-publish-all &> /dev/null)&)" \
 	/etc/crontabs/root

--- a/packages/ubus-lime-metrics/Makefile
+++ b/packages/ubus-lime-metrics/Makefile
@@ -7,7 +7,8 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Santiago Piccinini <spiccinini@altermundi.net>
   SUBMENU:=3. Applications
   TITLE:=Metrics ubus module
-  DEPENDS:= +lua +libubox-lua +libubus-lua +luci-lib-jsonc +netperf +mtr +check-internet +lime-system +ubus-lime-utils
+  DEPENDS:= +lua +libubox-lua +libubus-lua +luci-lib-jsonc +netperf +mtr +check-internet +lime-system +ubus-lime-utils \
+    +lime-utils
   PKGARCH:=all
 endef
 

--- a/packages/ubus-lime-metrics/files/etc/uci-defaults/99-save-last-known-path-to-internet
+++ b/packages/ubus-lime-metrics/files/etc/uci-defaults/99-save-last-known-path-to-internet
@@ -1,9 +1,6 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	"*/30 * * * * /usr/sbin/last_internet save" \
 	/etc/crontabs/root
+
+exit 0

--- a/packages/wifi-unstuck-wa/Makefile
+++ b/packages/wifi-unstuck-wa/Makefile
@@ -9,7 +9,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=Utilities
   TITLE:=$(PKG_NAME) provides workarounds for radio bugs
   MAINTAINER:=Santiago Piccinini <spiccinini@altermundi.net>
-  DEPENDS:=+lua +lime-system +luci-lib-nixio
+  DEPENDS:=+lua +lime-system +luci-lib-nixio +lime-utils
   PKGARCH:=all
 endef
 

--- a/packages/wifi-unstuck-wa/files/etc/uci-defaults/wifi-unstuck-cron
+++ b/packages/wifi-unstuck-wa/files/etc/uci-defaults/wifi-unstuck-cron
@@ -1,9 +1,6 @@
 #!/bin/sh
-
-unique_append() {
-	grep -qF "$1" "$2" || echo "$1" >>"$2"
-}
-
 unique_append \
 	'*/10 * * * * ((wifi-unstuck &> /dev/null)&)' \
 	/etc/crontabs/root
+
+exit 0


### PR DESCRIPTION
[WIP] still untested

**lime-system: utils.lua use nixio.fs for file operations**
This includes also a similar minor fix:
- fix: use the lua native #var to count tableLength(var)

**lime-utils: init the package with the script unique_append**
The following changes are made:
- initialize the package lime-utils with the script unique_append
- add a dependency on lime-utils to all packages
- always 'exit 0' on uci defaults that add new crontabs, to execute them
only at firstboot and not at every boot

Fixes: #949
