### PR TITLE
fix(ci): point LG_ENV at -dual-tftp target when staging kernel + ramdisk

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -562,6 +562,12 @@ jobs:
 
       - name: Lock labgrid place
         working-directory: libremesh-tests
+        env:
+          # LG_PLACE must be available before labgrid-client parses LG_ENV so
+          # that !template "$LG_PLACE" in target YAMLs resolves correctly.
+          # (lab_stage_firmware.sh may override LG_ENV to a -dual-tftp variant
+          # that still references $LG_PLACE in RemotePlace.)
+          LG_PLACE: labgrid-fcefyn-${{ matrix.place }}
         run: |
           set -euo pipefail
           echo "LG_PROXY=labgrid-fcefyn" >> "$GITHUB_ENV"

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -544,14 +544,23 @@ jobs:
         run: echo "OPENWRT_TESTS_DIR=$GITHUB_WORKSPACE/openwrt-tests" >> "$GITHUB_ENV"
 
       - name: Install uv
-        # v10.0.1 tolerates transient manifest-fetch failures with up to 3
-        # retries and progressive backoff (astral-sh/setup-uv#1016). Prior v7
-        # fetched raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson
-        # exactly once, and a single 503 (Backend.max_conn) from that endpoint
-        # killed the whole physical-DUT job before any test ran. v10's only
-        # breaking change is `enable-cache: auto`, which this workflow does not
-        # set, so the bump is behavior-preserving.
-        uses: astral-sh/setup-uv@v10.0.1
+        # Use the standalone installer instead of astral-sh/setup-uv to avoid a
+        # hard dependency on raw.githubusercontent.com/astral-sh/versions/.../uv.ndjson
+        # for version resolution. That endpoint went 503 (Backend.max_conn /
+        # Varnish) during runs 34356587946 and 34368726582, killing every
+        # physical-DUT job at "Install uv" before any stage/lock/test ran.
+        # setup-uv@v10 added retries only for thrown network errors, not for
+        # HTTP error statuses like 503 (see astral-sh/setup-uv#1016).
+        #
+        # The standalone installer resolves the pinned UV_VERSION directly from
+        # releases.astral.sh (mirror) with github.com/astral-sh/uv/releases as
+        # fallback, both of which skip the ndjson manifest entirely.
+        env:
+          UV_VERSION: "0.12.11"
+        run: |
+          set -euo pipefail
+          curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Sync libremesh-tests environment
         run: |
@@ -792,14 +801,23 @@ jobs:
         run: echo "OPENWRT_TESTS_DIR=$GITHUB_WORKSPACE/openwrt-tests" >> "$GITHUB_ENV"
 
       - name: Install uv
-        # v10.0.1 tolerates transient manifest-fetch failures with up to 3
-        # retries and progressive backoff (astral-sh/setup-uv#1016). Prior v7
-        # fetched raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson
-        # exactly once, and a single 503 (Backend.max_conn) from that endpoint
-        # killed the whole physical-DUT job before any test ran. v10's only
-        # breaking change is `enable-cache: auto`, which this workflow does not
-        # set, so the bump is behavior-preserving.
-        uses: astral-sh/setup-uv@v10.0.1
+        # Use the standalone installer instead of astral-sh/setup-uv to avoid a
+        # hard dependency on raw.githubusercontent.com/astral-sh/versions/.../uv.ndjson
+        # for version resolution. That endpoint went 503 (Backend.max_conn /
+        # Varnish) during runs 34356587946 and 34368726582, killing every
+        # physical-DUT job at "Install uv" before any stage/lock/test ran.
+        # setup-uv@v10 added retries only for thrown network errors, not for
+        # HTTP error statuses like 503 (see astral-sh/setup-uv#1016).
+        #
+        # The standalone installer resolves the pinned UV_VERSION directly from
+        # releases.astral.sh (mirror) with github.com/astral-sh/uv/releases as
+        # fallback, both of which skip the ndjson manifest entirely.
+        env:
+          UV_VERSION: "0.12.11"
+        run: |
+          set -euo pipefail
+          curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Sync libremesh-tests environment
         run: cd libremesh-tests && uv sync
@@ -902,14 +920,23 @@ jobs:
         run: echo "OPENWRT_TESTS_DIR=$GITHUB_WORKSPACE/openwrt-tests" >> "$GITHUB_ENV"
 
       - name: Install uv
-        # v10.0.1 tolerates transient manifest-fetch failures with up to 3
-        # retries and progressive backoff (astral-sh/setup-uv#1016). Prior v7
-        # fetched raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson
-        # exactly once, and a single 503 (Backend.max_conn) from that endpoint
-        # killed the whole physical-DUT job before any test ran. v10's only
-        # breaking change is `enable-cache: auto`, which this workflow does not
-        # set, so the bump is behavior-preserving.
-        uses: astral-sh/setup-uv@v10.0.1
+        # Use the standalone installer instead of astral-sh/setup-uv to avoid a
+        # hard dependency on raw.githubusercontent.com/astral-sh/versions/.../uv.ndjson
+        # for version resolution. That endpoint went 503 (Backend.max_conn /
+        # Varnish) during runs 34356587946 and 34368726582, killing every
+        # physical-DUT job at "Install uv" before any stage/lock/test ran.
+        # setup-uv@v10 added retries only for thrown network errors, not for
+        # HTTP error statuses like 503 (see astral-sh/setup-uv#1016).
+        #
+        # The standalone installer resolves the pinned UV_VERSION directly from
+        # releases.astral.sh (mirror) with github.com/astral-sh/uv/releases as
+        # fallback, both of which skip the ndjson manifest entirely.
+        env:
+          UV_VERSION: "0.12.11"
+        run: |
+          set -euo pipefail
+          curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Sync libremesh-tests environment
         run: cd libremesh-tests && uv sync
@@ -1001,14 +1028,23 @@ jobs:
           sudo apt-get install -y --no-install-recommends qemu-system-x86 ovmf
 
       - name: Install uv
-        # v10.0.1 tolerates transient manifest-fetch failures with up to 3
-        # retries and progressive backoff (astral-sh/setup-uv#1016). Prior v7
-        # fetched raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson
-        # exactly once, and a single 503 (Backend.max_conn) from that endpoint
-        # killed the whole physical-DUT job before any test ran. v10's only
-        # breaking change is `enable-cache: auto`, which this workflow does not
-        # set, so the bump is behavior-preserving.
-        uses: astral-sh/setup-uv@v10.0.1
+        # Use the standalone installer instead of astral-sh/setup-uv to avoid a
+        # hard dependency on raw.githubusercontent.com/astral-sh/versions/.../uv.ndjson
+        # for version resolution. That endpoint went 503 (Backend.max_conn /
+        # Varnish) during runs 34356587946 and 34368726582, killing every
+        # physical-DUT job at "Install uv" before any stage/lock/test ran.
+        # setup-uv@v10 added retries only for thrown network errors, not for
+        # HTTP error statuses like 503 (see astral-sh/setup-uv#1016).
+        #
+        # The standalone installer resolves the pinned UV_VERSION directly from
+        # releases.astral.sh (mirror) with github.com/astral-sh/uv/releases as
+        # fallback, both of which skip the ndjson manifest entirely.
+        env:
+          UV_VERSION: "0.12.11"
+        run: |
+          set -euo pipefail
+          curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Sync libremesh-tests environment
         run: |
@@ -1140,14 +1176,23 @@ jobs:
           vwifi-server --help || vwifi-server -h || true
 
       - name: Install uv
-        # v10.0.1 tolerates transient manifest-fetch failures with up to 3
-        # retries and progressive backoff (astral-sh/setup-uv#1016). Prior v7
-        # fetched raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson
-        # exactly once, and a single 503 (Backend.max_conn) from that endpoint
-        # killed the whole physical-DUT job before any test ran. v10's only
-        # breaking change is `enable-cache: auto`, which this workflow does not
-        # set, so the bump is behavior-preserving.
-        uses: astral-sh/setup-uv@v10.0.1
+        # Use the standalone installer instead of astral-sh/setup-uv to avoid a
+        # hard dependency on raw.githubusercontent.com/astral-sh/versions/.../uv.ndjson
+        # for version resolution. That endpoint went 503 (Backend.max_conn /
+        # Varnish) during runs 34356587946 and 34368726582, killing every
+        # physical-DUT job at "Install uv" before any stage/lock/test ran.
+        # setup-uv@v10 added retries only for thrown network errors, not for
+        # HTTP error statuses like 503 (see astral-sh/setup-uv#1016).
+        #
+        # The standalone installer resolves the pinned UV_VERSION directly from
+        # releases.astral.sh (mirror) with github.com/astral-sh/uv/releases as
+        # fallback, both of which skip the ndjson manifest entirely.
+        env:
+          UV_VERSION: "0.12.11"
+        run: |
+          set -euo pipefail
+          curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Sync libremesh-tests environment
         run: |

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -544,7 +544,14 @@ jobs:
         run: echo "OPENWRT_TESTS_DIR=$GITHUB_WORKSPACE/openwrt-tests" >> "$GITHUB_ENV"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # v10.0.1 tolerates transient manifest-fetch failures with up to 3
+        # retries and progressive backoff (astral-sh/setup-uv#1016). Prior v7
+        # fetched raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson
+        # exactly once, and a single 503 (Backend.max_conn) from that endpoint
+        # killed the whole physical-DUT job before any test ran. v10's only
+        # breaking change is `enable-cache: auto`, which this workflow does not
+        # set, so the bump is behavior-preserving.
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Sync libremesh-tests environment
         run: |
@@ -785,7 +792,14 @@ jobs:
         run: echo "OPENWRT_TESTS_DIR=$GITHUB_WORKSPACE/openwrt-tests" >> "$GITHUB_ENV"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # v10.0.1 tolerates transient manifest-fetch failures with up to 3
+        # retries and progressive backoff (astral-sh/setup-uv#1016). Prior v7
+        # fetched raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson
+        # exactly once, and a single 503 (Backend.max_conn) from that endpoint
+        # killed the whole physical-DUT job before any test ran. v10's only
+        # breaking change is `enable-cache: auto`, which this workflow does not
+        # set, so the bump is behavior-preserving.
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Sync libremesh-tests environment
         run: cd libremesh-tests && uv sync
@@ -888,7 +902,14 @@ jobs:
         run: echo "OPENWRT_TESTS_DIR=$GITHUB_WORKSPACE/openwrt-tests" >> "$GITHUB_ENV"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # v10.0.1 tolerates transient manifest-fetch failures with up to 3
+        # retries and progressive backoff (astral-sh/setup-uv#1016). Prior v7
+        # fetched raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson
+        # exactly once, and a single 503 (Backend.max_conn) from that endpoint
+        # killed the whole physical-DUT job before any test ran. v10's only
+        # breaking change is `enable-cache: auto`, which this workflow does not
+        # set, so the bump is behavior-preserving.
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Sync libremesh-tests environment
         run: cd libremesh-tests && uv sync
@@ -980,7 +1001,14 @@ jobs:
           sudo apt-get install -y --no-install-recommends qemu-system-x86 ovmf
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # v10.0.1 tolerates transient manifest-fetch failures with up to 3
+        # retries and progressive backoff (astral-sh/setup-uv#1016). Prior v7
+        # fetched raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson
+        # exactly once, and a single 503 (Backend.max_conn) from that endpoint
+        # killed the whole physical-DUT job before any test ran. v10's only
+        # breaking change is `enable-cache: auto`, which this workflow does not
+        # set, so the bump is behavior-preserving.
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Sync libremesh-tests environment
         run: |
@@ -1112,7 +1140,14 @@ jobs:
           vwifi-server --help || vwifi-server -h || true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # v10.0.1 tolerates transient manifest-fetch failures with up to 3
+        # retries and progressive backoff (astral-sh/setup-uv#1016). Prior v7
+        # fetched raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson
+        # exactly once, and a single 503 (Backend.max_conn) from that endpoint
+        # killed the whole physical-DUT job before any test ran. v10's only
+        # breaking change is `enable-cache: auto`, which this workflow does not
+        # set, so the bump is behavior-preserving.
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Sync libremesh-tests environment
         run: |

--- a/tools/ci/lab_stage_firmware.sh
+++ b/tools/ci/lab_stage_firmware.sh
@@ -63,8 +63,16 @@ if [[ -f "$KERNEL_FILE" && -f "$RAMDISK_FILE" ]]; then
 	echo "=== dual-tftp mode: kernel + rootfs ramdisk uImage ==="
 	echo "LG_IMAGE=$KERNEL_FILE" >>"${GITHUB_ENV:-/dev/null}"
 	echo "LG_IMAGE_INITRD=$RAMDISK_FILE" >>"${GITHUB_ENV:-/dev/null}"
+	# The dual-tftp target YAML is a sibling of the single-image default in
+	# libremesh-tests/targets/. See libremesh/libremesh-tests#5 for the split
+	# rationale. LG_ENV was pre-set to targets/<device>.yaml by the caller
+	# (build-firmware workflow); override with the -dual-tftp variant so
+	# labgrid resolves LG_IMAGE_INITRD and issues both TFTP loads.
+	DUAL_ENV="targets/${DEVICE}-dual-tftp.yaml"
+	echo "LG_ENV=$DUAL_ENV" >>"${GITHUB_ENV:-/dev/null}"
 	echo "Staged LG_IMAGE=$KERNEL_FILE"
 	echo "Staged LG_IMAGE_INITRD=$RAMDISK_FILE"
+	echo "Overrode LG_ENV=$DUAL_ENV"
 	echo "=== firmware sanity ==="
 	file "$KERNEL_FILE" || true
 	ls -la "$KERNEL_FILE"


### PR DESCRIPTION
## Context

Follow-up to [libremesh/libremesh-tests#5](https://github.com/libremesh/libremesh-tests/pull/5) which splits the LibreRouter v1 target YAML into two variants:

- `targets/librerouter_librerouter-v1.yaml` - single-image (default)
- `targets/librerouter_librerouter-v1-dual-tftp.yaml` - kernel + rootfs uImage

**Why the split**: the single-image variant is what mesh tests, LibreMesh releases and `openwrt-tests` healthcheck actually use (initramfs-kernel.bin, only `LG_IMAGE` set). The previous librerouter YAML required both `LG_IMAGE` and `LG_IMAGE_INITRD` unconditionally, breaking every non-dual flow with:

```
InvalidConfigError: configuration file '.../librerouter_librerouter-v1.yaml'
refers to unknown variable 'LG_IMAGE_INITRD'
```

## Problem in this CI

`.github/workflows/build-firmware.yml` pre-sets:

```
LG_ENV=targets/${{ matrix.device }}.yaml
```

After the libremesh-tests split, that path points at the **single-image** variant.

When `tools/ci/lab_stage_firmware.sh` then detects the dual-tftp payload (`bin` + `uimage` pair produced by `build_image.sh` for devices like the LibreRouter v1 on ath79), it exports `LG_IMAGE_INITRD` — but the single-image YAML does not reference that variable, so labgrid loads only the kernel and boot fails without a rootfs.

## Fix

When `lab_stage_firmware.sh` enters the dual-TFTP branch, override `LG_ENV` with the `-dual-tftp` sibling target file so labgrid resolves `LG_IMAGE_INITRD` and issues both TFTP loads:

```bash
DUAL_ENV="targets/${DEVICE}-dual-tftp.yaml"
echo "LG_ENV=$DUAL_ENV" >> "$GITHUB_ENV"
```

No change for single-image devices (`openwrt_one`, `linksys_e8450`, `bananapi_bpi-r4`, `qemu_*`): the else branch keeps the pre-set `LG_ENV`.

## Depends on

- [libremesh/libremesh-tests#5](https://github.com/libremesh/libremesh-tests/pull/5) - merge first so the `-dual-tftp` target file exists in the checked-out libremesh-tests.